### PR TITLE
Add comments for api types

### DIFF
--- a/deploy/crds/security.everoute.io_endpoints.yaml
+++ b/deploy/crds/security.everoute.io_endpoints.yaml
@@ -16,9 +16,25 @@ spec:
     singular: endpoint
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.reference.externalIDName
+      name: ExternalName
+      type: string
+    - jsonPath: .spec.reference.externalIDValue
+      name: ExternalValue
+      type: string
+    - jsonPath: .status.ips
+      name: IPAddr
+      type: string
+    - jsonPath: .status.macAddress
+      name: MAC
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Endpoint is a network communication entity. It's provided by
+          the endpoint provider, it could be a virtual network interface, a pod, an
+          ovs port or other entities.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,18 +49,25 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec contains description of the endpoint
             properties:
               reference:
+                description: Reference of an endpoint, also the external_id of an
+                  ovs interface. We map between endpoint and ovs interface use the
+                  Reference.
                 properties:
                   externalIDName:
+                    description: ExternalIDName of an endpoint.
                     type: string
                   externalIDValue:
+                    description: ExternalIDValue of an endpint.
                     type: string
                 required:
                 - externalIDName
                 - externalIDValue
                 type: object
               vid:
+                description: VID describe the endpoint in which VLAN
                 format: int32
                 type: integer
             required:
@@ -52,8 +75,10 @@ spec:
             - vid
             type: object
           status:
+            description: Status is the current state of the Endpoint
             properties:
               ips:
+                description: IPs of an endpoint, can be IPV4 or IPV6.
                 items:
                   description: IPAddress is net ip address, can be ipv4 or ipv6. Format
                     like 192.168.10.12 or fe80::488e:b1ff:fe37:5414
@@ -61,6 +86,7 @@ spec:
                   type: string
                 type: array
               macAddress:
+                description: MACAddress of an endpoint.
                 type: string
             type: object
         required:

--- a/deploy/crds/security.everoute.io_globalpolicies.yaml
+++ b/deploy/crds/security.everoute.io_globalpolicies.yaml
@@ -16,7 +16,11 @@ spec:
     singular: globalpolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.defaultAction
+      name: DefaultAction
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: GlobalPolicy allow defines default action of traffics and global
@@ -35,6 +39,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Specification of the desired behavior for this GlobalPolicy.
             properties:
               defaultAction:
                 default: Allow
@@ -71,6 +76,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/crds/security.everoute.io_securitypolicies.yaml
+++ b/deploy/crds/security.everoute.io_securitypolicies.yaml
@@ -16,7 +16,17 @@ spec:
     singular: securitypolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - jsonPath: .spec.symmetricMode
+      name: SymmetricMode
+      type: boolean
+    - jsonPath: .spec.policyTypes
+      name: PolicyTypes
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecurityPolicy describes what network traffic is allowed for

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -608,9 +608,25 @@ spec:
     singular: endpoint
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.reference.externalIDName
+      name: ExternalName
+      type: string
+    - jsonPath: .spec.reference.externalIDValue
+      name: ExternalValue
+      type: string
+    - jsonPath: .status.ips
+      name: IPAddr
+      type: string
+    - jsonPath: .status.macAddress
+      name: MAC
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Endpoint is a network communication entity. It's provided by
+          the endpoint provider, it could be a virtual network interface, a pod, an
+          ovs port or other entities.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -625,18 +641,25 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec contains description of the endpoint
             properties:
               reference:
+                description: Reference of an endpoint, also the external_id of an
+                  ovs interface. We map between endpoint and ovs interface use the
+                  Reference.
                 properties:
                   externalIDName:
+                    description: ExternalIDName of an endpoint.
                     type: string
                   externalIDValue:
+                    description: ExternalIDValue of an endpint.
                     type: string
                 required:
                 - externalIDName
                 - externalIDValue
                 type: object
               vid:
+                description: VID describe the endpoint in which VLAN
                 format: int32
                 type: integer
             required:
@@ -644,8 +667,10 @@ spec:
             - vid
             type: object
           status:
+            description: Status is the current state of the Endpoint
             properties:
               ips:
+                description: IPs of an endpoint, can be IPV4 or IPV6.
                 items:
                   description: IPAddress is net ip address, can be ipv4 or ipv6. Format
                     like 192.168.10.12 or fe80::488e:b1ff:fe37:5414
@@ -653,6 +678,7 @@ spec:
                   type: string
                 type: array
               macAddress:
+                description: MACAddress of an endpoint.
                 type: string
             type: object
         required:
@@ -686,7 +712,11 @@ spec:
     singular: globalpolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.defaultAction
+      name: DefaultAction
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: GlobalPolicy allow defines default action of traffics and global
@@ -705,6 +735,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Specification of the desired behavior for this GlobalPolicy.
             properties:
               defaultAction:
                 default: Allow
@@ -741,6 +772,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -765,7 +797,17 @@ spec:
     singular: securitypolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - jsonPath: .spec.symmetricMode
+      name: SymmetricMode
+      type: boolean
+    - jsonPath: .spec.policyTypes
+      name: PolicyTypes
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecurityPolicy describes what network traffic is allowed for

--- a/docs/content/en/docs/reference/apidocs.html
+++ b/docs/content/en/docs/reference/apidocs.html
@@ -30,6 +30,8 @@ display: inline-block;
 </li></ul>
 <h3 id="security.everoute.io/v1alpha1.Endpoint">Endpoint
 </h3>
+<p>Endpoint is a network communication entity. It&rsquo;s provided by the endpoint provider,
+it could be a virtual network interface, a pod, an ovs port or other entities.</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -70,6 +72,7 @@ EndpointSpec
 </em>
 </td>
 <td>
+<p>Spec contains description of the endpoint</p>
 <br/><br/>
 <table>
 <tr>
@@ -80,6 +83,7 @@ uint32
 </em>
 </td>
 <td>
+<p>VID describe the endpoint in which VLAN</p>
 </td>
 </tr>
 <tr>
@@ -92,6 +96,8 @@ EndpointReference
 </em>
 </td>
 <td>
+<p>Reference of an endpoint, also the external_id of an ovs interface.
+We map between endpoint and ovs interface use the Reference.</p>
 </td>
 </tr>
 </table>
@@ -107,6 +113,7 @@ EndpointStatus
 </em>
 </td>
 <td>
+<p>Status is the current state of the Endpoint</p>
 </td>
 </tr>
 </tbody>
@@ -155,6 +162,8 @@ GlobalPolicySpec
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>Specification of the desired behavior for this GlobalPolicy.</p>
 <br/><br/>
 <table>
 <tr>
@@ -390,6 +399,7 @@ If this field is set then neither of the other fields can be.</p>
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.EndpointSpec">EndpointSpec</a>)
 </p>
+<p>EndpointReference uniquely identifies an endpoint</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -406,6 +416,7 @@ string
 </em>
 </td>
 <td>
+<p>ExternalIDName of an endpoint.</p>
 </td>
 </tr>
 <tr>
@@ -416,6 +427,7 @@ string
 </em>
 </td>
 <td>
+<p>ExternalIDValue of an endpint.</p>
 </td>
 </tr>
 </tbody>
@@ -426,6 +438,7 @@ string
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.Endpoint">Endpoint</a>)
 </p>
+<p>EndpointSpec provides the specification of an Endpoint</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -442,6 +455,7 @@ uint32
 </em>
 </td>
 <td>
+<p>VID describe the endpoint in which VLAN</p>
 </td>
 </tr>
 <tr>
@@ -454,6 +468,8 @@ EndpointReference
 </em>
 </td>
 <td>
+<p>Reference of an endpoint, also the external_id of an ovs interface.
+We map between endpoint and ovs interface use the Reference.</p>
 </td>
 </tr>
 </tbody>
@@ -464,6 +480,7 @@ EndpointReference
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.Endpoint">Endpoint</a>)
 </p>
+<p>EndpointStatus describe the current state of the Endpoint</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -482,6 +499,7 @@ EndpointReference
 </em>
 </td>
 <td>
+<p>IPs of an endpoint, can be IPV4 or IPV6.</p>
 </td>
 </tr>
 <tr>
@@ -492,6 +510,7 @@ string
 </em>
 </td>
 <td>
+<p>MACAddress of an endpoint.</p>
 </td>
 </tr>
 </tbody>
@@ -502,6 +521,7 @@ string
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.GlobalPolicySpec">GlobalPolicySpec</a>)
 </p>
+<p>GlobalDefaultAction defines actions supported for GlobalPolicy.</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -511,10 +531,12 @@ string
 </thead>
 <tbody><tr>
 <td><p>&#34;Allow&#34;</p></td>
-<td></td>
+<td><p>GlobalDefaultActionAllow default allow all traffics between Endpoints.</p>
+</td>
 </tr><tr>
 <td><p>&#34;Drop&#34;</p></td>
-<td></td>
+<td><p>GlobalDefaultActionDrop default drop all traffics between Endpoints.</p>
+</td>
 </tr></tbody>
 </table>
 <h3 id="security.everoute.io/v1alpha1.GlobalPolicySpec">GlobalPolicySpec
@@ -523,6 +545,7 @@ string
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.GlobalPolicy">GlobalPolicy</a>)
 </p>
+<p>GlobalPolicySpec provides the specification of a GlobalPolicy</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -567,6 +590,7 @@ GlobalDefaultAction
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.SecurityPolicyPeer">SecurityPolicyPeer</a>)
 </p>
+<p>NamespacedName contains information to specify an object.</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -605,6 +629,7 @@ string
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.SecurityPolicyPort">SecurityPolicyPort</a>)
 </p>
+<p>Protocol defines network protocols supported for SecurityPolicy.</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>
@@ -845,6 +870,7 @@ want match multiple ports, you should write like 20,22-24,90.</p>
 (<em>Appears in:</em>
 <a href="#security.everoute.io/v1alpha1.SecurityPolicy">SecurityPolicy</a>)
 </p>
+<p>SecurityPolicySpec provides the specification of a SecurityPolicy</p>
 <table class="table table-striped">
 <thead style="background-color: rgb(160,180,190)">
 <tr>

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1408,7 +1408,8 @@ func schema_pkg_apis_security_v1alpha1_Endpoint(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Endpoint is a network communication entity. It's provided by the endpoint provider, it could be a virtual network interface, a pod, an ovs port or other entities.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -1431,12 +1432,14 @@ func schema_pkg_apis_security_v1alpha1_Endpoint(ref common.ReferenceCallback) co
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointSpec"),
+							Description: "Spec contains description of the endpoint",
+							Ref:         ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointStatus"),
+							Description: "Status is the current state of the Endpoint",
+							Ref:         ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointStatus"),
 						},
 					},
 				},
@@ -1499,18 +1502,21 @@ func schema_pkg_apis_security_v1alpha1_EndpointReference(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EndpointReference uniquely identifies an endpoint",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"externalIDName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ExternalIDName of an endpoint.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"externalIDValue": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ExternalIDValue of an endpint.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -1524,17 +1530,20 @@ func schema_pkg_apis_security_v1alpha1_EndpointSpec(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EndpointSpec provides the specification of an Endpoint",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"vid": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int64",
+							Description: "VID describe the endpoint in which VLAN",
+							Type:        []string{"integer"},
+							Format:      "int64",
 						},
 					},
 					"reference": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointReference"),
+							Description: "Reference of an endpoint, also the external_id of an ovs interface. We map between endpoint and ovs interface use the Reference.",
+							Ref:         ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.EndpointReference"),
 						},
 					},
 				},
@@ -1550,11 +1559,13 @@ func schema_pkg_apis_security_v1alpha1_EndpointStatus(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EndpointStatus describe the current state of the Endpoint",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"ips": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "IPs of an endpoint, can be IPV4 or IPV6.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1567,8 +1578,9 @@ func schema_pkg_apis_security_v1alpha1_EndpointStatus(ref common.ReferenceCallba
 					},
 					"macAddress": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "MACAddress of an endpoint.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -1605,7 +1617,8 @@ func schema_pkg_apis_security_v1alpha1_GlobalPolicy(ref common.ReferenceCallback
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.GlobalPolicySpec"),
+							Description: "Specification of the desired behavior for this GlobalPolicy.",
+							Ref:         ref("github.com/everoute/everoute/pkg/apis/security/v1alpha1.GlobalPolicySpec"),
 						},
 					},
 				},
@@ -1666,7 +1679,8 @@ func schema_pkg_apis_security_v1alpha1_GlobalPolicySpec(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "GlobalPolicySpec provides the specification of a GlobalPolicy",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"defaultAction": {
 						SchemaProps: spec.SchemaProps{
@@ -1700,7 +1714,8 @@ func schema_pkg_apis_security_v1alpha1_NamespacedName(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "NamespacedName contains information to specify an object.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -1944,7 +1959,8 @@ func schema_pkg_apis_security_v1alpha1_SecurityPolicySpec(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "SecurityPolicySpec provides the specification of a SecurityPolicy",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"tier": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
fix #190 

Add comments in file `pkg/apis/security/v1alpha1/types.go`.
Other file changes were generated by `make docker-generate`.