### PR TITLE
test(monitor): start and wait informer before monitor

### DIFF
--- a/pkg/monitor/suite_test.go
+++ b/pkg/monitor/suite_test.go
@@ -109,12 +109,14 @@ func TestMain(m *testing.M) {
 	})
 
 	agentName = monitor.Name()
-	go ovsdbMonitor.Run(stopChan)
-	go monitor.Run(stopChan)
 
 	// fix: create event lost when reflector list and watch with fake client
 	// the agent monitor loops infinitely to create agentinfo when agentinfo not in informer cache
+	go monitor.agentInformer.Run(stopChan)
 	cache.WaitForCacheSync(stopChan, monitor.agentInformer.HasSynced)
+
+	go ovsdbMonitor.Run(stopChan)
+	go monitor.Run(stopChan)
 
 	exitCode := m.Run()
 	os.Exit(exitCode)


### PR DESCRIPTION
monitor 使用 k8s fake client 进行测试，fake client 实现有漏洞，informer 使用 fake client 在 list 和 watch 之间可能会丢事件。
如果 agentinfo create 事件丢失，monitor 则无法正常运行，一直尝试创建 agentinfo。但会因为 agentinfo 已存在失败。

此 PR 调整 monitor test 中 informer 的启动顺序，先启动 informer，然后启动 monitor。防止产生上述问题。