### PR TITLE
fix(cniserver): add prefix "_" for veth pair name

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -178,7 +178,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniRequest) (*cni
 
 	nsPath := "/host" + request.Netns
 	// vethName - ovs port name
-	vethName := request.ContainerId[:12]
+	vethName := "_" + request.ContainerId[:12]
 	if err = ns.WithNetNSPath(nsPath, func(hostNS ns.NetNS) error {
 		// create veth pair in container NS and host NS
 		// TODO: MTU is a const variable here
@@ -250,7 +250,7 @@ func (s *CNIServer) CmdCheck(ctx context.Context, request *cnipb.CniRequest) (*c
 		return s.RetError(cnipb.ErrorCode_DECODING_FAILURE, "failed to decode request", err)
 	}
 
-	vethName := request.ContainerId[:12]
+	vethName := "_" + request.ContainerId[:12]
 
 	// check ovs port
 	if !s.ovsDriver.IsPortNamePresent(vethName) {
@@ -281,7 +281,7 @@ func (s *CNIServer) CmdDel(ctx context.Context, request *cnipb.CniRequest) (*cni
 		return s.RetError(cnipb.ErrorCode_DECODING_FAILURE, "Parse request conf error", err)
 	}
 
-	vethName := request.ContainerId[:12]
+	vethName := "_" + request.ContainerId[:12]
 
 	// delete ovs port
 	if s.ovsDriver.IsPortNamePresent(vethName) {


### PR DESCRIPTION
ovs will check veth name
```
bool
ovsdb_parser_is_id(const char *string)
{
    unsigned char c;

    c = *string;
    if (!isalpha(c) && c != '_') {
        return false;
    }

    for (;;) {
        c = *++string;
        if (c == '\0') {
            return true;
        } else if (!isalpha(c) && !isdigit(c) && c != '_') {
            return false;
        }
    }
}
```