### PR TITLE
feat: set gw ippool private

### DIFF
--- a/deploy/chart/templates/crds/ipam.everoute.io_ippools.yaml
+++ b/deploy/chart/templates/crds/ipam.everoute.io_ippools.yaml
@@ -44,6 +44,8 @@ spec:
                 description: 'Gateway must a valid IP in Subnet nolint: lll'
                 pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                 type: string
+              private:
+                type: boolean
               subnet:
                 description: 'Subnet is the total L2 network, nolint: lll'
                 pattern: ^(?:(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-2]\d|3[0-2])$

--- a/deploy/chart/templates/everoute_ippool.yaml
+++ b/deploy/chart/templates/everoute_ippool.yaml
@@ -6,7 +6,8 @@ metadata:
   name: everoute-built-in
   namespace: kube-system
 spec:
+  private: true
   cidr: {{ .Values.CNIConf.gwIPPool.cidr }}
-  subnet: {{ .Values.CNIConf.gwIPPool.cidr }}
+  subnet: {{ .Values.CNIConf.gwIPPool.subnet }}
   gateway: {{ .Values.CNIConf.gwIPPool.gateway }}
 {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -16,8 +16,9 @@ CNIConf:
   vni: 5000
   ipam: ""
   gwIPPool:
-    gateway: 240.100.224.0
-    cidr: 240.100.224.0/19
+    gateway: 240.100.0.1
+    subnet: 240.100.0.0/16
+    cidr: 240.100.0.0/24
 
 webhook:
   type: Service # enum: Service, URL

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -769,6 +769,8 @@ spec:
                 description: 'Gateway must a valid IP in Subnet nolint: lll'
                 pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
                 type: string
+              private:
+                type: boolean
               subnet:
                 description: 'Subnet is the total L2 network, nolint: lll'
                 pattern: ^(?:(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-2]\d|3[0-2])$

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ replace (
 	github.com/contiv/libOpenflow => github.com/everoute/libOpenflow v1.0.0
 	github.com/contiv/libovsdb => github.com/everoute/libovsdb v0.0.0-20230606074221-485f24386155
 	github.com/contiv/ofnet => github.com/everoute/ofnet v0.0.0-20231123100718-d071171cf898
+	github.com/everoute/ipam => github.com/everoute/ipam v1.1.1-0.20240118021612-1cef479f6551
 	github.com/osrg/gobgp => github.com/everoute/gobgp v0.0.0-20210127101833-12edfc1f4514
 	github.com/vishvananda/netlink => github.com/everoute/netlink v0.0.0-20230901045851-81de37d489fe
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20230227204213-929b88f6cb43

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/everoute/ipam v1.1.0 h1:ZcgdLqIJAOtx6tIha32b8WCK/LEaJLfqFpYI7xemIt0=
-github.com/everoute/ipam v1.1.0/go.mod h1:p7jCXS1iCfTWEglMdJrh3BsfDD8BvvgA/T/wz+TM8vg=
+github.com/everoute/ipam v1.1.1-0.20240118021612-1cef479f6551 h1:5ThRS6GF5aERO8dncq+X70TvjZC34xZCf6xOLE0LPKA=
+github.com/everoute/ipam v1.1.1-0.20240118021612-1cef479f6551/go.mod h1:p7jCXS1iCfTWEglMdJrh3BsfDD8BvvgA/T/wz+TM8vg=
 github.com/everoute/libOpenflow v1.0.0 h1:3xxCS3Fjo44NvP6jpD9zuPSHEe8AxvfQzOjbCJn0GXM=
 github.com/everoute/libOpenflow v1.0.0/go.mod h1:Glli90eKTMhkETRmgjf2DgHTf+PDCQUv6nZvubrLuuA=
 github.com/everoute/libovsdb v0.0.0-20230606074221-485f24386155 h1:JwthEk9kaDQF2W1R5PVR19Unwj3e55FUVG3YM6409Dw=


### PR DESCRIPTION
主要功能：
部署everoute时创建ippool everoute-built-in 用于给cnibr0-gw分配IP。
通过values可在部署everoute时配置 everoute-built-in ip池的 cidr,subnet，gatway。
默认everoute-built-in ip池的spec.private属性为true，不会从这个IP池中分配IP给其他Pod。

自测：
创建了ip池 everoute-built-in 

且从这个IP池中分配了两个IP分别给两个节点的cnibr0-gw网口
<img width="442" alt="image" src="https://github.com/everoute/everoute/assets/26404219/3f2409f4-af9c-4372-93a8-391e57bbd334">
不会从这个IP池中分配IP给其他Pod
<img width="809" alt="image" src="https://github.com/everoute/everoute/assets/26404219/292304ac-bf53-4702-a5c2-dc2ae8081f29">



