### PR TITLE
Add kubectl printcolumn for policyrules

### DIFF
--- a/deploy/crds/policyrule.everoute.io_policyrules.yaml
+++ b/deploy/crds/policyrule.everoute.io_policyrules.yaml
@@ -16,7 +16,35 @@ spec:
     singular: policyrule
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.direction
+      name: Direction
+      type: string
+    - jsonPath: .spec.ruleType
+      name: RuleType
+      type: string
+    - jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - jsonPath: .spec.srcIPAddr
+      name: SrcIPAddr
+      type: string
+    - jsonPath: .spec.dstIPAddr
+      name: DstIPAddr
+      type: string
+    - jsonPath: .spec.ipProtocol
+      name: IPProtocol
+      type: string
+    - jsonPath: .spec.dstPort
+      name: DstPort
+      type: string
+    - jsonPath: .spec.dstPortMask
+      name: DstPortMask
+      type: string
+    - jsonPath: .spec.action
+      name: Action
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PolicyRule

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -516,7 +516,35 @@ spec:
     singular: policyrule
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.direction
+      name: Direction
+      type: string
+    - jsonPath: .spec.ruleType
+      name: RuleType
+      type: string
+    - jsonPath: .spec.tier
+      name: Tier
+      type: string
+    - jsonPath: .spec.srcIPAddr
+      name: SrcIPAddr
+      type: string
+    - jsonPath: .spec.dstIPAddr
+      name: DstIPAddr
+      type: string
+    - jsonPath: .spec.ipProtocol
+      name: IPProtocol
+      type: string
+    - jsonPath: .spec.dstPort
+      name: DstPort
+      type: string
+    - jsonPath: .spec.dstPortMask
+      name: DstPortMask
+      type: string
+    - jsonPath: .spec.action
+      name: Action
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PolicyRule

--- a/pkg/apis/policyrule/v1alpha1/policyrule_types.go
+++ b/pkg/apis/policyrule/v1alpha1/policyrule_types.go
@@ -25,6 +25,15 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Direction",type="string",JSONPath=".spec.direction"
+// +kubebuilder:printcolumn:name="RuleType",type="string",JSONPath=".spec.ruleType"
+// +kubebuilder:printcolumn:name="Tier",type="string",JSONPath=".spec.tier"
+// +kubebuilder:printcolumn:name="SrcIPAddr",type="string",JSONPath=".spec.srcIPAddr"
+// +kubebuilder:printcolumn:name="DstIPAddr",type="string",JSONPath=".spec.dstIPAddr"
+// +kubebuilder:printcolumn:name="IPProtocol",type="string",JSONPath=".spec.ipProtocol"
+// +kubebuilder:printcolumn:name="DstPort",type="string",JSONPath=".spec.dstPort"
+// +kubebuilder:printcolumn:name="DstPortMask",type="string",JSONPath=".spec.dstPortMask"
+// +kubebuilder:printcolumn:name="Action",type="string",JSONPath=".spec.action"
 
 // PolicyRule
 // +k8s:openapi-gen=true


### PR DESCRIPTION
We can use `kubectl get policyrule` show policy details
```
$kubectl get policyrule -A
NAME    DIRECTION   RULETYPE      TIER    SRCIPADDR   DSTIPADDR           IPPROTOCOL   DSTPORT   DSTPORTMASK   ACTION
test    Ingress     DefaultRule   tier0               192.168.24.121/32                                        Drop
```