### PR TITLE
fix(cni): pod fail to access nodePort with backend in same host

### DIFF
--- a/cmd/everoute-agent/config.go
+++ b/cmd/everoute-agent/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
 
@@ -101,6 +102,13 @@ func setAgentConf(datapathManager *datapath.DpManager, k8sReader client.Reader) 
 	}
 	if len(agentInfo.PodCIDR) == 0 {
 		klog.Fatalf("PodCIDR should be specified when setup kubernetes cluster. E.g. `kubeadm init --pod-network-cidr 10.0.0.0/16`")
+	}
+
+	// get node ip
+	for _, nodeAddr := range node.Status.Addresses {
+		if nodeAddr.Type == corev1.NodeInternalIP {
+			agentInfo.NodeIP = net.ParseIP(nodeAddr.Address)
+		}
 	}
 
 	// get cluster CIDR

--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -173,6 +173,7 @@ type AgentConf struct {
 	EnableCNI bool // enable CNI in Everoute
 
 	NodeName   string
+	NodeIP     net.IP
 	PodCIDR    []cnitypes.IPNet
 	BridgeName string
 

--- a/pkg/agent/proxy/route.go
+++ b/pkg/agent/proxy/route.go
@@ -277,6 +277,18 @@ func (r *NodeReconciler) UpdateIptables(nodeList corev1.NodeList, thisNode corev
 			klog.Errorf("Append filter FORWARD error, err: %s", err)
 		}
 	}
+
+	// bypass nodeport snat from gw-local
+	if exist, err = ipt.Exists("nat", "POSTROUTING", "-o", r.DatapathManager.AgentInfo.LocalGwName,
+		"-m", "mark", "--mark", "0x01/0x01", "-j", "ACCEPT"); err != nil {
+		klog.Errorf("Check net POSTROUTING error, err: %s", err)
+	}
+	if !exist {
+		if err = ipt.Insert("nat", "POSTROUTING", 1, "-o", r.DatapathManager.AgentInfo.LocalGwName,
+			"-m", "mark", "--mark", "0x01/0x01", "-j", "ACCEPT"); err != nil {
+			klog.Errorf("Check net POSTROUTING error, err: %s", err)
+		}
+	}
 }
 
 func (r *NodeReconciler) UpdateNetwork() {


### PR DESCRIPTION
This scene is worked with kernel v.4.x.
Before, we handle nodePort on uplink-bridge with zone 0.
But in kernel v5.x, some things difference with ct state. So pkt cannot send from uplink back to pod.
This patch will only process nodePort with local nodeIP