### PR TITLE
ci: add timeout for k8s e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,6 +168,7 @@ jobs:
           kubectl get nodes -owide
 
       - name: run test cases
+        timeout-minutes: 40
         run: ./k8se2e/bin/ginkgo -nodes=15 --skip="SCTP" --focus="${{ matrix.focus }}" ./k8se2e/bin/e2e.test -- --disable-log-dump --provider="skeleton" --kubeconfig=/home/runner/.kube/config
 
       - name: delete test k8s cluster


### PR DESCRIPTION
Sometimes, k8s e2e will get stuck. And we don't find the reason now, so set timeout for it