### PR TITLE
feat: watch gw-ep endpoint create event to sync node delete

### DIFF
--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -322,7 +322,7 @@ func updateGwEndpoint(k8sClient client.Client, datapathManager *datapath.DpManag
 				Spec: v1alpha1.EndpointSpec{
 					Type: v1alpha1.EndpointStatic,
 					Reference: v1alpha1.EndpointReference{
-						ExternalIDName:  "gw-ep",
+						ExternalIDName:  constants.GwEpExternalIDName,
 						ExternalIDValue: datapathManager.Info.NodeName,
 					},
 				},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -66,7 +66,8 @@ const (
 	EncapModeGeneve = "geneve"
 	GeneveHeaderLen = 50
 
-	GwEndpointName = "gw-ep"
+	GwEpNamePrefix     = "gw-ep"
+	GwEpExternalIDName = "gw-ep"
 
 	EverouteIPAM = "everoute"
 

--- a/pkg/utils/cni.go
+++ b/pkg/utils/cni.go
@@ -15,7 +15,7 @@ type CNIArgs struct {
 }
 
 func GetGwEndpointName(nodeName string) string {
-	return constants.GwEndpointName + "-" + nodeName
+	return constants.GwEpNamePrefix + "-" + nodeName
 }
 
 func GetNodeInternalIP(node *corev1.Node) string {


### PR DESCRIPTION
controller会watch node删除事件来删除对应节点的gw-endpoint，node删除事件有可能丢失，所以同时watch endpoint创建事件，如果endpoint对应的node不存在，则删除这个gw-endpoint