### PR TITLE
fix(cni): split cni datapath init and everoute datapath init

### DIFF
--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -66,6 +66,7 @@ func main() {
 		klog.Fatalf("Failed to get datapath config. error: %v. ", err)
 	}
 	datapathManager := datapath.NewDatapathManager(datapathConfig, ofPortIPAddrMoniotorChan)
+	datapathManager.InitializeDatapath(stopChan)
 
 	config := ctrl.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(constants.ControllerRuntimeQPS, constants.ControllerRuntimeBurst)
@@ -88,7 +89,7 @@ func main() {
 		go cniServer.Run(stopChan)
 	}
 
-	datapathManager.InitializeDatapath(stopChan)
+	datapathManager.InitializeCNI()
 
 	if err = startManager(mgr, datapathManager, stopChan); err != nil {
 		klog.Fatalf("error %v when start controller manager.", err)

--- a/pkg/agent/datapath/clsBridge.go
+++ b/pkg/agent/datapath/clsBridge.go
@@ -343,3 +343,7 @@ func (c *ClsBridge) AddSFCRule() error {
 func (c *ClsBridge) RemoveSFCRule() error {
 	return nil
 }
+
+func (c *ClsBridge) BridgeInitCNI() {
+
+}

--- a/pkg/agent/datapath/localBridge.go
+++ b/pkg/agent/datapath/localBridge.go
@@ -201,7 +201,11 @@ func (l *LocalBridge) BridgeInit() {
 	if err := l.initFromLocalRedirectTable(sw); err != nil {
 		log.Fatalf("Failed to init local bridge from local redirect table, error: %v", err)
 	}
+}
+
+func (l *LocalBridge) BridgeInitCNI() {
 	if l.datapathManager.AgentInfo.EnableCNI {
+		sw := l.OfSwitch
 		if err := l.initCniRelatedFlow(sw); err != nil {
 			log.Fatalf("Failed to init cni related flows, error: %v", err)
 		}

--- a/pkg/agent/datapath/policyBridge.go
+++ b/pkg/agent/datapath/policyBridge.go
@@ -500,3 +500,7 @@ func (p *PolicyBridge) AddSFCRule() error {
 func (p *PolicyBridge) RemoveSFCRule() error {
 	return nil
 }
+
+func (p *PolicyBridge) BridgeInitCNI() {
+
+}

--- a/pkg/agent/datapath/uplinkBridge.go
+++ b/pkg/agent/datapath/uplinkBridge.go
@@ -136,3 +136,7 @@ func (u *UplinkBridge) AddSFCRule() error {
 func (u *UplinkBridge) RemoveSFCRule() error {
 	return nil
 }
+
+func (u *UplinkBridge) BridgeInitCNI() {
+
+}


### PR DESCRIPTION
cni datapath need get pod CIDR from apiserver. 
While agent could not connection to apiserver, it will block the whole datapath init process.