### PR TITLE
Fix everoute e2e on Tower

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/streamrail/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6
 	github.com/vektah/gqlparser/v2 v2.1.0
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
 	google.golang.org/grpc v1.35.0
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -915,8 +915,9 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -992,8 +993,9 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1083,6 +1085,7 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=

--- a/tests/e2e/framework/node/agent.go
+++ b/tests/e2e/framework/node/agent.go
@@ -45,7 +45,7 @@ func (n *Agent) Healthz() (bool, error) {
 	return n.checkProcess(agentBinaryName)
 }
 
-// dump the flows and parse the Output
+// DumpFlow dumps the flows and parse the Output
 func (n *Agent) DumpFlow() ([]string, error) {
 	flowDump, err := n.runOpenflowCmd("dump-flows")
 	if err != nil {
@@ -57,8 +57,11 @@ func (n *Agent) DumpFlow() ([]string, error) {
 
 	var flowList []string
 	for _, flow := range flowDB {
+		if !strings.HasPrefix(flow, " cookie=") {
+			continue
+		}
 		felem := strings.Fields(flow)
-		if len(felem) > 2 {
+		if len(felem) >= 5 {
 			felem = append([]string{felem[2]}, felem[5:]...)
 			fstr := strings.Join(felem, " ")
 			flowList = append(flowList, fstr)


### PR DESCRIPTION
**commit: [dump flows with prefix "cookie="](https://github.com/everoute/everoute/pull/470/commits/2f5221d17f10dbbea76b62c2413d9295a77fe6dc)**
We dump flows with the prefix "cookie=" to make sure e2e won't panic on the following flow result:
```
OFPST_FLOW reply (OF1.3) (xid=0x2): flags=[more]
 cookie=0x4000000000009, duration=427501.390s, table=0, n_packets=157064305, n_bytes=69446849982, priority=300,ip actions=ct(table=1,zone=65520)
 cookie=0x400000000000a, duration=427501.390s, table=0, n_packets=97589, n_bytes=4343847, priority=300,in_port=102 actions=output:201
 cookie=0x400000000000b, duration=427501.390s, table=0, n_packets=20321227, n_bytes=1285196685, priority=300,in_port=201 actions=output:102
 cookie=0x0, duration=427541.969s, table=0, n_packets=1038, n_bytes=108639, priority=0 actions=NORMAL
```

<br/>

**commit: [fix(e2e): upgrade golang.org/x/crypto to support rsa-sha2-256/512](https://github.com/everoute/everoute/pull/470/commits/bdebcdf10968d0ea49a1c369440de20361208efb)**
OpenSSH disabled the SHA-1 based ssh-rsa by default in version 8.8, so we upgrade golang.org/x/crypto to support [rsa-sha2-256/512](https://github.com/everoute/everoute/pull/470/commits/bdebcdf10968d0ea49a1c369440de20361208efb).
See more: https://github.com/golang/go/issues/39885