### PR TITLE
add kube-proxy replace config and init iptables route

### DIFF
--- a/build/images/release/Dockerfile
+++ b/build/images/release/Dockerfile
@@ -30,7 +30,7 @@ ARG TARGETARCH
 RUN echo "platform $TARGETOS $TARGETARCH"
 
 RUN apt update && apt install -y openvswitch-switch=2.17.* iptables \
-    iproute2 tcpdump wget && rm -rf /var/lib/apt/lists/*
+    iproute2 tcpdump wget ipset && rm -rf /var/lib/apt/lists/*
 
 #RUN install yq
 RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_${TARGETOS}_${TARGETARCH} && chmod a+x /usr/local/bin/yq

--- a/build/script/init_agent
+++ b/build/script/init_agent
@@ -66,6 +66,7 @@ AGENT_CONFIG_PATH=/var/lib/everoute/agentconfig.yaml
 
 DEFAULT_BRIDGE=`cat ${AGENT_CONFIG_PATH} | grep datapathConfig: -A1 | grep -v datapathConfig: | awk -F ':' '{print $1}' | awk '$1=$1'`
 ENABLE_PROXY=`yq '.CNIConf.enableProxy'  ${AGENT_CONFIG_PATH}`
+KUBE_PROXY_REPLACE=`yq '.CNIConf.kubeProxyReplace'  ${AGENT_CONFIG_PATH}`
 ENCAP_MODE=`yq '.CNIConf.encapMode'  ${AGENT_CONFIG_PATH}`
 VNI=`yq '.CNIConf.vni' ${AGENT_CONFIG_PATH}`
 GW_IFACE=${DEFAULT_BRIDGE}-gw
@@ -83,6 +84,8 @@ CLS_TO_UPLINK_PATCH="${CLS_BRIDGE}-cls-to-uplink"
 UPLINK_TO_CLS_PATCH="${UPLINK_BRIDGE}-uplink-to-cls"
 LOCAL_TO_NAT_PATCH="${DEFAULT_BRIDGE}-local-to-nat"
 NAT_TO_LOCAL_PATCH="${NAT_BRIDGE}-nat-to-local"
+NAT_TO_UPLINK_PATCH="${NAT_BRIDGE}-nat-to-uplink"
+UPLINK_TO_NAT_PATCH="${UPLINK_BRIDGE}-uplink-to-nat"
 TUNNEL_IFACE="${DEFAULT_BRIDGE}-tunnel"
 
 ovs-vsctl add-br ${DEFAULT_BRIDGE} -- set bridge ${DEFAULT_BRIDGE} protocols=OpenFlow10,OpenFlow11,OpenFlow12,OpenFlow13 fail_mode=secure
@@ -129,6 +132,20 @@ if [ "${ENABLE_PROXY}" == "true" ];then
     # check
     ip link show ${NAT_BRIDGE} || error_handle
     [[ `cat /proc/sys/net/ipv4/conf/${NAT_BRIDGE}/rp_filter` -ne 1 ]] && error_handle
+
+    if [ "${KUBE_PROXY_REPLACE}" == "true" ];then
+        echo "create port for kube proxy replace"
+        ovs-vsctl \
+            -- add-port ${UPLINK_BRIDGE} ${UPLINK_TO_NAT_PATCH} \
+            -- set interface ${UPLINK_TO_NAT_PATCH} type=patch options:peer=${NAT_TO_UPLINK_PATCH}
+        ovs-vsctl \
+            -- add-port ${NAT_BRIDGE} ${NAT_TO_UPLINK_PATCH} \
+            -- set interface ${NAT_TO_UPLINK_PATCH} type=patch options:peer=${UPLINK_TO_NAT_PATCH}
+
+        echo 1 > /proc/sys/net/ipv4/conf/${GW_IFACE}/accept_local
+        # check
+        [[ `cat /proc/sys/net/ipv4/conf/${GW_IFACE}/accept_local` -ne 1 ]] && error_handle
+    fi
 else
     # add port gw-local
     ovs-vsctl add-port ${DEFAULT_BRIDGE} ${GW_LOCAL_IFACE} -- set Interface ${GW_LOCAL_IFACE} type=internal

--- a/cmd/everoute-controller/main.go
+++ b/cmd/everoute-controller/main.go
@@ -94,6 +94,9 @@ func main() {
 
 	config := ctrl.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(constants.ControllerRuntimeQPS, constants.ControllerRuntimeBurst)
+	if opts.getAPIServer() != "" {
+		config.Host = opts.getAPIServer()
+	}
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                  clientsetscheme.Scheme,
 		MetricsBindAddress:      opts.metricsAddr,

--- a/deploy/chart/templates/config.yaml
+++ b/deploy/chart/templates/config.yaml
@@ -33,6 +33,21 @@ data:
       {{- else}}
       # ipam: everoute
       {{- end}}
+
+      # enable kube-proxy replace, if enable kubeProxyReplace, must set svcInternalIP and apiServer
+      kubeProxyReplace: {{ .Values.CNIConf.kubeProxyReplace | default false }}
+      {{- if ne (.Values.CNIConf.svcInternalIP | default "") "" }}
+      svcInternalIP: {{ .Values.CNIConf.svcInternalIP }}
+      {{- else}}
+      # svcInternalIP: 169.254.0.254
+      {{- end}}
+
+    # when set apiServer, use it to connect kube-apiserver. It must be a valid url. And if enable cni kubeProxyReplace, must set apiServer
+    {{- if ne (.Values.apiServer | default "") "" }}
+    apiServer: {{ .Values.apiServer }}
+    {{- else}}
+    # apiServer: "https://192.168.7.1:6443"
+    {{- end}}
   cni-conf.conflist: |
     {
         "cniVersion": "0.3.0",
@@ -68,6 +83,13 @@ data:
       # ipam: everoute
       # ipamCleanPeriod: 30
       {{- end}}
+
+    # when set apiServer, use it to connect kube-apiserver. It must be a valid url. And if enable cni kubeProxyReplace, must set apiServer
+    {{- if ne (.Values.apiServer | default "") "" }}
+    apiServer: {{ .Values.apiServer }}
+    {{- else}}
+    # apiServer: "https://192.168.7.1:6443"
+    {{- end}}
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -20,6 +20,10 @@ CNIConf:
     gateway: 240.100.0.1
     subnet: 240.100.0.0/16
     cidr: 240.100.0.0/24
+  kubeProxyReplace: false
+  svcInternalIP: 169.254.0.254
+
+apiServer: ""
 
 webhook:
   type: Service # enum: Service, URL

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -36,6 +36,13 @@ data:
 
       # use everoute ipam
       # ipam: everoute
+
+      # enable kube-proxy replace, if enable kubeProxyReplace, must set svcInternalIP and apiServer
+      kubeProxyReplace: false
+      svcInternalIP: 169.254.0.254
+
+    # when set apiServer, use it to connect kube-apiserver. It must be a valid url. And if enable cni kubeProxyReplace, must set apiServer
+    # apiServer: "https://192.168.7.1:6443"
   cni-conf.conflist: |
     {
         "cniVersion": "0.3.0",
@@ -62,6 +69,9 @@ data:
       # use everoute ipam, and when use everoute ipam, must set ipamCleanPeriod, unit is second
       # ipam: everoute
       # ipamCleanPeriod: 30
+
+    # when set apiServer, use it to connect kube-apiserver. It must be a valid url. And if enable cni kubeProxyReplace, must set apiServer
+    # apiServer: "https://192.168.7.1:6443"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-ping/ping v0.0.0-20210506233800-ff8be3320020
 	github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9
 	github.com/goftp/server v0.0.0-20200708154336-f64f7c2d8a42
+	github.com/gonetx/ipset v0.1.0
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/gonetx/ipset v0.1.0 h1:LFkRdTbedg2UYXFN/2mOtgbvdWyo+OERrwVbtrPVuYY=
+github.com/gonetx/ipset v0.1.0/go.mod h1:AwNAf1Vtqg0cJ4bha4w1ROX5cO/8T50UYoegxM20AH8=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=

--- a/pkg/agent/datapath/localBridgeOverlay.go
+++ b/pkg/agent/datapath/localBridgeOverlay.go
@@ -262,7 +262,7 @@ func (l *LocalBridgeOverlay) DelIPPoolGW(gw string) error {
 	return nil
 }
 
-//nolint
+//nolint:all
 func (l *LocalBridgeOverlay) initInputTable() error {
 	sw := l.OfSwitch
 
@@ -298,7 +298,6 @@ func (l *LocalBridgeOverlay) initInputTable() error {
 	return nil
 }
 
-//nolint
 func (l *LocalBridgeOverlay) initArpProxytable() error {
 	sw := l.OfSwitch
 	inportOutput, _ := sw.OutputPort(openflow.P_IN_PORT)
@@ -400,8 +399,8 @@ func (l *LocalBridgeOverlay) initInPortTable() error {
 
 func (l *LocalBridgeOverlay) initFromNatTable() error {
 	toPolicyFlow, _ := l.fromNatTable.NewFlow(ofctrl.FlowMatch{
-		PktMark:     SvcPktMark,
-		PktMarkMask: &SvcPktMarkMask,
+		PktMark:     InternalSvcPktMark,
+		PktMarkMask: &InternalSvcPktMarkMask,
 		Priority:    HIGH_MATCH_FLOW_PRIORITY,
 	})
 	if err := toPolicyFlow.LoadField(LBOOutputPortReg, uint64(l.datapathManager.BridgeChainPortMap[l.name][LocalToPolicySuffix]), LBOOutputPortRange); err != nil {
@@ -428,8 +427,8 @@ func (l *LocalBridgeOverlay) initFromNatTable() error {
 
 func (l *LocalBridgeOverlay) initFromPolicyTable() error {
 	toLocalFlow, _ := l.fromPolicyTable.NewFlow(ofctrl.FlowMatch{
-		PktMark:     SvcPktMark,
-		PktMarkMask: &SvcPktMarkMask,
+		PktMark:     InternalSvcPktMark,
+		PktMarkMask: &InternalSvcPktMarkMask,
 		Priority:    HIGH_MATCH_FLOW_PRIORITY,
 	})
 	if err := toLocalFlow.Resubmit(nil, &LBOForwardToLocalTable); err != nil {
@@ -462,7 +461,7 @@ func (l *LocalBridgeOverlay) initFromLocalTable() error {
 		IpDaMask:  (*net.IP)(&l.datapathManager.Info.ClusterCIDR.Mask),
 		Priority:  HIGH_MATCH_FLOW_PRIORITY,
 	})
-	if err := svcFlow.LoadField("nxm_nx_pkt_mark", SvcPktMarkValue, SvcPktMarkRange); err != nil {
+	if err := svcFlow.LoadField("nxm_nx_pkt_mark", constants.PktMarkSetValue, InternalSvcPktMarkRange); err != nil {
 		return fmt.Errorf("failed to setup from local table svc flow set svc mark action, err: %v", err)
 	}
 	if err := svcFlow.LoadField(LBOOutputPortReg, uint64(l.natPort), LBOOutputPortRange); err != nil {

--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -50,7 +50,7 @@ import (
 	"github.com/everoute/everoute/pkg/utils"
 )
 
-//nolint
+//nolint:all
 const (
 	HIGH_MATCH_FLOW_PRIORITY            = 300
 	MID_MATCH_FLOW_PRIORITY             = 200
@@ -61,7 +61,7 @@ const (
 	FLOW_MATCH_OFFSET                   = 3
 )
 
-//nolint
+//nolint:all
 const (
 	POLICY_TIER1    = 50
 	POLICY_TIER2    = 100
@@ -69,19 +69,19 @@ const (
 	POLICY_TIER3    = 150
 )
 
-//nolint
+//nolint:all
 const (
 	POLICY_DIRECTION_OUT = 0
 	POLICY_DIRECTION_IN  = 1
 )
 
-//nolint
+//nolint:all
 const (
 	IP_BROADCAST_ADDR = "255.255.255.255"
 	LOOP_BACK_ADDR    = "127.0.0.1"
 )
 
-//nolint
+//nolint:all
 const (
 	FLOW_ROUND_NUM_LENGTH           = 4
 	FLOW_SEQ_NUM_LENGTH             = 28
@@ -90,7 +90,7 @@ const (
 	DEFAULT_POLICY_ENFORCEMENT_MODE = "work"
 )
 
-//nolint
+//nolint:all
 const (
 	PROTOCOL_ARP  = 0x0806
 	PROTOCOL_IP   = 0x0800
@@ -99,7 +99,7 @@ const (
 	PROTOCOL_ICMP = 0x01
 )
 
-//nolint
+//nolint:all
 const (
 	LOCAL_BRIDGE_KEYWORD  = "local"
 	POLICY_BRIDGE_KEYWORD = "policy"
@@ -273,10 +273,12 @@ type DpManagerConfig struct {
 }
 
 type DpManagerCNIConfig struct {
-	EnableProxy bool // enable proxy
-	EncapMode   string
-	MTU         int // pod mtu
-	IPAMType    string
+	EnableProxy      bool // enable proxy
+	EncapMode        string
+	MTU              int // pod mtu
+	IPAMType         string
+	KubeProxyReplace bool
+	SvcInternalIP    net.IP // kube-proxy replace need it
 }
 
 type Endpoint struct {
@@ -572,7 +574,7 @@ func NewVDSForConfigProxy(datapathManager *DpManager, vdsID, ovsbrname string) {
 	go natControl.Connect(fmt.Sprintf("%s/%s.%s", ovsVswitchdUnixDomainSockPath, natBr.GetName(), ovsVswitchdUnixDomainSockSuffix))
 }
 
-//nolint
+//nolint:all
 func NewVDSForConfigBase(datapathManager *DpManager, vdsID, ovsbrname string) {
 	// initialize vds bridge chain
 	localBridge := NewLocalBridge(ovsbrname, datapathManager)
@@ -1360,6 +1362,14 @@ func (datapathManager *DpManager) IsEnableProxy() bool {
 	}
 
 	return datapathManager.Config.CNIConfig.EnableProxy
+}
+
+func (datapathManager *DpManager) IsEnableKubeProxyReplace() bool {
+	if !datapathManager.IsEnableProxy() {
+		return false
+	}
+
+	return datapathManager.Config.CNIConfig.KubeProxyReplace
 }
 
 func (datapathManager *DpManager) IsEnableOverlay() bool {

--- a/pkg/agent/proxy/iptables/base.go
+++ b/pkg/agent/proxy/iptables/base.go
@@ -8,8 +8,10 @@ import (
 )
 
 type Options struct {
-	LocalGwName    string
-	ClusterPodCIDR string
+	LocalGwName      string
+	ClusterPodCIDR   string
+	KubeProxyReplace bool
+	SvcInternalIP    string
 }
 
 type baseIPtables struct{}

--- a/pkg/agent/proxy/iptables/overlay_mode.go
+++ b/pkg/agent/proxy/iptables/overlay_mode.go
@@ -36,7 +36,10 @@ func NewOverlayIPtables(enableEverouteProxy bool, opt *Options) OverlayIPtables 
 	}
 
 	if enableEverouteProxy {
-		o.proxy = &everouteProxy{}
+		o.proxy = &everouteProxy{
+			kubeProxyReplace: opt.KubeProxyReplace,
+			svcInternalIP:    opt.SvcInternalIP,
+		}
 	} else {
 		if opt.LocalGwName == "" {
 			klog.Fatal("New overlay mode iptables controller with kube-proxy failed, missing param local gw nic name")

--- a/pkg/agent/proxy/iptables/proxy_iptables.go
+++ b/pkg/agent/proxy/iptables/proxy_iptables.go
@@ -1,10 +1,13 @@
 package iptables
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 	"k8s.io/klog"
+
+	"github.com/everoute/everoute/pkg/constants"
 )
 
 type proxyIPtables interface {
@@ -23,7 +26,7 @@ func (k *kubeProxy) everouteOutput(ipt *iptables.IPTables) []string {
 	ruleSpec := []string{"-o", k.localGwName, "-j", "ACCEPT"}
 	expectRule := strings.Join(ruleSpec, " ")
 	if err = ipt.InsertUnique("nat", "EVEROUTE-OUTPUT", 1, ruleSpec...); err != nil {
-		klog.Errorf("Append %s into nat EVEROUTE-OUTPUT error, err: %s", k.localGwName, err)
+		klog.Errorf("Insert %s into nat EVEROUTE-OUTPUT error, err: %s", k.localGwName, err)
 	}
 	return []string{expectRule}
 }
@@ -45,13 +48,101 @@ func (k *kubeProxy) prerouting(ipt *iptables.IPTables) {
 	}
 }
 
-type everouteProxy struct{}
+type everouteProxy struct {
+	kubeProxyReplace bool
+	svcInternalIP    string
+}
 
-func (*everouteProxy) everouteOutput(*iptables.IPTables) []string { return []string{} }
+func (e *everouteProxy) everouteOutput(ipt *iptables.IPTables) []string {
+	if !e.kubeProxyReplace {
+		return nil
+	}
+	if e.svcInternalIP == "" {
+		klog.Error("Doesn't set svcInternalIP when enable kubeProxyReplace")
+		return nil
+	}
+
+	ruleSpec := []string{"-s", e.svcInternalIP + "/32", "-j", "MASQUERADE"}
+	expectRule := strings.Join(ruleSpec, " ")
+	if err := ipt.InsertUnique("nat", "EVEROUTE-OUTPUT", 1, ruleSpec...); err != nil {
+		klog.Errorf("Insert svcInternalIP %s into nat EVEROUTE-OUTPUT error, err: %s", e.svcInternalIP, err)
+	}
+	return []string{expectRule}
+}
 
 func (*everouteProxy) forward(*iptables.IPTables) {}
 
-func (*everouteProxy) prerouting(*iptables.IPTables) {}
+func (e *everouteProxy) prerouting(ipt *iptables.IPTables) {
+	if !e.kubeProxyReplace {
+		return
+	}
+
+	var err error
+	if err = e.createEverouteSvcChain(ipt); err != nil {
+		return
+	}
+	e.addEverouteSvcToPrerouting(ipt)
+
+	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcTCP)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with tcp, err: %s", constants.SvcChain, err)
+	}
+	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcUDP)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with udp, err: %s", constants.SvcChain, err)
+	}
+	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameLBSvc)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for loadbalancer svc, err: %s", constants.SvcChain, err)
+	}
+}
+
+func (*everouteProxy) createEverouteSvcChain(ipt *iptables.IPTables) error {
+	var err error
+	var exist bool
+	// check existence of chain EVEROUTE-SVC, if not, then create it
+	if exist, err = ipt.ChainExists("mangle", constants.SvcChain); err != nil {
+		klog.Errorf("Get iptables %s error, error: %s", constants.SvcChain, err)
+		return err
+	}
+	if !exist {
+		err = ipt.NewChain("mangle", constants.SvcChain)
+		if err != nil {
+			klog.Errorf("Create iptables %s error, error: %s", constants.SvcChain, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (*everouteProxy) addEverouteSvcToPrerouting(ipt *iptables.IPTables) {
+	if err := ipt.InsertUnique("mangle", "PREROUTING", 1, "-j", constants.SvcChain); err != nil {
+		klog.Errorf("insert %s into nat PREROUTING error, err: %s", constants.SvcChain, err)
+	}
+}
 
 var _ proxyIPtables = &kubeProxy{localGwName: ""}
-var _ proxyIPtables = &everouteProxy{}
+var _ proxyIPtables = &everouteProxy{kubeProxyReplace: false, svcInternalIP: ""}
+
+func getRuleSpecByIPSet(set string) []string {
+	rule := []string{}
+
+	// protocol
+	if set == constants.IPSetNameNPSvcTCP {
+		rule = append(rule, "-p", "tcp")
+	}
+	if set == constants.IPSetNameNPSvcUDP {
+		rule = append(rule, "-p", "udp")
+	}
+
+	// match set
+	rule = append(rule, "-m", "set", "--match-set", set)
+	if set == constants.IPSetNameLBSvc {
+		rule = append(rule, "dst,dst")
+	} else {
+		rule = append(rule, "dst")
+	}
+
+	// mark
+	svcPktMarkString := fmt.Sprintf("%#x/%#x", 1<<constants.ExternalSvcPktMarkBit, 1<<constants.ExternalSvcPktMarkBit)
+	rule = append(rule, "-j", "MARK", "--set-xmark", svcPktMarkString)
+
+	return rule
+}

--- a/pkg/agent/proxy/iptables/proxy_iptables_test.go
+++ b/pkg/agent/proxy/iptables/proxy_iptables_test.go
@@ -1,0 +1,39 @@
+package iptables
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/everoute/everoute/pkg/constants"
+)
+
+func TestGetRuleSpecByIPSet(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		exp  string
+	}{
+		{
+			name: "nodeport svc tcp",
+			arg:  constants.IPSetNameNPSvcTCP,
+			exp:  "-p tcp -m set --match-set er-npsvc-tcp dst -j MARK --set-xmark 0x10000000/0x10000000",
+		},
+		{
+			name: "nodeport svc udp",
+			arg:  constants.IPSetNameNPSvcUDP,
+			exp:  "-p udp -m set --match-set er-npsvc-udp dst -j MARK --set-xmark 0x10000000/0x10000000",
+		},
+		{
+			name: "lb svc",
+			arg:  constants.IPSetNameLBSvc,
+			exp:  "-m set --match-set er-lbsvc dst,dst -j MARK --set-xmark 0x10000000/0x10000000",
+		},
+	}
+
+	for _, c := range tests{
+		res := getRuleSpecByIPSet(c.arg)
+		if strings.Join(res, " ") != c.exp {
+			t.Errorf("test %s failed, res is %s, exp is %s", c.name, strings.Join(res, " ") , c.exp)
+		}
+	}
+}

--- a/pkg/agent/proxy/route.go
+++ b/pkg/agent/proxy/route.go
@@ -378,9 +378,11 @@ func SetupRouteAndIPtables(ctx context.Context, datapathManager *datapath.DpMana
 		clusterPodCIDRString = ""
 		gatewayIP = *datapathManager.Info.ClusterPodGw
 	}
-	iptCtrl := eriptables.NewOverlayIPtables(datapathManager.Config.CNIConfig.EnableProxy, &eriptables.Options{
-		LocalGwName:    datapathManager.Info.LocalGwName,
-		ClusterPodCIDR: clusterPodCIDRString,
+	iptCtrl := eriptables.NewOverlayIPtables(datapathManager.IsEnableProxy(), &eriptables.Options{
+		LocalGwName:      datapathManager.Info.LocalGwName,
+		ClusterPodCIDR:   clusterPodCIDRString,
+		KubeProxyReplace: datapathManager.IsEnableKubeProxyReplace(),
+		SvcInternalIP:    datapathManager.Config.CNIConfig.SvcInternalIP.String(),
 	})
 	routeCtrl := NewOverlayRoute(gatewayIP, clusterPodCIDRString, datapathManager)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -77,10 +77,27 @@ const (
 
 	GwIPPoolName = "everoute-built-in"
 
-	LocalRulePriority       = 200
-	FromGwLocalRulePriority = 100
+	LocalRulePriority        = 200
+	FromGwLocalRulePriority  = 100
+	SvcRulePriority          = 110
+	ClusterIPSvcRulePriority = 111
+	SvcLocalIPRulePriority   = 120
 
 	FromGwLocalRouteTable = 100
+	SvcToGWRouteTable     = 110
+
+	// InternalSvcPktMarkBit pod request clusterIP svc, used in local bridge
+	InternalSvcPktMarkBit = 29
+	// ExternalSvcPktMarkBit nodeport/lb/clusterIP svc mark, used in uplink bridge and kernel route
+	ExternalSvcPktMarkBit = 28
+
+	PktMarkSetValue uint64 = 0x1
+
+	IPSetNameNPSvcTCP = "er-npsvc-tcp"
+	IPSetNameNPSvcUDP = "er-npsvc-udp"
+	IPSetNameLBSvc    = "er-lbsvc"
+
+	SvcChain = "EVEROUTE-SVC"
 )
 
 const (


### PR DESCRIPTION
1. add config: kubeProxyReplace, apiServer,svcInternalIP
2. create patch port for bridge nat and uplink in init-agent
3. create ipset,iptables,route for kubeproxy replace feature

test:
  - route:
<img width="972" alt="image" src="https://github.com/everoute/everoute/assets/26404219/71db1e36-02b1-40c7-9d29-ff2f6d92e9ec">
 
- iptables:
<img width="1194" alt="image" src="https://github.com/everoute/everoute/assets/26404219/ee920cf8-4959-4a62-b420-20d87a3cc209">
<img width="1155" alt="image" src="https://github.com/everoute/everoute/assets/26404219/592c8d0a-f6fa-454e-a28a-1a3625017382">

 - ipset:
<img width="755" alt="image" src="https://github.com/everoute/everoute/assets/26404219/7f87669d-396f-4a15-ac3b-d3d1c1b42384">

