### PR TITLE
chore: replace modules empty version with an explicit version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/containernetworking/cni v1.0.0
 	github.com/containernetworking/plugins v1.0.0
 	github.com/contiv/libOpenflow v0.0.0-20200107061746-e3817550c83b
-	github.com/contiv/libovsdb v0.0.0
-	github.com/contiv/ofnet v0.0.0-00010101000000-000000000000
+	github.com/contiv/libovsdb v0.0.0-20160406174930-bbc744d8ddc8
+	github.com/contiv/ofnet v0.0.0-20180104211757-c080e5b6e9be
 	github.com/coreos/go-iptables v0.6.0
 	github.com/fatih/color v1.7.0
 	github.com/fsnotify/fsnotify v1.5.1


### PR DESCRIPTION
After replaces, it will be easier when other repos use everoute as a module