### PR TITLE
refactor ip address learning logic

### DIFF
--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// Init everoute datapathManager: init bridge chain config and default flow
 	stopChan := ctrl.SetupSignalHandler()
-	ofPortIPAddrMoniotorChan := make(chan map[string][]net.IP, 1024)
+	ofPortIPAddrMoniotorChan := make(chan map[string]net.IP, 1024)
 
 	// TODO Update vds which is managed by everoute agent from datapathConfig.
 	datapathConfig, err := getDatapathConfig()

--- a/deploy/crds/agent.everoute.io_agentinfos.yaml
+++ b/deploy/crds/agent.everoute.io_agentinfos.yaml
@@ -80,14 +80,11 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                                ips:
-                                  items:
-                                    description: IPAddress is net ip address, can
-                                      be ipv4 or ipv6. Format like 192.168.10.12 or
-                                      fe80::488e:b1ff:fe37:5414
-                                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
+                                ipmap:
+                                  additionalProperties:
+                                    format: date-time
                                     type: string
-                                  type: array
+                                  type: object
                                 mac:
                                   type: string
                                 name:

--- a/deploy/everoute-controller/role.yaml
+++ b/deploy/everoute-controller/role.yaml
@@ -55,6 +55,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - group.everoute.io
   resources:

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -80,14 +80,11 @@ spec:
                                   additionalProperties:
                                     type: string
                                   type: object
-                                ips:
-                                  items:
-                                    description: IPAddress is net ip address, can
-                                      be ipv4 or ipv6. Format like 192.168.10.12 or
-                                      fe80::488e:b1ff:fe37:5414
-                                    pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
+                                ipmap:
+                                  additionalProperties:
+                                    format: date-time
                                     type: string
-                                  type: array
+                                  type: object
                                 mac:
                                   type: string
                                 name:
@@ -1998,6 +1995,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - group.everoute.io
   resources:

--- a/pkg/agent/controller/policyrule/policyrule_controller_test.go
+++ b/pkg/agent/controller/policyrule/policyrule_controller_test.go
@@ -110,7 +110,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ofPortUpdateChan := make(chan map[string][]net.IP, 100)
+	ofPortUpdateChan := make(chan map[string]net.IP, 100)
 
 	if err := datapath.ExcuteCommand(datapath.SetupBridgeChain, "ovsbr1"); err != nil {
 		klog.Fatalf("Failed to setup bridgechain, error: %v", err)

--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -142,8 +142,8 @@ type DpManager struct {
 	OvsdbDriverMap map[string]map[string]*ovsdbDriver.OvsDriver // map vds to bridge ovsdbDriver map
 	ControllerMap  map[string]map[string]*ofctrl.Controller
 
-	localEndpointDB           cmap.ConcurrentMap       // list of local endpoint map
-	ofPortIPAddressUpdateChan chan map[string][]net.IP // map bridgename-ofport to endpoint ips
+	localEndpointDB           cmap.ConcurrentMap     // list of local endpoint map
+	ofPortIPAddressUpdateChan chan map[string]net.IP // map bridgename-ofport to endpoint ips
 	datapathConfig            *Config
 	Rules                     map[string]*EveroutePolicyRuleEntry // rules database
 	flowReplayChan            chan struct{}
@@ -210,7 +210,7 @@ type RoundInfo struct {
 // Datapath manager act as openflow controller:
 // 1. event driven local endpoint info crud and related flow update,
 // 2. collect local endpoint ip learned from different ovsbr(1 per vds), and sync it to management plane
-func NewDatapathManager(datapathConfig *Config, ofPortIPAddressUpdateChan chan map[string][]net.IP) *DpManager {
+func NewDatapathManager(datapathConfig *Config, ofPortIPAddressUpdateChan chan map[string]net.IP) *DpManager {
 	datapathManager := new(DpManager)
 	datapathManager.BridgeChainMap = make(map[string]map[string]Bridge)
 	datapathManager.OvsdbDriverMap = make(map[string]map[string]*ovsdbDriver.OvsDriver)

--- a/pkg/apis/agent/v1alpha1/types.go
+++ b/pkg/apis/agent/v1alpha1/types.go
@@ -87,12 +87,12 @@ type BondConfig struct {
 }
 
 type OVSInterface struct {
-	Name        string            `json:"name,omitempty"`
-	ExternalIDs map[string]string `json:"externalIDs,omitempty"`
-	Type        string            `json:"type,omitempty"`
-	Ofport      int32             `json:"ofport,omitempty"`
-	Mac         string            `json:"mac,omitempty"`
-	IPs         []types.IPAddress `json:"ips,omitempty"`
+	Name        string                          `json:"name,omitempty"`
+	ExternalIDs map[string]string               `json:"externalIDs,omitempty"`
+	Type        string                          `json:"type,omitempty"`
+	Ofport      int32                           `json:"ofport,omitempty"`
+	Mac         string                          `json:"mac,omitempty"`
+	IPMap       map[types.IPAddress]metav1.Time `json:"ipmap,omitempty"`
 }
 
 type AgentConditionType string

--- a/pkg/apis/agent/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/agent/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	types "github.com/everoute/everoute/pkg/types"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -181,10 +182,12 @@ func (in *OVSInterface) DeepCopyInto(out *OVSInterface) {
 			(*out)[key] = val
 		}
 	}
-	if in.IPs != nil {
-		in, out := &in.IPs, &out.IPs
-		*out = make([]types.IPAddress, len(*in))
-		copy(*out, *in)
+	if in.IPMap != nil {
+		in, out := &in.IPMap, &out.IPMap
+		*out = make(map[types.IPAddress]v1.Time, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
 	}
 	return
 }

--- a/pkg/controller/endpoint/endpoint_controller_perf_test.go
+++ b/pkg/controller/endpoint/endpoint_controller_perf_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -50,7 +51,10 @@ func getAgentInfos() []*agentv1alpha1.AgentInfo {
 				Interfaces: []agentv1alpha1.OVSInterface{{
 					ExternalIDs: map[string]string{id: id},
 					Mac:         "mac:address",
-					IPs:         []types.IPAddress{"192.168.2.2", "192.168.1.1"},
+					IPMap: map[types.IPAddress]metav1.Time{
+						types.IPAddress("192.168.2.2"): {},
+						types.IPAddress("192.168.1.1"): {},
+					},
 				}},
 			})
 		}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -637,14 +637,14 @@ func schema_pkg_apis_agent_v1alpha1_OVSInterface(ref common.ReferenceCallback) c
 							Format: "",
 						},
 					},
-					"ips": {
+					"ipmap": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
-							Items: &spec.SchemaOrArray{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 									},
 								},
 							},
@@ -653,6 +653,8 @@ func schema_pkg_apis_agent_v1alpha1_OVSInterface(ref common.ReferenceCallback) c
 				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/tests/e2e/framework/endpoint/netns/provider.go
+++ b/tests/e2e/framework/endpoint/netns/provider.go
@@ -381,7 +381,7 @@ func toCrdEndpoint(endpoint *model.Endpoint, resourceVersion string) *v1alpha1.E
 
 	securityEp.Spec = v1alpha1.EndpointSpec{
 		Reference: v1alpha1.EndpointReference{
-			ExternalIDName:  "external_uuid",
+			ExternalIDName:  "iface-id",
 			ExternalIDValue: fmt.Sprintf("uuid-%s", endpoint.Status.LocalID),
 		},
 	}

--- a/tests/e2e/framework/endpoint/netns/scripts.go
+++ b/tests/e2e/framework/endpoint/netns/scripts.go
@@ -42,7 +42,7 @@ const (
 		vethName="veth-${netns}"
 		portName=${vethName}
 		vethPeerName="vethpeer-${netns}"
-		portExternalIDName="external_uuid"
+		portExternalIDName="iface-id"
 		portExternalIDValue="uuid-${netns}"
 
 		ip netns add ${netns}


### PR DESCRIPTION
1. Agent take stateless ip learning logic, not save any of interface
   state like ipset etc
2. Endpoint controller act as the stateful processing manager: save
   interface ip set; ip set timeout management