### PR TITLE
refactor(plugin-tower): streaming upload file with graphql

### DIFF
--- a/plugin/tower/pkg/client/client.go
+++ b/plugin/tower/pkg/client/client.go
@@ -23,9 +23,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -136,58 +133,6 @@ func (c *Client) Query(req *Request) (*Response, error) {
 	}
 
 	return &resp, nil
-}
-
-// EncodeRequest encode graphql request to http request. If req contains an upload
-// file, it encode message as multipart/form-data, and the file will not be copied
-func EncodeRequest(req *Request) (RequestInterface, error) {
-	m := LoadJSONPathUploadMap("variables", req.Variables)
-	if len(m) == 0 {
-		raw, err := json.Marshal(req)
-		return JSONRequest(raw), err
-	}
-
-	indexJSONPathMap := map[string][]string{}
-	index := 0
-	for jsonPath := range m {
-		indexJSONPathMap[strconv.Itoa(index)] = []string{jsonPath}
-		index++
-	}
-
-	multipartWriter := NewMultipartWriterRequest()
-	defer multipartWriter.Close()
-
-	// Content-Disposition: form-data; name="operations"
-	fw, err := multipartWriter.CreateFormField("operations")
-	if err != nil {
-		return nil, fmt.Errorf("encode request: %s", err)
-	}
-	err = json.NewEncoder(fw).Encode(req)
-	if err != nil {
-		return nil, fmt.Errorf("encode request: %s", err)
-	}
-
-	// Content-Disposition: form-data; name="map"
-	fw, err = multipartWriter.CreateFormField("map")
-	if err != nil {
-		return nil, fmt.Errorf("encode request: %s", err)
-	}
-	err = json.NewEncoder(fw).Encode(indexJSONPathMap)
-	if err != nil {
-		return nil, fmt.Errorf("encode request: %s", err)
-	}
-
-	// Content-Disposition: form-data; name="0"; filename="fileName"
-	// Content-Type: application/octet-stream
-	for index, jsonPath := range indexJSONPathMap {
-		upload := m[jsonPath[0]]
-		err = multipartWriter.CreateFormFile(index, upload.FileName, upload.File)
-		if err != nil {
-			return nil, fmt.Errorf("encode request: %s", err)
-		}
-	}
-
-	return multipartWriter, nil
 }
 
 // Auth send login request to tower, and save token
@@ -433,59 +378,4 @@ func closeChanFunc(ch chan struct{}) func() {
 
 type TaskMonitor interface {
 	WaitForTask(ctx context.Context, taskID string) (*schema.Task, error)
-}
-
-// LoadJSONPathUploadMap get all upload from the object
-func LoadJSONPathUploadMap(pathPrefix string, obj interface{}) map[string]Upload {
-	m := make(map[string]Upload)
-	if obj != nil {
-		setJSONPathUploadMap(m, pathPrefix, reflect.ValueOf(obj))
-	}
-	return m
-}
-
-func setJSONPathUploadMap(m map[string]Upload, parentJSONPath string, obj reflect.Value) {
-	switch obj.Type().Kind() {
-	case reflect.Interface, reflect.Ptr:
-		if !obj.IsNil() {
-			setJSONPathUploadMap(m, parentJSONPath, obj.Elem())
-		}
-
-	case reflect.Array, reflect.Slice:
-		for i := 0; i < obj.Len(); i++ {
-			setJSONPathUploadMap(m, fmt.Sprintf("%s.%d", parentJSONPath, i), obj.Index(i))
-		}
-
-	case reflect.Map:
-		for _, mapKey := range obj.MapKeys() {
-			setJSONPathUploadMap(m, fmt.Sprintf("%s.%s", parentJSONPath, mapKey), obj.MapIndex(mapKey))
-		}
-
-	case reflect.Struct:
-		if obj.Type() == reflect.TypeOf(Upload{}) {
-			m[parentJSONPath] = obj.Interface().(Upload)
-			return
-		}
-		for i := 0; i < obj.NumField(); i++ {
-			jsonTagName := getFieldJSONTag(obj.Type().Field(i))
-			if jsonTagName == "" {
-				continue
-			}
-			setJSONPathUploadMap(m, fmt.Sprintf("%s.%s", parentJSONPath, jsonTagName), obj.Field(i))
-		}
-	}
-}
-
-func getFieldJSONTag(field reflect.StructField) string {
-	jsonTag := field.Tag.Get("json")
-
-	if field.PkgPath != "" || field.Anonymous || jsonTag == "-" {
-		return ""
-	}
-
-	tag := strings.Split(jsonTag, ",")[0]
-	if tag != "" {
-		return tag
-	}
-	return field.Name
 }

--- a/plugin/tower/pkg/client/client_test.go
+++ b/plugin/tower/pkg/client/client_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package client_test
 
 import (
-	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -73,56 +71,5 @@ func getUserInfo(user *model.User) *client.UserInfo {
 		Username: user.Name,
 		Password: user.Password,
 		Source:   string(user.Source),
-	}
-}
-
-func TestLoadJSONPathUploadMap(t *testing.T) {
-	testCases := []struct {
-		object    interface{}
-		expectMap map[string]client.Upload
-	}{
-		{
-			object:    nil,
-			expectMap: map[string]client.Upload{},
-		},
-		{
-			object: map[string]interface{}{
-				"string": "this is string",
-				"int":    10,
-				"slice":  []string{"stringA", "stringB"},
-				"file":   &client.Upload{FileName: "fileA"},
-			},
-			expectMap: map[string]client.Upload{"variables.file": {FileName: "fileA"}},
-		},
-		{
-			object: []client.Upload{
-				{FileName: "fileA"},
-				{FileName: "fileB"},
-			},
-			expectMap: map[string]client.Upload{"variables.0": {FileName: "fileA"}, "variables.1": {FileName: "fileB"}},
-		},
-		{
-			object: struct {
-				A string         `json:"tag_a"`
-				B *client.Upload `json:"tag_b"`
-				C *client.Upload `json:"-"`
-				d *client.Upload
-			}{
-				A: "this is string",
-				B: &client.Upload{FileName: "fileB"},
-				C: &client.Upload{FileName: "fileC"},
-				d: &client.Upload{FileName: "fileD"},
-			},
-			expectMap: map[string]client.Upload{"variables.tag_b": {FileName: "fileB"}},
-		},
-	}
-
-	for index, tc := range testCases {
-		t.Run(fmt.Sprintf("tc%2d", index), func(t *testing.T) {
-			actualMap := client.LoadJSONPathUploadMap("variables", tc.object)
-			if !reflect.DeepEqual(actualMap, tc.expectMap) {
-				t.Fatalf("expect LoadJSONPathUploadMap = %v, got LoadJSONPathUploadMap = %v", tc.expectMap, actualMap)
-			}
-		})
 	}
 }

--- a/plugin/tower/pkg/client/request.go
+++ b/plugin/tower/pkg/client/request.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+)
+
+// RequestInterface provides metadata of a http request
+type RequestInterface interface {
+	String() string       // humanreadable string
+	GetReader() io.Reader // request body reader
+	ContentType() string  // content-type in header
+}
+
+// MultipartWriterRequest generates multipart messages as RequestInterface, it wraps multipart
+// writer. But differently, you can CreateFormFile with file reader directly.
+type MultipartWriterRequest struct {
+	*multipart.Writer
+
+	readers              []io.Reader
+	humanreadableContent string
+}
+
+// NewMultipartWriterRequest returns a new MultipartWriterRequest
+func NewMultipartWriterRequest() *MultipartWriterRequest {
+	m := &MultipartWriterRequest{}
+	m.Writer = multipart.NewWriter(m)
+	return m
+}
+
+func (m *MultipartWriterRequest) Write(data []byte) (int, error) {
+	if len(m.readers) == 0 {
+		m.readers = append(m.readers, bytes.NewBuffer(nil))
+	}
+	m.humanreadableContent += string(data)
+	return m.readers[len(m.readers)-1].(io.Writer).Write(data)
+}
+
+func (m *MultipartWriterRequest) CreateFormFile(fieldname, filename string, reader io.Reader) error {
+	_, err := m.Writer.CreateFormFile(fieldname, filename)
+	if err != nil {
+		return err
+	}
+	m.humanreadableContent += "COLLAPSED FORM FILE CONTENT\n"
+	m.readers = append(m.readers, reader, bytes.NewBuffer(nil))
+	return nil
+}
+
+func (m *MultipartWriterRequest) ContentType() string  { return m.FormDataContentType() }
+func (m *MultipartWriterRequest) String() string       { return m.humanreadableContent }
+func (m *MultipartWriterRequest) GetReader() io.Reader { return io.MultiReader(m.readers...) }
+
+type JSONRequest []byte
+
+func (r JSONRequest) ContentType() string  { return "application/json" }
+func (r JSONRequest) String() string       { return string(r) }
+func (r JSONRequest) GetReader() io.Reader { return bytes.NewReader(r) }

--- a/plugin/tower/pkg/client/request.go
+++ b/plugin/tower/pkg/client/request.go
@@ -18,8 +18,13 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 // RequestInterface provides metadata of a http request
@@ -72,3 +77,110 @@ type JSONRequest []byte
 func (r JSONRequest) ContentType() string  { return "application/json" }
 func (r JSONRequest) String() string       { return string(r) }
 func (r JSONRequest) GetReader() io.Reader { return bytes.NewReader(r) }
+
+// EncodeRequest encode graphql request to http request. If req contains an upload
+// file, it encode message as multipart/form-data, and the file will not be copied
+func EncodeRequest(req *Request) (RequestInterface, error) {
+	m := loadJSONPathUploadMap("variables", req.Variables)
+	if len(m) == 0 {
+		raw, err := json.Marshal(req)
+		return JSONRequest(raw), err
+	}
+
+	indexJSONPathMap := map[string][]string{}
+	index := 0
+	for jsonPath := range m {
+		indexJSONPathMap[strconv.Itoa(index)] = []string{jsonPath}
+		index++
+	}
+
+	multipartWriter := NewMultipartWriterRequest()
+	defer multipartWriter.Close()
+
+	// Content-Disposition: form-data; name="operations"
+	fw, err := multipartWriter.CreateFormField("operations")
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %s", err)
+	}
+	err = json.NewEncoder(fw).Encode(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %s", err)
+	}
+
+	// Content-Disposition: form-data; name="map"
+	fw, err = multipartWriter.CreateFormField("map")
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %s", err)
+	}
+	err = json.NewEncoder(fw).Encode(indexJSONPathMap)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %s", err)
+	}
+
+	// Content-Disposition: form-data; name="0"; filename="fileName"
+	// Content-Type: application/octet-stream
+	for index, jsonPath := range indexJSONPathMap {
+		upload := m[jsonPath[0]]
+		err = multipartWriter.CreateFormFile(index, upload.FileName, upload.File)
+		if err != nil {
+			return nil, fmt.Errorf("encode request: %s", err)
+		}
+	}
+
+	return multipartWriter, nil
+}
+
+// loadJSONPathUploadMap get all upload from the object
+func loadJSONPathUploadMap(pathPrefix string, obj interface{}) map[string]Upload {
+	m := make(map[string]Upload)
+	if obj != nil {
+		setJSONPathUploadMap(m, pathPrefix, reflect.ValueOf(obj))
+	}
+	return m
+}
+
+func setJSONPathUploadMap(m map[string]Upload, parentJSONPath string, obj reflect.Value) {
+	switch obj.Type().Kind() {
+	case reflect.Interface, reflect.Ptr:
+		if !obj.IsNil() {
+			setJSONPathUploadMap(m, parentJSONPath, obj.Elem())
+		}
+
+	case reflect.Array, reflect.Slice:
+		for i := 0; i < obj.Len(); i++ {
+			setJSONPathUploadMap(m, fmt.Sprintf("%s.%d", parentJSONPath, i), obj.Index(i))
+		}
+
+	case reflect.Map:
+		for _, mapKey := range obj.MapKeys() {
+			setJSONPathUploadMap(m, fmt.Sprintf("%s.%s", parentJSONPath, mapKey), obj.MapIndex(mapKey))
+		}
+
+	case reflect.Struct:
+		if obj.Type() == reflect.TypeOf(Upload{}) {
+			m[parentJSONPath] = obj.Interface().(Upload)
+			return
+		}
+		for i := 0; i < obj.NumField(); i++ {
+			jsonTagName := getFieldJSONTag(obj.Type().Field(i))
+			if jsonTagName == "" {
+				continue
+			}
+			setJSONPathUploadMap(m, fmt.Sprintf("%s.%s", parentJSONPath, jsonTagName), obj.Field(i))
+		}
+	}
+}
+
+func getFieldJSONTag(field reflect.StructField) string {
+	jsonTag := field.Tag.Get("json")
+
+	if field.PkgPath != "" || field.Anonymous || jsonTag == "-" {
+		return ""
+	}
+
+	tag := strings.Split(jsonTag, ",")[0]
+	if tag != "" {
+		return tag
+	}
+	return field.Name
+}

--- a/plugin/tower/pkg/client/request_test.go
+++ b/plugin/tower/pkg/client/request_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestJSONRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	content := rand.String(10)
+	request := JSONRequest(content)
+
+	Expect(request.ContentType()).Should(Equal("application/json"))
+	Expect(request.String()).Should(Equal(content))
+	raw, err := io.ReadAll(request.GetReader())
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(string(raw)).Should(Equal(content))
+}
+
+func TestMultipartWriterRequest(t *testing.T) {
+	RegisterTestingT(t)
+
+	request := NewMultipartWriterRequest()
+	fieldName := rand.String(10)
+	fileName := rand.String(10)
+	fileContentRaw := rand.String(100)
+
+	err := request.CreateFormFile(fieldName, fileName, bytes.NewBufferString(fileContentRaw))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(request.Close()).ShouldNot(HaveOccurred())
+	Expect(request.String()).ShouldNot(BeEmpty())
+
+	mediatype, params, _ := mime.ParseMediaType(request.ContentType())
+	Expect(mediatype).Should(Equal("multipart/form-data"))
+	Expect(params["boundary"]).ShouldNot(BeEmpty())
+
+	mp, err := multipart.NewReader(request.GetReader(), params["boundary"]).NextPart()
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(mp.FormName()).Should(Equal(fieldName))
+	Expect(mp.FileName()).Should(Equal(fileName))
+	raw, err := io.ReadAll(mp)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(string(raw)).Should(Equal(fileContentRaw))
+}
+
+func TestEncodeRequest(t *testing.T) {
+	t.Run("encode request without any uploads", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		req, err := EncodeRequest(&Request{Query: "my{id}", Variables: map[string]interface{}{
+			"v1": 1,
+			"v2": "2",
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(req.ContentType()).Should(Equal("application/json"))
+		Expect(req.String()).Should(Equal(`{"query":"my{id}","variables":{"v1":1,"v2":"2"}}`))
+	})
+
+	t.Run("encode request with an upload", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		fileName := rand.String(10)
+		fileContentRaw := rand.String(100)
+		req, err := EncodeRequest(&Request{Query: "my{id}", Variables: map[string]interface{}{
+			"file": Upload{
+				FileName: fileName,
+				File:     bytes.NewBufferString(fileContentRaw),
+			},
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		mediatype, params, _ := mime.ParseMediaType(req.ContentType())
+		Expect(mediatype).Should(Equal("multipart/form-data"))
+		Expect(params["boundary"]).ShouldNot(BeEmpty())
+		mr := multipart.NewReader(req.GetReader(), params["boundary"])
+
+		mp, err := mr.NextPart()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(mp.FormName()).Should(Equal("operations"))
+		raw, err := io.ReadAll(mp)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(raw)).Should(Equal(`{"query":"my{id}","variables":{"file":{"FileName":"` + fileName + `","File":{}}}}` + "\n"))
+
+		mp, err = mr.NextPart()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(mp.FormName()).Should(Equal("map"))
+		raw, err = io.ReadAll(mp)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(raw)).Should(Equal(`{"0":["variables.file"]}` + "\n"))
+
+		mp, err = mr.NextPart()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(mp.FormName()).Should(Equal("0"))
+		Expect(mp.FileName()).Should(Equal(fileName))
+		raw, err = io.ReadAll(mp)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(raw)).Should(Equal(fileContentRaw))
+	})
+}


### PR DESCRIPTION
Combine HTTP body reader and upload file reader, reduce the memory usage for copy file.