### PR TITLE
fix(plugin-tower): data race when server immediately stop

### DIFF
--- a/plugin/tower/pkg/server/fake/server.go
+++ b/plugin/tower/pkg/server/fake/server.go
@@ -110,7 +110,6 @@ func (s *Server) start() error {
 	}
 
 	serveErr := make(chan error)
-	defer close(serveErr)
 
 	go func() {
 		err := server.Serve(s.listener)
@@ -118,6 +117,7 @@ func (s *Server) start() error {
 		case serveErr <- err:
 		default:
 		}
+		close(serveErr)
 	}()
 
 	select {

--- a/plugin/tower/pkg/server/fake/server_test.go
+++ b/plugin/tower/pkg/server/fake/server_test.go
@@ -33,3 +33,10 @@ func TestServer_ServeStop(t *testing.T) {
 		}
 	}
 }
+
+func TestServeStop(t *testing.T) {
+	server := NewServer()
+	// should no data race when server immediately stop, see issue: #430
+	server.Serve()
+	defer server.Stop()
+}


### PR DESCRIPTION
fix #430 