### PR TITLE
fix(ER-708): skip match monitor tier3 ingress when ct match monitor drop

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -141,6 +141,7 @@ var (
 	ep3VlanInputFlow1              = "table=0, priority=200,in_port=33 actions=load:0x1->NXM_NX_REG3[0..1],load:0x21->NXM_NX_PKT_MARK[0..15],resubmit(,1)"
 	ep3VlanFilterFlow1             = "table=1, priority=200,in_port=33,dl_vlan=1 actions=resubmit(,10),resubmit(,15)"
 	ep3VlanFilterFlow2             = "table=1, priority=200,in_port=33,vlan_tci=0x1002/0x1ffe actions=resubmit(,10),resubmit(,15)"
+	ctDropMatchFlow                = "table=70, priority=300,ct_label=0x80000000000000000000000000000000/0x80000000000000000000000000000000,ip actions=load:0x20->NXM_NX_REG4[0..15],resubmit(,71)"
 )
 
 func TestMain(m *testing.M) {
@@ -172,6 +173,7 @@ func TestDpManager(t *testing.T) {
 
 	testLocalEndpoint(t)
 	testERPolicyRule(t)
+	testPolicyTableInit(t)
 	testMonitorRule(t)
 	testFlowReplay(t)
 	testRoundNumFlip(t)
@@ -281,6 +283,14 @@ func testERPolicyRule(t *testing.T) {
 		if _, ok := datapathManager.Rules[rule3.RuleID]; ok {
 			t.Errorf("Failed to remove ER policy rule, rule %v in cache", rule3)
 		}
+	})
+}
+
+func testPolicyTableInit(t *testing.T) {
+	t.Run("test policy table init flow", func(t *testing.T) {
+		Eventually(func() error {
+			return flowValidator([]string{ctDropMatchFlow})
+		}, timeout, interval).Should(Succeed())
 	})
 }
 

--- a/pkg/agent/datapath/policyBridge.go
+++ b/pkg/agent/datapath/policyBridge.go
@@ -13,7 +13,7 @@ import (
 	"github.com/everoute/everoute/pkg/constants"
 )
 
-//nolint
+// //nolint
 const (
 	INPUT_TABLE                 = 0
 	CT_STATE_TABLE              = 1
@@ -248,8 +248,8 @@ func (p *PolicyBridge) initCTFlow(sw *ofctrl.OFSwitch) error {
 	ctDropFilterFlow, _ := p.ctCommitTable.NewFlow(ofctrl.FlowMatch{
 		Priority:    HIGH_MATCH_FLOW_PRIORITY,
 		Ethertype:   PROTOCOL_IP,
-		CTLabel:     &[16]byte{0x8},
-		CTLabelMask: &[16]byte{0x8},
+		CTLabel:     &[16]byte{0x80},
+		CTLabelMask: &[16]byte{0x80},
 	})
 	if err := ctDropFilterFlow.LoadField("nxm_nx_reg4", 0x20, openflow13.NewNXRange(0, 15)); err != nil {
 		return err


### PR DESCRIPTION
fix: https://github.com/everoute/analyzer/issues/254, [ER-708](http://jira.smartx.com/browse/ER-708)
design document: https://docs.google.com/document/d/1L-Xikqh2RGwV2-JP9CUW_iPyZVs5-6lc3cZgsS-jJF4
ct label usage: https://docs.google.com/spreadsheets/d/1jADYgo0tt1-Q9GYglZkRoiDRn0VGHyj2zNVNDPxgxLU
e2e test report: https://docs.google.com/document/d/1zCV1u_S8AujXj6NOJun_dVasjUKbl7B6_aF0mQ7HK_I/edit