### PR TITLE
feat: use node name for agent name in kubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,18 @@ e2e-tools:
 	CGO_ENABLED=0 go build -o bin/e2ectl tests/e2e/tools/e2ectl/*.go
 	CGO_ENABLED=0 go build -o bin/net-utils tests/e2e/tools/net-utils/*.go
 
-test:
+agent-uuid:
+	mkdir -p /var/lib/everoute/agent
+	cat /proc/sys/kernel/random/uuid > /var/lib/everoute/agent/name
+
+test: agent-uuid
 	go test ./plugin/tower/pkg/controller/... ./pkg/... -v
 
 docker-test: image-test
 	$(eval WORKDIR := /go/src/github.com/everoute/everoute)
 	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) -v /lib/modules:/lib/modules --privileged everoute/unit-test make test
 
-cover-test:
+cover-test: agent-uuid
 	go test ./plugin/tower/pkg/controller/... ./pkg/... -coverprofile=coverage.out \
 		-coverpkg=./pkg/...,./plugin/tower/pkg/controller/...
 
@@ -53,7 +57,7 @@ docker-cover-test: image-test
 	$(eval WORKDIR := /go/src/github.com/everoute/everoute)
 	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) -v /lib/modules:/lib/modules --privileged everoute/unit-test make cover-test
 
-race-test:
+race-test: agent-uuid
 	go test ./plugin/tower/pkg/controller/... ./pkg/... -race
 
 docker-race-test: image-test

--- a/cmd/everoute-agent/config.go
+++ b/cmd/everoute-agent/config.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/everoute/everoute/pkg/agent/datapath"
+	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/utils"
 )
 
@@ -84,15 +85,11 @@ func setAgentConf(datapathManager *datapath.DpManager, k8sReader client.Reader) 
 	k8sClient := k8sReader.(client.Client)
 	agentInfo := datapathManager.AgentInfo
 	agentInfo.EnableCNI = true
-
-	nodeName, _ := os.Hostname()
-	nodeName = strings.ToLower(nodeName)
-	agentInfo.NodeName = nodeName
+	agentInfo.NodeName = os.Getenv(constants.AgentNodeNameENV)
 
 	node := corev1.Node{}
-
 	if err := k8sClient.Get(context.Background(), client.ObjectKey{
-		Name: nodeName,
+		Name: agentInfo.NodeName,
 	}, &node); err != nil {
 		klog.Fatalf("get node info error, err:%s", err)
 	}

--- a/deploy/everoute-agent/agent.yaml
+++ b/deploy/everoute-agent/agent.yaml
@@ -93,6 +93,11 @@ spec:
           args:
             - --enable-cni=true
             - -v=0
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
           volumeMounts:

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -1665,6 +1665,11 @@ spec:
           args:
             - --enable-cni=true
             - -v=0
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
           volumeMounts:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,4 +46,6 @@ const (
 
 	ControllerRuntimeQPS   = 1000.0
 	ControllerRuntimeBurst = 2000
+
+	AgentNodeNameENV = "NODE_NAME"
 )

--- a/pkg/monitor/agent.go
+++ b/pkg/monitor/agent.go
@@ -22,8 +22,8 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	typeuuid "k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
@@ -40,6 +39,7 @@ import (
 
 	"github.com/everoute/everoute/pkg/agent/datapath"
 	agentv1alpha1 "github.com/everoute/everoute/pkg/apis/agent/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/types"
 )
 
@@ -800,22 +800,14 @@ func listUUID(uuidList interface{}) []ovsdb.UUID {
 func readOrGenerateAgentName() (string, error) {
 	content, err := ioutil.ReadFile(AgentNameConfigPath)
 	if err == nil {
-		return string(content), nil
+		return strings.TrimSpace(string(content)), nil
 	}
 
-	name := string(typeuuid.NewUUID())
+	// use node name for agent name in kubernetes
+	nodeName := os.Getenv(constants.AgentNodeNameENV)
+	klog.Infof("Current NodeName: %s", nodeName)
 
-	err = os.MkdirAll(filepath.Dir(AgentNameConfigPath), 0644)
-	if err != nil {
-		return "", fmt.Errorf("while write name %s: %s", name, err)
-	}
-
-	err = ioutil.WriteFile(AgentNameConfigPath, []byte(name), 0644)
-	if err != nil {
-		return "", fmt.Errorf("while write name %s: %s", name, err)
-	}
-
-	return name, nil
+	return nodeName, nil
 }
 
 func getCpIntf(bridgeName string, newInterface agentv1alpha1.OVSInterface, cpAgentInfo *agentv1alpha1.AgentInfo) *agentv1alpha1.OVSInterface {

--- a/tests/e2e/scripts/agent-setup.sh
+++ b/tests/e2e/scripts/agent-setup.sh
@@ -23,6 +23,7 @@ KUBECONFIG_PATH=${2:-/var/lib/everoute/agent-kubeconfig.yaml}
 DEFAULT_BRIDGE="ovsbr1"
 OFPORT_NUM=10
 AGENT_CONFIG_PATH=/var/lib/everoute/agentconfig.yaml
+AGENT_NAME_PATH=/var/lib/everoute/agent/name
 
 LOCAL_TO_POLICY_OFPORT=101
 POLICY_TO_LOCAL_OFPORT=102
@@ -74,6 +75,8 @@ cat > ${AGENT_CONFIG_PATH} << EOF
 datapathConfig:
     ${DEFAULT_BRIDGE}: ${DEFAULT_BRIDGE}
 EOF
+mkdir -p "$(dirname ${AGENT_NAME_PATH})"
+cat /proc/sys/kernel/random/uuid > ${AGENT_NAME_PATH}
 
 echo "start everoute-agent"
 nohup /usr/local/bin/everoute-agent --kubeconfig ${KUBECONFIG_PATH} > /var/log/everoute-agent.log 2>&1 &


### PR DESCRIPTION
Before, we used a randomly generated uuid as agent name. 
Agent name is the name of agentinfo CR.
Now, we should match agent and endpoint,
so agentName must be able to correspond to agent.