### PR TITLE
fix(cni): remove updatNetwork at startup

### DIFF
--- a/pkg/agent/proxy/route.go
+++ b/pkg/agent/proxy/route.go
@@ -320,7 +320,6 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// update network config every 100 seconds
-	r.UpdateNetwork()
 	ticker := time.NewTicker(100 * time.Second)
 	go func() {
 		for {


### PR DESCRIPTION
It will log error because cache not ready at startup. 
Update will be triggered with Node Create Event.