### PR TITLE
ci: add build cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  cache-registry: 'docker-registry-cache.docker-registry.svc:5000'
+
 jobs:
   build:
     runs-on: [self-hosted, pod]
@@ -21,12 +24,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: docker/setup-qemu-action@v2
-
-      - run: docker context create build
-
-      - uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: build
 
       - name: Login docker hub
         uses: docker/login-action@v2
@@ -49,6 +46,8 @@ jobs:
             registry.smtx.io/everoute/release:${{ env.IMAGE_TAG }}
           platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=registry,ref=${{ env.cache-registry }}/everoute/cni/build
+          cache-to: type=registry,ref=${{ env.cache-registry }}/everoute/cni/build, mod=max
 
       - name: Check if tag is a release tag
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,21 @@ on:
     # 7:00 UTC+8
     - cron: "0 23 * * *"
 
+env:
+  cache-registry: 'docker-registry-cache.docker-registry.svc:5000'
+
 jobs:
   build-unit-test-image:
-    runs-on: [self-hosted, build]
+    runs-on: [self-hosted, pod]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Login registry.smtx.io
+        uses: docker/login-action@v2
+        with:
+          registry: registry.smtx.io
+          username: ${{ secrets.HARBOR_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_PUSH_TOKEN }}
 
       - name: build unit-test image
         uses: docker/build-push-action@v4
@@ -25,6 +35,8 @@ jobs:
           tags: registry.smtx.io/everoute/unit-test
           context: ./build/images/unit-test/
           push: true
+          cache-from: type=registry,ref=${{ env.cache-registry }}/everoute/cni/unit
+          cache-to: type=registry,ref=${{ env.cache-registry }}/everoute/cni/unit, mod=max
 
   pr-check:
     needs: [build-unit-test-image, static-check, generate-check]
@@ -43,7 +55,6 @@ jobs:
 
   static-check:
     runs-on: [ubuntu-20.04]
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -58,6 +69,8 @@ jobs:
         uses: crate-ci/typos@v1.0.4
 
       - name: Check golang lint
+        # skip it for branch main can't pass this check
+        if: ${{ github.event_name == 'pull_request' }}
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53
@@ -76,9 +89,16 @@ jobs:
         run: sudo make docker-e2e-test
   
   build-k8s-e2e-image:
-    runs-on: [self-hosted, build]
+    runs-on: [self-hosted, pod]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Login registry.smtx.io
+        uses: docker/login-action@v2
+        with:
+          registry: registry.smtx.io
+          username: ${{ secrets.HARBOR_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_PUSH_TOKEN }}
 
       - name: build everoute image
         uses: docker/build-push-action@v4
@@ -87,6 +107,8 @@ jobs:
           tags: registry.smtx.io/everoute/everoute_release:${{ github.sha }}
           context: .
           push: true
+          cache-from: type=registry,ref=${{ env.cache-registry }}/everoute/cni/build
+          cache-to: type=registry,ref=${{ env.cache-registry }}/everoute/cni/build, mod=max
 
   run-k8s-e2e:
     needs: [build-k8s-e2e-image, static-check, generate-check, pr-check]
@@ -106,8 +128,6 @@ jobs:
           else
             echo "focus=NetworkPolicy" >> $GITHUB_ENV
           fi
-      
-      - run: echo "${{ env.focus }}"
 
       - name: config PATH
         run: |


### PR DESCRIPTION
1、use pod runner to build image
2、add build cache

ci failed to build image, because pr source fork repo can't use everoute/everoute secrets. there has been test in https://github.com/everoute/everoute/actions/runs/6493999967 for build, and https://github.com/everoute/everoute/actions/runs/6493999975 for ci