### PR TITLE
fix(policy): change apply order while updating patches

### DIFF
--- a/pkg/agent/controller/policy/cache/rule.go
+++ b/pkg/agent/controller/policy/cache/rule.go
@@ -285,14 +285,6 @@ func (rule *CompleteRule) ApplyPatch(patch *GroupPatch) {
 }
 
 func applyCountMap(count map[string]*IPBlockItem, added, deled map[string]*IPBlockItem) {
-	for ip, add := range added {
-		if _, exist := count[ip]; !exist {
-			count[ip] = NewIPBlockItem()
-		}
-		count[ip].StaticCount += add.StaticCount
-		count[ip].AgentRef.Insert(add.AgentRef.List()...)
-	}
-
 	for ip, del := range deled {
 		if _, exist := count[ip]; !exist {
 			continue
@@ -307,6 +299,14 @@ func applyCountMap(count map[string]*IPBlockItem, added, deled map[string]*IPBlo
 		if count[ip].StaticCount == 0 && count[ip].AgentRef.Len() == 0 {
 			delete(count, ip)
 		}
+	}
+
+	for ip, add := range added {
+		if _, exist := count[ip]; !exist {
+			count[ip] = NewIPBlockItem()
+		}
+		count[ip].StaticCount += add.StaticCount
+		count[ip].AgentRef.Insert(add.AgentRef.List()...)
 	}
 }
 


### PR DESCRIPTION
### Problem
#### origin
ip: agent1

#### update patch v1 (migrate)
ip: agent1 agent2

#### update patch v2 (migrate finish)
-> ip: agent2

#### group cache update
add new(v2) agent2
del old (v1) agent1 agent2

finally it will be **ip: {}**

### Solution
del old (v1) agent1 agent2
add new(v2) agent2
