### PR TITLE
chore(deploy): set agent update strategy to "update all at same time"

### DIFF
--- a/deploy/everoute-agent/agent.yaml
+++ b/deploy/everoute-agent/agent.yaml
@@ -40,6 +40,10 @@ spec:
     matchLabels:
       app: everoute
       component: everoute-agent
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1024
   template:
     metadata:
       labels:

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -1612,6 +1612,10 @@ spec:
     matchLabels:
       app: everoute
       component: everoute-agent
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1024
   template:
     metadata:
       labels:


### PR DESCRIPTION
Default stategy is rolling update with maxUnavailable 1, that means we have to update agent one by one.
It will takes a long time for updating when there are lots of agents in cluster.