### PR TITLE
fix: node controller ut must run after k8smanager start

### DIFF
--- a/pkg/controller/k8s/node_controller_test.go
+++ b/pkg/controller/k8s/node_controller_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -61,7 +60,7 @@ var _ = Describe("node controller test", func() {
 					err2 := k8sClient.Get(ctx, epKey, &ep)
 					g.Expect(err2).ShouldNot(BeNil())
 					g.Expect(errors.IsNotFound(err2)).Should(BeTrue())
-				}, 5*time.Minute, interval).Should(Succeed())
+				}, timeout, interval).Should(Succeed())
 			})
 		})
 	})

--- a/pkg/controller/k8s/suite_test.go
+++ b/pkg/controller/k8s/suite_test.go
@@ -138,11 +138,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	ctx := ctrl.SetupSignalHandler()
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
+	k8sManager.GetCache().WaitForCacheSync(ctx)
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 }, 60)


### PR DESCRIPTION
ut概率失败原因：
k8smanager 通过go协程启动，如果运行单测的时候k8smanager还没有启动，那么单测会失败
解决方式：
k8smanager在启动过程中会等待cache同步，所以在运行单测之前等待cache同步，那么运行单测时，k8smanager大概率已经启动