### PR TITLE
fix: reply hostnetwork endpoint's arp in cnibr0-gw-local

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -150,7 +150,8 @@ var (
 	IPv4Lenth       uint16 = 32
 	PortLength      uint16 = 16
 
-	ArpOperReply uint64 = 2
+	ArpOperRequest uint16 = 1
+	ArpOperReply   uint64 = 2
 )
 
 var IPMaskMatchFullBit = net.ParseIP("255.255.255.255")

--- a/pkg/agent/datapath/uplinkBridgeOverlay.go
+++ b/pkg/agent/datapath/uplinkBridgeOverlay.go
@@ -251,6 +251,7 @@ func (u *UplinkBridgeOverlay) initArpProxytable() error {
 		Ethertype:  PROTOCOL_ARP,
 		ArpTpa:     &u.datapathManager.Info.GatewayIP,
 		ArpTpaMask: &IPMaskMatchFullBit,
+		ArpOper:    ArpOperRequest,
 		Priority:   HIGH_MATCH_FLOW_PRIORITY,
 	})
 	if err := setupArpProxyFlowAction(gwProxyFlow, u.datapathManager.Info.GatewayMac); err != nil {
@@ -264,6 +265,7 @@ func (u *UplinkBridgeOverlay) initArpProxytable() error {
 		Ethertype:  PROTOCOL_ARP,
 		ArpTpa:     &u.datapathManager.Info.ClusterPodCIDR.IP,
 		ArpTpaMask: (*net.IP)(&u.datapathManager.Info.ClusterPodCIDR.Mask),
+		ArpOper:    ArpOperRequest,
 		Priority:   MID_MATCH_FLOW_PRIORITY,
 	})
 	fakeMac, _ := net.ParseMAC(FACK_MAC)


### PR DESCRIPTION
When use kube-proxy, svc pkt will do DNAT in kernel through cnibr0-gw-local. After DNAT, it will request the endpoint IP's arp before pkt come back to cnibr0-gw-local. The PR add reply hostnetwork endpoint arp flow in local bridge
