### PR TITLE
ci: cooperate with sks1.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,7 @@ jobs:
         run: |
           cat deploy/everoute.yaml
           kubectl apply -f deploy/chart/templates/crds/ipam.everoute.io_ippools.yaml
+          kubectl apply -f hack/ippool_ci.yaml
           kubectl apply -f deploy/everoute.yaml
 
       - name: wait k8s cluster ready
@@ -179,11 +180,6 @@ jobs:
           kubectl wait --for=condition=Ready nodes --all --timeout=10m
           kubectl --kubeconfig /home/runner/sksconfig/sksconfig get ksc ${{ env.CLUSTER_NAME }}
           kubectl get nodes -owide
-
-      - name: create ippool
-        if: matrix.ipam == 'everoute'
-        run: |
-          kubectl apply -f hack/ippool_ci.yaml
 
       - name: run ServiceProxy cases
         if: matrix.enable-proxy == true

--- a/hack/ippool_ci.yaml
+++ b/hack/ippool_ci.yaml
@@ -1,13 +1,13 @@
-apiVersion: ipam.everoute.io/v1alpha1
-kind: IPPool
-metadata:
-  name: ippool-ci0
-  namespace: kube-system
-spec:
-  cidr: 16.16.0.0/29
-  subnet: 16.16.0.0/24
-  gateway: 16.16.0.1
----
+# apiVersion: ipam.everoute.io/v1alpha1
+# kind: IPPool
+# metadata:
+#   name: ippool-ci0
+#   namespace: kube-system
+# spec:
+#   cidr: 16.16.0.0/29
+#   subnet: 16.16.0.0/24
+#   gateway: 16.16.0.1
+# ---
 apiVersion: ipam.everoute.io/v1alpha1
 kind: IPPool
 metadata:

--- a/hack/kubesmartcluster.yaml.tmpl
+++ b/hack/kubesmartcluster.yaml.tmpl
@@ -158,6 +158,8 @@ spec:
     host: {{k8s-e2e-cluster-vip}}
     port: 6443
   network:
+    cni:
+      name: stub-cni
     managementNetworkInterface: ens4
     pods:
       cidrBlocks:

--- a/hack/kubesmartcluster_idc.yaml.tmpl
+++ b/hack/kubesmartcluster_idc.yaml.tmpl
@@ -158,6 +158,8 @@ spec:
     host: {{k8s-e2e-cluster-vip}}
     port: 6443
   network:
+    cni:
+      name: stub-cni
     managementNetworkInterface: ens4
     pods:
       cidrBlocks:


### PR DESCRIPTION
1. sks 1.2需要通过 stub-cni类型表示不安装cni插件 (ci环境sks已升级至1.2)
2. 使用everoute ipam 在某个ip池剩下极少数IP的情况下，若多个Pod创建请求IP，会导致Pod需要重试多次才能创建成功 [ipam issue](https://github.com/everoute/ipam/issues/33)。这会导致ci有概率失败，所以ci中暂时只使用1个IP池