### PR TITLE
fix: port in networkPolicy could not sync to securityPolicy

### DIFF
--- a/pkg/controller/k8s/network_policy_controller.go
+++ b/pkg/controller/k8s/network_policy_controller.go
@@ -197,7 +197,7 @@ func getSecurityPolicyPort(networkPolicyPort []networkingv1.NetworkPolicyPort) [
 	for _, port := range networkPolicyPort {
 		newPort := v1alpha1.SecurityPolicyPort{
 			Protocol:  v1alpha1.Protocol(*port.Protocol),
-			PortRange: port.Port.StrVal,
+			PortRange: port.Port.String(),
 		}
 		// handle port range for Kubernetes v1.22+
 		/*


### PR DESCRIPTION
In networkPolicy, port was defined with `*intstr.IntOrString`
`port.StrVal` should be used for `intstr.IntOrString`
`port.String()` should be used for `*intstr.IntOrString`
Otherwise, the string value will be empty