### PR TITLE
fix(cni-enable): change flag parse position

### DIFF
--- a/pkg/agent/proxy/route.go
+++ b/pkg/agent/proxy/route.go
@@ -301,6 +301,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// update network config every 100 seconds
+	r.UpdateNetwork()
 	ticker := time.NewTicker(100 * time.Second)
 	go func() {
 		for {


### PR DESCRIPTION
variable enableCNI will not init because of wrong position of flag.Parse()