### PR TITLE
ci: use kube-apiServer v1.24 in unit test image

### DIFF
--- a/build/images/unit-test/Dockerfile
+++ b/build/images/unit-test/Dockerfile
@@ -4,12 +4,12 @@
 FROM golang:1.20 as downloader
 
 ENV ETCD_RELEASE_URL=https://github.com/etcd-io/etcd/releases/download
-ENV ETCD_VERSION=v3.4.18
-RUN curl -L ${ETCD_RELEASE_URL}/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VERSION}.tar && \
-  tar xf /tmp/etcd-${ETCD_VERSION}.tar -C /usr/local/bin --strip-components=1 --extract etcd-${ETCD_VERSION}-linux-amd64/etcd
+ENV ETCD_VERSION=v3.5.6
+RUN curl -L ${ETCD_RELEASE_URL}/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VERSION}-linux-amd64.tar && \
+    tar -xf /tmp/etcd-${ETCD_VERSION}-linux-amd64.tar -C /usr/local/bin --strip-components=1 --extract etcd-${ETCD_VERSION}-linux-amd64/etcd
 
 ENV KUBERNETES_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-ENV KUBERNETES_VERSION=v1.18.17
+ENV KUBERNETES_VERSION=v1.24.17
 RUN curl -L ${KUBERNETES_RELEASE_URL}/${KUBERNETES_VERSION}/bin/linux/amd64/kube-apiserver -o /usr/local/bin/kube-apiserver && \
     chmod +x /usr/local/bin/kube-apiserver
 

--- a/pkg/agent/controller/proxy/controller_test.go
+++ b/pkg/agent/controller/proxy/controller_test.go
@@ -58,7 +58,7 @@ var _ = Describe("proxy controller", func() {
 			Protocol: corev1.ProtocolTCP,
 			Port:     80,
 		}
-		portName3 = port3.Name
+		portName3    = port3.Name
 		svcPortName3 = "svcportname-http"
 	)
 
@@ -204,6 +204,8 @@ var _ = Describe("proxy controller", func() {
 			svcCopy.Spec.ClusterIP = ""
 			svcCopy.Spec.ClusterIPs = []string{}
 			svcCopy.Spec.ExternalName = "test"
+			svcCopy.Spec.IPFamilies = nil
+			svcCopy.Spec.IPFamilyPolicy = nil
 			Expect(k8sClient.Create(ctx, svcCopy)).Should(Succeed())
 			time.Sleep(Timeout)
 			_, exists, _ := proxyController.baseSvcCache.GetByKey(svcID)
@@ -1099,7 +1101,7 @@ var _ = Describe("proxy controller", func() {
 					}
 					return equalBackend(backCache.(*proxycache.Backend), &expBackend)
 				}, Timeout, Interval).Should(BeTrue())
-				
+
 				dpOvs := svcIndex.GetSvcOvsInfo(svcID)
 				Expect(dpOvs).ToNot(BeNil())
 				Expect(svcIndex.GetDnatFlow(bk3)).ToNot(BeNil())

--- a/pkg/controller/group/suite_test.go
+++ b/pkg/controller/group/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package group_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +42,7 @@ var (
 	k8sClient          client.Client // You'll be using this client in your tests.
 	testEnv            *envtest.Environment
 	useExistingCluster bool
+	ctx, cancel        = context.WithCancel(ctrl.SetupSignalHandler())
 )
 
 const (
@@ -116,7 +118,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -125,6 +127,8 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	By("stop controller manager")
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/ipam/suit_test.go
+++ b/pkg/controller/ipam/suit_test.go
@@ -1,6 +1,7 @@
 package ipam
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,7 @@ var (
 	k8sClient          client.Client // You'll be using this client in your tests.
 	testEnv            *envtest.Environment
 	useExistingCluster bool
+	ctx, cancel        = context.WithCancel(ctrl.SetupSignalHandler())
 )
 
 const (
@@ -81,7 +83,6 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	ctx := ctrl.SetupSignalHandler()
 	go func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -99,6 +100,8 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	By("stop controller manager")
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/k8s/suite_test.go
+++ b/pkg/controller/k8s/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package k8s
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +42,7 @@ var (
 	k8sClient          client.Client // You'll be using this client in your tests.
 	testEnv            *envtest.Environment
 	useExistingCluster bool
+	ctx, cancel        = context.WithCancel(ctrl.SetupSignalHandler())
 )
 
 const (
@@ -138,7 +140,6 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	ctx := ctrl.SetupSignalHandler()
 	go func() {
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -150,6 +151,8 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	By("stop controller manager")
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/webhook/validates/suite_test.go
+++ b/pkg/webhook/validates/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validates_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,6 +43,7 @@ var (
 	testEnv            *envtest.Environment
 	validate           *validates.CRDValidate
 	useExistingCluster bool
+	ctx, cancel        = context.WithCancel(ctrl.SetupSignalHandler())
 )
 
 var (
@@ -122,7 +124,7 @@ var _ = BeforeSuite(func() {
 	Expect(validate).ToNot(BeNil())
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -140,6 +142,8 @@ var _ = AfterSuite(func() {
 	for _, f := range ObjectsCleanFunc {
 		f()
 	}
+	By("stop controller manager")
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
use kube-apiserver v1.24 in unit test image
must stop controller runtime before stop kube-apiserver