### PR TITLE
refactor(k8s-api): upgrade webhook from v1beta to v1

### DIFF
--- a/cmd/everoute-controller/main.go
+++ b/cmd/everoute-controller/main.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +47,7 @@ import (
 
 func init() {
 	utilruntime.Must(corev1.AddToScheme(clientsetscheme.Scheme))
-	utilruntime.Must(v1beta1.AddToScheme(clientsetscheme.Scheme))
+	utilruntime.Must(admv1.AddToScheme(clientsetscheme.Scheme))
 	utilruntime.Must(networkingv1.AddToScheme(clientsetscheme.Scheme))
 }
 
@@ -181,7 +181,7 @@ func setWebhookCert(k8sReader client.Reader, tlsCertDir string) {
 
 	// update webhook
 	webhookReq := types.NamespacedName{Name: "validator.everoute.io"}
-	webhookObj := &v1beta1.ValidatingWebhookConfiguration{}
+	webhookObj := &admv1.ValidatingWebhookConfiguration{}
 	if err := backoff.Retry(func() error {
 		if err := k8sClient.Get(ctx, webhookReq, webhookObj); err != nil {
 			return err

--- a/deploy/everoute-controller/webhook.yaml
+++ b/deploy/everoute-controller/webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validator.everoute.io
 webhooks:
-  - clientConfig:
+  - admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
       # CaBundle must set as the ca for secret everoute-controller-tls.
       caBundle:
       service:

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -2044,12 +2044,14 @@ metadata:
   name: everoute-controller
   namespace: kube-system
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validator.everoute.io
 webhooks:
-  - clientConfig:
+  - admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
       # CaBundle must set as the ca for secret everoute-controller-tls.
       caBundle:
       service:

--- a/tests/e2e/config/webhook.yaml
+++ b/tests/e2e/config/webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validator.everoute.io
 webhooks:
-  - clientConfig:
+  - admissionReviewVersions: [ "v1" ]
+    sideEffects: None
+    clientConfig:
       # CaBundle must set as the ca for secret everoute-controller-tls.
       caBundle:
       # use local everoute-controller webhook


### PR DESCRIPTION
warning info: admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+,
unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration.
Actually, CR could not be created in v1.21.5, there will be an error in conversion.