### PR TITLE
feat: release gateway ip

### DIFF
--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -328,7 +328,7 @@ func updateGwEndpoint(k8sClient client.Client, datapathManager *datapath.DpManag
 				Spec: v1alpha1.EndpointSpec{
 					Type: v1alpha1.EndpointStatic,
 					Reference: v1alpha1.EndpointReference{
-						ExternalIDName:  "gw-ep",
+						ExternalIDName:  constants.GwEpExternalIDName,
 						ExternalIDValue: datapathManager.Info.NodeName,
 					},
 				},

--- a/cmd/everoute-controller/config.go
+++ b/cmd/everoute-controller/config.go
@@ -29,9 +29,10 @@ type controllerConfig struct {
 }
 
 type CNIConf struct {
-	EnableProxy bool   `yaml:"enableProxy,omitempty"`
-	EncapMode   string `yaml:"encapMode,omitempty"`
-	IPAM        string `yaml:"ipam,omitempty"`
+	EnableProxy     bool   `yaml:"enableProxy,omitempty"`
+	EncapMode       string `yaml:"encapMode,omitempty"`
+	IPAM            string `yaml:"ipam,omitempty"`
+	IPAMCleanPeriod int    `yaml:"ipamCleanPeriod,omitempty"`
 }
 
 func NewOptions() *Options {
@@ -66,6 +67,14 @@ func (o *Options) useEverouteIPAM() bool {
 	}
 
 	return o.Config.CNIConf.IPAM == constants.EverouteIPAM
+}
+
+func (o *Options) getIPAMCleanPeriod() int {
+	if !o.useEverouteIPAM() {
+		return 0
+	}
+
+	return o.Config.CNIConf.IPAMCleanPeriod
 }
 
 func (o *Options) complete() error {

--- a/deploy/chart/templates/config.yaml
+++ b/deploy/chart/templates/config.yaml
@@ -46,6 +46,7 @@ data:
       {{- end}}
       {{- if ne (.Values.CNIConf.ipam | default "") "" }}
       ipam: {{ .Values.CNIConf.ipam }}
+      ipamCleanPeriod: {{ .Values.CNIConf.ipamCleanPeriod | default 30 }}
       {{- end}}
 kind: ConfigMap
 metadata:

--- a/deploy/chart/templates/controller/role.yaml
+++ b/deploy/chart/templates/controller/role.yaml
@@ -120,3 +120,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - update
+  - get
+  - watch
+  - list

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -15,6 +15,7 @@ CNIConf:
   mtu: 0
   vni: 5000
   ipam: ""
+  ipamCleanPeriod: 30
   gwIPPool:
     gateway: 240.100.0.1
     subnet: 240.100.0.0/16

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -2361,6 +2361,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - update
+  - get
+  - watch
+  - list
 ---
 # Source: everoute/templates/agent/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.7
+	k8s.io/apiextensions-apiserver v0.27.7
 	k8s.io/apimachinery v0.27.7
 	k8s.io/apiserver v0.27.7
 	k8s.io/cli-runtime v0.27.3
@@ -110,7 +111,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.27.7 // indirect
 	k8s.io/component-base v0.27.7 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -71,7 +71,8 @@ const (
 	EncapModeGeneve = "geneve"
 	GeneveHeaderLen = 50
 
-	GwEndpointName = "gw-ep"
+	GwEpNamePrefix     = "gw-ep"
+	GwEpExternalIDName = "gw-ep"
 
 	EverouteIPAM = "everoute"
 

--- a/pkg/controller/ipam/endpoint.go
+++ b/pkg/controller/ipam/endpoint.go
@@ -1,0 +1,107 @@
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	"github.com/everoute/ipam/pkg/ipam"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
+)
+
+func NewEpPredicate(nodeMap *sync.Map) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			o, ok := e.Object.(*v1alpha1.Endpoint)
+			if !ok {
+				klog.Errorf("Failed to transfer deleted endpoint: %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+				return false
+			}
+			if o.Spec.Reference.ExternalIDName == constants.GwEpExternalIDName {
+				nodeMap.Store(types.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}, o.Spec.Reference.ExternalIDValue)
+			}
+			return false
+		},
+		UpdateFunc: func(event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			k := types.NamespacedName{
+				Namespace: e.Object.GetNamespace(),
+				Name:      e.Object.GetName(),
+			}
+			_, ok := nodeMap.Load(k)
+			return ok
+		},
+	}
+}
+
+type Reconciler struct {
+	client.Client
+	GWIPPoolNs   string
+	GWIPPoolName string
+
+	nodeMap *sync.Map
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.Infof("Receive endpoint reconcile %v for ipam", req.NamespacedName)
+	ep := v1alpha1.Endpoint{}
+	err := r.Client.Get(ctx, req.NamespacedName, &ep)
+	if err == nil {
+		klog.Infof("Endpoint %v is exists, return", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+	if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get endpoint %v: %v", req.NamespacedName, err)
+		return ctrl.Result{}, err
+	}
+
+	node, exists := r.nodeMap.LoadAndDelete(req.NamespacedName)
+	if !exists {
+		klog.Errorf("Can't find gw endpoint %v node, can't release it's ip", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+	nodeName := node.(string)
+	// release gateway ip
+	netConf := ipam.NetConf{
+		Type:             ipamv1alpha1.AllocateTypeCNIUsed,
+		AllocateIdentify: nodeName,
+		Pool:             r.GWIPPoolName,
+	}
+	if err := ipam.InitIpam(r.Client, r.GWIPPoolNs).ExecDel(ctx, &netConf); err != nil {
+		klog.Errorf("Failed to release gateway ip for node %s, err: %v", nodeName, err)
+		return ctrl.Result{}, err
+	}
+	klog.Infof("Success release gateway ip for node %s", nodeName)
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.GWIPPoolNs == "" || r.GWIPPoolName == "" {
+		return fmt.Errorf("can't setup ipam endpoint reconciler without gateway ippool namespace and name")
+	}
+	r.nodeMap = &sync.Map{}
+
+	c, err := controller.New("endpoint-controller", mgr, controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind(mgr.GetCache(), &v1alpha1.Endpoint{}), &handler.EnqueueRequestForObject{}, NewEpPredicate(r.nodeMap))
+}

--- a/pkg/controller/ipam/endpoint_test.go
+++ b/pkg/controller/ipam/endpoint_test.go
@@ -1,0 +1,140 @@
+package ipam
+
+import (
+	"context"
+	"time"
+
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
+)
+
+var _ = Describe("ipam controller", func() {
+	ctx := context.Background()
+	nodeName := "node10"
+	epName := "gw1"
+	ip := "13.13.13.7"
+	pool := ipamv1alpha1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNs,
+		},
+		Spec: ipamv1alpha1.IPPoolSpec{
+			Private: true,
+			CIDR:    "13.13.13.0/25",
+			Gateway: "13.13.13.1",
+			Subnet:  "13.13.13.0/24",
+		},
+	}
+	ep := v1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      epName,
+			Namespace: poolNs,
+		},
+		Spec: v1alpha1.EndpointSpec{
+			Reference: v1alpha1.EndpointReference{
+				ExternalIDName:  constants.GwEpExternalIDName,
+				ExternalIDValue: nodeName,
+			},
+		},
+	}
+	epReq := types.NamespacedName{
+		Namespace: poolNs,
+		Name:      epName,
+	}
+	pReq := types.NamespacedName{
+		Namespace: poolNs,
+		Name:      poolName,
+	}
+	BeforeEach(func() {
+		p := pool.DeepCopy()
+		Expect(k8sClient.Create(ctx, p)).Should(Succeed())
+		a := make(map[string]ipamv1alpha1.AllocateInfo)
+		a[ip] = ipamv1alpha1.AllocateInfo{
+			Type: ipamv1alpha1.AllocateTypeCNIUsed,
+			ID:   nodeName,
+		}
+		p.Status = ipamv1alpha1.IPPoolStatus{
+			AllocatedIPs: a,
+		}
+		Expect(k8sClient.Status().Update(ctx, p)).Should(Succeed())
+	})
+	AfterEach(func() {
+		p := ipamv1alpha1.IPPool{}
+		Expect(k8sClient.DeleteAllOf(ctx, &p, client.InNamespace(poolNs))).Should(Succeed())
+		e := v1alpha1.Endpoint{}
+		Expect(k8sClient.DeleteAllOf(ctx, &e, client.InNamespace(poolNs))).Should(Succeed())
+	})
+
+	Context("delete allocate ip gw endpoint", func() {
+		BeforeEach(func() {
+			ep1 := ep.DeepCopy()
+			Expect(k8sClient.Create(ctx, ep1)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				ep1 := v1alpha1.Endpoint{}
+				g.Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+		})
+		It("success release", func() {
+			ep1 := v1alpha1.Endpoint{}
+			Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &ep1)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				p := ipamv1alpha1.IPPool{}
+				g.Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+				g.Expect(p.Status.AllocatedIPs).ShouldNot(HaveKey(ip))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Context("delete other endpoint", func() {
+		BeforeEach(func() {
+			ep1 := ep.DeepCopy()
+			ep1.Spec.Reference.ExternalIDName = "test"
+			Expect(k8sClient.Create(ctx, ep1)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				ep1 := v1alpha1.Endpoint{}
+				g.Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+		})
+		It("doesn't release ip", func() {
+			ep1 := v1alpha1.Endpoint{}
+			Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &ep1)).Should(Succeed())
+
+			time.Sleep(timeout)
+			p := ipamv1alpha1.IPPool{}
+			Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+			Expect(p.Status.AllocatedIPs).Should(HaveKey(ip))
+		})
+	})
+
+	Context("delete unallocate ip gw endpoint", func() {
+		BeforeEach(func() {
+			ep1 := ep.DeepCopy()
+			ep1.Spec.Reference.ExternalIDValue = "test"
+			Expect(k8sClient.Create(ctx, ep1)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				ep1 := v1alpha1.Endpoint{}
+				g.Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+		})
+		It("doesn't release ip", func() {
+			ep1 := v1alpha1.Endpoint{}
+			Expect(k8sClient.Get(ctx, epReq, &ep1)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, &ep1)).Should(Succeed())
+
+			time.Sleep(timeout)
+			p := ipamv1alpha1.IPPool{}
+			Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+			Expect(p.Status.AllocatedIPs).Should(HaveKey(ip))
+		})
+	})
+})

--- a/pkg/controller/ipam/suit_test.go
+++ b/pkg/controller/ipam/suit_test.go
@@ -1,0 +1,105 @@
+package ipam
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	k8sClient          client.Client // You'll be using this client in your tests.
+	testEnv            *envtest.Environment
+	useExistingCluster bool
+)
+
+const (
+	RunTestWithExistingCluster = "TESTING_WITH_EXISTING_CLUSTER"
+	poolNs                     = "test-ipam-gw"
+	poolName                   = "pool"
+	timeout                    = time.Second * 10
+	interval                   = time.Second
+)
+
+func TestPolicyController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ipam controller suite")
+}
+
+var _ = BeforeSuite(func() {
+	if os.Getenv(RunTestWithExistingCluster) == "true" {
+		By("testing with existing cluster")
+		useExistingCluster = true
+	}
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		UseExistingCluster: &useExistingCluster,
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths:           []string{filepath.Join("..", "..", "..", "deploy", "chart", "templates", "crds")},
+			CleanUpAfterUse: true,
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = securityv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ipamv1alpha1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		// disable metrics serving
+		MetricsBindAddress: "0",
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sManager).ToNot(BeNil())
+
+	err = (&Reconciler{
+		Client:       k8sManager.GetClient(),
+		GWIPPoolNs:   poolNs,
+		GWIPPoolName: poolName,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	ctx := ctrl.SetupSignalHandler()
+	go func() {
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: poolNs,
+		},
+	}
+	Expect(k8sClient.Create(ctx, &ns)).ToNot(HaveOccurred())
+	k8sManager.GetCache().WaitForCacheSync(ctx)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/ipam/everoute_ipam.go
+++ b/pkg/ipam/everoute_ipam.go
@@ -6,7 +6,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	cnitypes "github.com/containernetworking/cni/pkg/types/100"
 	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
-	ipam "github.com/everoute/ipam/pkg/ipam"
+	"github.com/everoute/ipam/pkg/ipam"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/ipam/release_gw_ip.go
+++ b/pkg/ipam/release_gw_ip.go
@@ -1,0 +1,113 @@
+package ipam
+
+import (
+	"context"
+
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	"github.com/everoute/ipam/pkg/cron"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/utils"
+)
+
+var _ cron.ProcessFun = (&CleanGwStaleIP{}).Process
+
+type CleanGwStaleIP struct {
+	PoolNs   string
+	PoolName string
+	GwEpNs   string
+}
+
+func NewCleanStaleIP(poolNs, poolName, gwEpNs string) *CleanGwStaleIP {
+	return &CleanGwStaleIP{
+		PoolNs:   poolNs,
+		PoolName: poolName,
+		GwEpNs:   gwEpNs,
+	}
+}
+
+func (c *CleanGwStaleIP) Process(ctx context.Context, k8sClient client.Client, k8sReader client.Reader) {
+	req := types.NamespacedName{
+		Namespace: c.PoolNs,
+		Name:      c.PoolName,
+	}
+	pool := ipamv1alpha1.IPPool{}
+	if err := k8sClient.Get(ctx, req, &pool); err != nil {
+		klog.Errorf("Failed to get ippool %v, err: %v", req, err)
+		return
+	}
+	if len(pool.Status.AllocatedIPs) == 0 {
+		return
+	}
+
+	delIPs := []string{}
+	for ip, a := range pool.Status.AllocatedIPs {
+		if a.Type != ipamv1alpha1.AllocateTypeCNIUsed {
+			continue
+		}
+		if c.needReleaseForGw(ctx, k8sClient, k8sReader, a.ID) {
+			klog.Infof("Try to release gateway ip %s for node %s", ip, a.ID)
+			delIPs = append(delIPs, ip)
+		}
+	}
+	if len(delIPs) == 0 {
+		return
+	}
+
+	for _, ip := range delIPs {
+		delete(pool.Status.AllocatedIPs, ip)
+	}
+	if err := k8sClient.Status().Update(ctx, &pool); err != nil {
+		klog.Errorf("Release gateway ips %v failed: %v", delIPs, err)
+		return
+	}
+	klog.Infof("Success to release gateway ips %v", delIPs)
+}
+
+func (c *CleanGwStaleIP) needReleaseForGw(ctx context.Context, k8sClient client.Client, k8sReader client.Reader, nodeName string) bool {
+	epReq := types.NamespacedName{
+		Namespace: c.GwEpNs,
+		Name:      utils.GetGwEndpointName(nodeName),
+	}
+	ep := v1alpha1.Endpoint{}
+	err := k8sClient.Get(ctx, epReq, &ep)
+	if err == nil {
+		return false
+	}
+	if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get endpoint %v, err: %v", epReq, err)
+		return false
+	}
+
+	// is endpoint doesn't exist without cache
+	ep = v1alpha1.Endpoint{}
+	err = k8sReader.Get(ctx, epReq, &ep)
+	if err == nil {
+		return false
+	}
+	if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get endpoint %v, err: %v", epReq, err)
+		return false
+	}
+
+	// perhaps endpoint wasn't create when the agent start just now
+	nodeReq := types.NamespacedName{
+		Name: nodeName,
+	}
+	node := corev1.Node{}
+	err = k8sReader.Get(ctx, nodeReq, &node)
+	if err == nil {
+		return false
+	}
+	if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get node %v, err: %v", nodeReq, err)
+		return false
+	}
+
+	return true
+}

--- a/pkg/ipam/release_gw_ip_test.go
+++ b/pkg/ipam/release_gw_ip_test.go
@@ -1,0 +1,125 @@
+package ipam
+
+import (
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/utils"
+)
+
+var _ = Describe("release stale gw ip", func() {
+	nodeName := "node10"
+	ip1 := "13.13.13.7"
+	ip2 := "13.13.13.5"
+	pool := ipamv1alpha1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: ns,
+		},
+		Spec: ipamv1alpha1.IPPoolSpec{
+			Private: true,
+			CIDR:    "13.13.13.0/25",
+			Gateway: "13.13.13.1",
+			Subnet:  "13.13.13.0/24",
+		},
+	}
+	ep := v1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.GetGwEndpointName(nodeName),
+			Namespace: ns,
+		},
+	}
+	pReq := types.NamespacedName{
+		Namespace: ns,
+		Name:      poolName,
+	}
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+	BeforeEach(func() {
+		p := pool.DeepCopy()
+		Expect(k8sClient.Create(ctx, p)).Should(Succeed())
+	})
+	AfterEach(func() {
+		p := ipamv1alpha1.IPPool{}
+		Expect(k8sClient.DeleteAllOf(ctx, &p, client.InNamespace(ns))).Should(Succeed())
+		ep := v1alpha1.Endpoint{}
+		Expect(k8sClient.DeleteAllOf(ctx, &ep, client.InNamespace(ns))).Should(Succeed())
+		node := corev1.Node{}
+		Expect(k8sClient.DeleteAllOf(ctx, &node)).Should(Succeed())
+	})
+
+	Context("ippool hasn't allocate ip", func() {
+		When("gateway endpoint and node all doesn't exists", func() {
+			It("ippool status doesn't changed", func() {
+				c.Process(ctx, k8sClient, k8sClient)
+				p := ipamv1alpha1.IPPool{}
+				Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+				Expect(len(p.Status.AllocatedIPs)).Should(Equal(0))
+			})
+		})
+	})
+
+	Context("ippool has allocate cnitype ip", func() {
+		BeforeEach(func() {
+			p := ipamv1alpha1.IPPool{}
+			Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+			a := make(map[string]ipamv1alpha1.AllocateInfo)
+			a[ip1] = ipamv1alpha1.AllocateInfo{
+				Type: ipamv1alpha1.AllocateTypeCNIUsed,
+				ID:   nodeName,
+			}
+			a[ip2] = ipamv1alpha1.AllocateInfo{
+				Type: ipamv1alpha1.AllocateTypePod,
+				ID:   "ns1/pod1",
+				CID:  "cid",
+			}
+			p.Status.AllocatedIPs = a
+			Expect(k8sClient.Status().Update(ctx, &p)).Should(Succeed())
+		})
+		When("gateway endpoint and node all doesn't exists", func() {
+
+			It("release stale gateway ip", func() {
+				c.Process(ctx, k8sClient, k8sClient)
+				p := ipamv1alpha1.IPPool{}
+				Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+				Expect(p.Status.AllocatedIPs).NotTo(HaveKey(ip1))
+				Expect(p.Status.AllocatedIPs).To(HaveKey(ip2))
+			})
+		})
+		When("endpoint exists", func() {
+			BeforeEach(func() {
+				e := ep.DeepCopy()
+				Expect(k8sClient.Create(ctx, e)).Should(Succeed())
+			})
+			It("doesn't release gateway ip", func() {
+				c.Process(ctx, k8sClient, k8sClient)
+				p := ipamv1alpha1.IPPool{}
+				Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+				Expect(p.Status.AllocatedIPs).To(HaveKey(ip1))
+				Expect(p.Status.AllocatedIPs).To(HaveKey(ip2))
+			})
+		})
+		When("only node exists", func() {
+			BeforeEach(func() {
+				n := node.DeepCopy()
+				Expect(k8sClient.Create(ctx, n)).Should(Succeed())
+			})
+			It("doesn't release gateway ip", func() {
+				c.Process(ctx, k8sClient, k8sClient)
+				p := ipamv1alpha1.IPPool{}
+				Expect(k8sClient.Get(ctx, pReq, &p)).Should(Succeed())
+				Expect(p.Status.AllocatedIPs).To(HaveKey(ip1))
+				Expect(p.Status.AllocatedIPs).To(HaveKey(ip2))
+			})
+		})
+	})
+})

--- a/pkg/ipam/suit_test.go
+++ b/pkg/ipam/suit_test.go
@@ -1,0 +1,76 @@
+package ipam
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ipamv1alpha1 "github.com/everoute/ipam/api/ipam/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+)
+
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ns        = "rel-test"
+	ctx       = context.Background()
+	interval  = 1 * time.Second
+	timeout   = 10 * time.Second
+	c         *CleanGwStaleIP
+	poolName  = "pool1"
+)
+
+var _ = BeforeSuite(func() {
+	By("setup test environment")
+	notExistCluster := false
+	testEnv = &envtest.Environment{
+		UseExistingCluster: &notExistCluster,
+		//BinaryAssetsDirectory: "/usr/local/bin",
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths:              []string{filepath.Join("..", "..", "deploy", "chart", "templates", "crds")},
+			CleanUpAfterUse:    true,
+			ErrorIfPathMissing: true,
+		},
+	}
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	By("get k8sClient")
+	scheme := scheme.Scheme
+	Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme)).Should(Succeed())
+	Expect(ipamv1alpha1.AddToScheme(scheme)).Should(Succeed())
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	By("create namespace")
+	nsObj := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+	Expect(k8sClient.Create(ctx, &nsObj)).Should(Succeed())
+
+	By("init CleanStaleIP")
+	c = NewCleanStaleIP(ns, poolName, ns)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Expect(testEnv.Stop()).Should(Succeed())
+})
+
+func TestCron(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "release gw ip suite")
+}

--- a/pkg/utils/cni.go
+++ b/pkg/utils/cni.go
@@ -15,7 +15,7 @@ type CNIArgs struct {
 }
 
 func GetGwEndpointName(nodeName string) string {
-	return constants.GwEndpointName + "-" + nodeName
+	return constants.GwEpNamePrefix + "-" + nodeName
 }
 
 func GetNodeInternalIP(node *corev1.Node) string {


### PR DESCRIPTION
功能：
- watch gateway endpoint 删除事件，release 对应节点的gateway IP
- 周期任务判断已分配的cniused 类型的IP对应的endpoint和node是否存在，如果gateway endpoint和node都不存在，则release IP 

自测：
- 周期任务会删除IPPool status中endpoint和node都不存在的cniused类型的IP分配信息
- k8s集群扩容，增加1个节点，正常为新节点的gateway 分配IP
- k8s集群缩容，删除1个节点，正常回收被删除节点的gateway ip