### PR TITLE
fix(cni): remove useless endpoint ip sync

### DIFF
--- a/deploy/everoute-agent/role.yaml
+++ b/deploy/everoute-agent/role.yaml
@@ -43,7 +43,6 @@ rules:
     - security.everoute.io
   resources:
     - securitypolicies
-    - endpoints
     - globalpolicies
   verbs:
     - get

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -1793,7 +1793,6 @@ rules:
     - security.everoute.io
   resources:
     - securitypolicies
-    - endpoints
     - globalpolicies
   verbs:
     - get


### PR DESCRIPTION
1. endpoint status will be replaced will empty agentinfo, this sync op does not make sense.
2. agent will not watch endpoint