### PR TITLE
ci: set k8s e2e own runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
           - feature: Proxy
             focus: NetworkPolicy|ClusterIP|clusterIP
           - focus: NetworkPolicy
-    runs-on: [self-hosted, pod]
+    runs-on: [self-hosted, pod-k8s-e2e]
     steps:
       - uses: actions/checkout@v2
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: run test cases
         timeout-minutes: 40
-        run: ./k8se2e/bin/ginkgo -nodes=15 --skip="SCTP" --focus="${{ matrix.focus }}" ./k8se2e/bin/e2e.test -- --disable-log-dump --provider="skeleton" --kubeconfig=/home/runner/.kube/config
+        run: ./k8se2e/bin/ginkgo -nodes=10 --skip="SCTP" --focus="${{ matrix.focus }}" ./k8se2e/bin/e2e.test -- --disable-log-dump --provider="skeleton" --kubeconfig=/home/runner/.kube/config
 
       - name: delete test k8s cluster
         id: delenv

--- a/hack/kubesmartcluster.yaml.tmpl
+++ b/hack/kubesmartcluster.yaml.tmpl
@@ -188,12 +188,12 @@ spec:
       nodeConfig:
         cloneMode: FastClone
         cpuCores: 4
-        memoryMB: 6144
+        memoryMB: 8192
         network:
           devices:
           - networkType: IPV4_DHCP
             tag: default
             vlan: clg9ooxpx00wn0958aq97kssi
       nodeDrainTimeout: 5m0s
-      replicas: 9
+      replicas: 5
   version: v1.22.16


### PR DESCRIPTION
set k8s e2e own runner with label pod-k8s-e2e to control k8s-e2e concurrency