### PR TITLE
fix: check externalIDs when merge old ip to agentinfo

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,6 +68,9 @@ const (
 	// sks related
 	SksManagedLabelKey   = "sks-managed"
 	SksManagedLabelValue = "true"
+
+	// endpoint
+	EndpointExternalIDKey = "iface-id"
 )
 
 const (

--- a/pkg/controller/endpoint/endpoint_controller.go
+++ b/pkg/controller/endpoint/endpoint_controller.go
@@ -59,7 +59,6 @@ const (
 	externalIDIndex              = "externalIDIndex"
 	ipAddrIndex                  = "ipaddrIndex"
 	agentIndex                   = "agentIndex"
-	endpointExternalIDKey        = "iface-id"
 	k8sEndpointExternalIDKey     = "pod-uuid"
 	IfaceIPAddrCleanInterval int = 5
 )
@@ -533,7 +532,7 @@ func computeInterfaceExpiredIPs(timeout time.Duration, iface *iface) []string {
 func getEndpointIfaceIDFromIfaceCache(iface *iface) string {
 	// if normal vm endpoint attached to interface: endpointId k-v pair is
 	// endpointExternalIDKey : endpointID
-	if ifaceID, ok := iface.externalIDs[endpointExternalIDKey]; ok {
+	if ifaceID, ok := iface.externalIDs[constants.EndpointExternalIDKey]; ok {
 		return ifaceID
 	}
 	// if k8s endpoint attached to interface: endpointID k-v pair is
@@ -548,7 +547,7 @@ func getEndpointIfaceIDFromIfaceCache(iface *iface) string {
 func getEndpointIfaceIDFromOvsIface(ovsIface agentv1alpha1.OVSInterface) string {
 	// if normal vm endpoint attached to interface: endpointID k-v pair is
 	// endpointExternalIDKey: endpointID
-	if ifaceID, ok := ovsIface.ExternalIDs[endpointExternalIDKey]; ok {
+	if ifaceID, ok := ovsIface.ExternalIDs[constants.EndpointExternalIDKey]; ok {
 		return ifaceID
 	}
 	// if k8s endpoint attached to interface: endpointID k-v pair is

--- a/pkg/controller/endpoint/suit_test.go
+++ b/pkg/controller/endpoint/suit_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
 )
 
 var (
@@ -32,6 +33,7 @@ var (
 const (
 	RunTestWithExistingCluster = "TESTING_WITH_EXISTING_CLUSTER"
 	strictMacNs                = "strict-mac"
+	endpointExternalIDKey      = constants.EndpointExternalIDKey
 )
 
 func TestStrictMacController(t *testing.T) {

--- a/pkg/monitor/agent_test.go
+++ b/pkg/monitor/agent_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/types"
 )
 
@@ -137,9 +138,11 @@ func TestAgentMonitorIpAddressLearning(t *testing.T) {
 	t.Logf("create new bridge %s", brName)
 	Expect(createBridge(ovsClient, brName)).Should(Succeed())
 
+	externalIDs := make(map[string]string)
+	externalIDs[constants.EndpointExternalIDKey] = rand.String(7)
 	var portName = rand.String(10)
 	var ofPort1 = uint32(rand.IntnRange(10, 100))
-	var iface = Iface{IfaceName: rand.String(10), IfaceType: "internal", OfPort: ofPort1}
+	var iface = Iface{IfaceName: rand.String(10), IfaceType: "internal", OfPort: ofPort1, externalID: externalIDs}
 	var ipAddr1 = net.ParseIP("10.10.10.1")
 	var ipAddr2 = net.ParseIP("10.10.10.2")
 
@@ -223,9 +226,11 @@ func TestAgentMonitorProbeTimeoutIP(t *testing.T) {
 		portName, peerName := rand.String(10), rand.String(10)
 		ip := net.ParseIP("10.10.10.1")
 		ofPort := uint32(rand.IntnRange(10, 100))
+		externalIDs := make(map[string]string)
+		externalIDs[constants.EndpointExternalIDKey] = rand.String(7)
 
 		Expect(createVethPair(portName, peerName)).Should(Succeed())
-		Expect(createPort(ovsClient, bridgeName, portName, &Iface{Trunk: []int{100, 120}, OfPort: ofPort})).Should(Succeed())
+		Expect(createPort(ovsClient, bridgeName, portName, &Iface{Trunk: []int{100, 120}, OfPort: ofPort, externalID: externalIDs})).Should(Succeed())
 		Eventually(func() error {
 			_, err := getIface(k8sClient, bridgeName, portName, portName)
 			return err


### PR DESCRIPTION
已验证场景：
- 添加虚拟机网卡
- 虚拟机网卡添加IP
- 添加ECP Pod IP
- 重启节点