### PR TITLE
ci: k8s e2e run in idc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         enable-proxy: [true, false]
         encap-mode: ["", geneve]
-    runs-on: [self-hosted, pod-k8s-e2e]
+    runs-on: [self-hosted, pod-k8s-e2e-v2]
     steps:
       - uses: actions/checkout@v2
 
@@ -113,6 +113,11 @@ jobs:
           mkdir -p /runner/_work/bin/
           echo "/runner/_work/bin/" >> $GITHUB_PATH
 
+      - name: set env
+        run: |
+          echo "PoolName=$PoolName" >> $GITHUB_ENV
+          echo "Tmpl=$Tmpl" >> $GITHUB_ENV
+
       - name: install helm
         run: cp /home/runner/tool/helm /runner/_work/bin/
 
@@ -127,7 +132,7 @@ jobs:
 
       - name: allocate cluster vip
         run: |
-          out=$(curl -X POST  'https://ip.dev.smtx.io/v1/ips?name=sdn1')
+          out=$(curl -X POST  'https://ip.dev.smtx.io/v1/ips?name=${{ env.PoolName }}')
           success=$(echo $out | grep "fullSuccess" |wc -l)
           if [ $success != 1 ]; then exit 1; fi
           ipright=${out#*\"ips\":[\"}
@@ -140,10 +145,10 @@ jobs:
       - name: create k8s cluster...
         run: |
           echo "new k8s cluster name is ${{ env.CLUSTER_NAME }}"
-          sed -i s/{{k8s-e2e-cluster-name}}/${{ env.CLUSTER_NAME }}/g hack/kubesmartcluster.yaml.tmpl
+          sed -i s/{{k8s-e2e-cluster-name}}/${{ env.CLUSTER_NAME }}/g hack/${{ env.Tmpl }}
           echo "k8s cluster vip is ${{ env.VIP }}"
-          sed -i s/{{k8s-e2e-cluster-vip}}/${{ env.VIP }}/g hack/kubesmartcluster.yaml.tmpl
-          kubectl --v=9 apply -f hack/kubesmartcluster.yaml.tmpl --kubeconfig /home/runner/sksconfig/sksconfig
+          sed -i s/{{k8s-e2e-cluster-vip}}/${{ env.VIP }}/g hack/${{ env.Tmpl }}
+          kubectl --v=9 apply -f hack/${{ env.Tmpl }} --kubeconfig /home/runner/sksconfig/sksconfig
           kubectl --kubeconfig /home/runner/sksconfig/sksconfig wait --for=jsonpath='{.status.controlPlaneAvailable}'=true KubeSmartCluster/${{ env.CLUSTER_NAME }} --timeout=10m
 
       - name: get new k8s cluster kubeconfig and test connection
@@ -166,6 +171,7 @@ jobs:
           kubectl apply -f deploy/everoute.yaml
 
       - name: wait k8s cluster ready
+        timeout-minutes: 10
         run: |
           kubectl --kubeconfig /home/runner/sksconfig/sksconfig wait --for=jsonpath='{.status.phase}'=Ready KubeSmartCluster/${{ env.CLUSTER_NAME }} --timeout=10m
           mastercount=$(kubectl --kubeconfig /home/runner/sksconfig/sksconfig get ksc ${{ env.CLUSTER_NAME }} -o template --template={{.status.controlPlanes.totalCount}})
@@ -189,11 +195,11 @@ jobs:
       - name: delete test k8s cluster
         id: delenv
         if: ${{ always() }}
-        run: kubectl --kubeconfig /home/runner/sksconfig/sksconfig delete -f hack/kubesmartcluster.yaml.tmpl
+        run: kubectl --kubeconfig /home/runner/sksconfig/sksconfig delete -f hack/${{ env.Tmpl }}
 
       - name: recycle vip
         if: ${{ always() && steps.delenv.conclusion == 'success' }}
-        run: curl -X DELETE "https://ip.dev.smtx.io/v1/ips?name=sdn1&ip="${{ env.VIP }}
+        run: curl -X DELETE "https://ip.dev.smtx.io/v1/ips?name="${{ env.PoolName }}"&ip="${{ env.VIP }}
   
   # run-tower-e2e:
   #   runs-on: [self-hosted, tower]

--- a/hack/kubesmartcluster_idc.yaml.tmpl
+++ b/hack/kubesmartcluster_idc.yaml.tmpl
@@ -1,0 +1,199 @@
+apiVersion: kubesmart.smtx.io/v1alpha1
+kind: KubeSmartCluster
+metadata:
+  annotations:
+    sks-display-name: {{k8s-e2e-cluster-name}}
+  name: {{k8s-e2e-cluster-name}}
+  namespace: default
+spec:
+  cloudProvider:
+    cloudtower:
+      cloudtowerServer:
+        secretRef:
+          name: cloudtower-server
+          namespace: default
+        spec:
+          authMode: LOCAL
+          password: ""
+          server: ""
+          username: ""
+      elfCluster: 77f087d3-1347-4f66-abab-7367a802efdd
+      vmTemplate: clhu3w1zubjx309588eq207w5
+      zbsVip: ""
+    name: cloudtower
+  clusterConfiguration:
+    customImageRegistry: registry.smtx.io/kubesmart
+    kubernetes:
+      controlPlane:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              admission-control-config-file: /etc/kubernetes/admission.yaml
+              audit-log-maxage: "30"
+              audit-log-maxbackup: "10"
+              audit-log-maxsize: "100"
+              audit-log-path: /var/log/apiserver/audit.log
+              audit-policy-file: /etc/kubernetes/auditpolicy.yaml
+              enable-admission-plugins: AlwaysPullImages,EventRateLimit
+              profiling: "false"
+              request-timeout: 300s
+              tls-cipher-suites: TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
+            extraVolumes:
+            - hostPath: /var/log/apiserver
+              mountPath: /var/log/apiserver
+              name: apiserver-log
+              pathType: DirectoryOrCreate
+            - hostPath: /etc/kubernetes/admission.yaml
+              mountPath: /etc/kubernetes/admission.yaml
+              name: admission-config
+              pathType: FileOrCreate
+              readOnly: true
+            - hostPath: /etc/kubernetes/auditpolicy.yaml
+              mountPath: /etc/kubernetes/auditpolicy.yaml
+              name: audit-policy
+              pathType: FileOrCreate
+              readOnly: true
+          controllerManager:
+            extraArgs:
+              profiling: "false"
+              terminated-pod-gc-threshold: "10"
+          dns: {}
+          etcd: {}
+          networking: {}
+          scheduler:
+            extraArgs:
+              profiling: "false"
+        files:
+        - content: |
+            apiVersion: apiserver.config.k8s.io/v1
+            kind: AdmissionConfiguration
+            plugins:
+              - name: EventRateLimit
+                configuration:
+                  apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+                  kind: Configuration
+                  limits:
+                    - type: Server
+                      burst: 20000
+                      qps: 5000
+          owner: root:root
+          path: /etc/kubernetes/admission.yaml
+        - content: |
+            apiVersion: audit.k8s.io/v1
+            kind: Policy
+            rules:
+              - level: None
+                userGroups:
+                - system:nodes
+              - level: None
+                users:
+                - system:kube-scheduler
+                - system:volume-scheduler
+                - system:kube-controller-manager
+              - level: None
+                nonResourceURLs:
+                - /healthz*
+                - /version
+                - /swagger*
+              - level: Metadata
+                resources:
+                - resources: ["secrets", "configmaps", "tokenreviews"]
+              - level: Metadata
+                omitStages:
+                  - RequestReceived
+                resources:
+                - resources: ["pods", "deployments"]
+          owner: root:root
+          path: /etc/kubernetes/auditpolicy.yaml
+        initConfiguration:
+          localAPIEndpoint: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+              event-qps: "0"
+              protect-kernel-defaults: "true"
+              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        joinConfiguration:
+          discovery: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+              event-qps: "0"
+              protect-kernel-defaults: "true"
+              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+      workers:
+        joinConfiguration:
+          discovery: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+              event-qps: "0"
+              protect-kernel-defaults: "true"
+              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+    operation:
+      createClusterTimeout: 0s
+      rollbackClusterTimeout: 0s
+      updateClusterTimeout: 0s
+      upgradeClusterTimeout: 0s
+    proxy: {}
+    security:
+      sshPassword: "smartx"
+    skipTLSVerify: true
+  components:
+    externaldns:
+      externaldns:
+        disabled: true
+    ingress:
+      contour:
+        disabled: true
+    loadbalancer:
+      metallb:
+        disabled: true
+    logging:
+      elasticcurator: {}
+      elasticsearch: {}
+      fluentbit: {}
+      kibana: {}
+      loggingoperator: {}
+    monitoring:
+      kubeprometheus: {}
+  controlPlaneEndpoint:
+    host: {{k8s-e2e-cluster-vip}}
+    port: 6443
+  network:
+    managementNetworkInterface: ens4
+    pods:
+      cidrBlocks:
+      - 172.16.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/22
+  storage:
+    csi:
+      elf:
+        name: smtx-elf-csi
+  topology:
+    controlPlane:
+      name: controlplane
+      nodeConfig:
+        cloneMode: FastClone
+        cpuCores: 4
+        memoryMB: 8192
+        network:
+          devices:
+          - networkType: IPV4_DHCP
+            tag: default
+            vlan: cll1r3hb3bs6r09589fiyvarn
+      nodeDrainTimeout: 5m0s
+      replicas: 1
+    workers:
+    - name: workergroup1
+      nodeConfig:
+        cloneMode: FastClone
+        cpuCores: 4
+        memoryMB: 8192
+        network:
+          devices:
+          - networkType: IPV4_DHCP
+            tag: default
+            vlan: cll1r3hb3bs6r09589fiyvarn
+      nodeDrainTimeout: 5m0s
+      replicas: 5
+  version: v1.25.4


### PR DESCRIPTION
k8s e2e 能同时在7031和idc环境上运行
实现方式：
- 运行2个runnerdeployment，其label都是pod-k8s-e2e-v2，分别在7031集群和idc集群运行k8s e2e
- 在idc环境上运行的k8s集群的vip池为sdn2（172.21.253.0-172.21.253.30），在7031集群上运行的k8s集群的vip池为sdn1（192.168.65.1-100）。通过runner环境的环境变量PoolName区分。
- idc环境的ksc yaml为kubesmartcluster_idc.yaml.tmpl，7031环境为kubesmartcluster.yaml.tmpl。通过runner的环境变量Tmpl区分