### PR TITLE
fix(cni): delete error apiserver param check

### DIFF
--- a/cmd/everoute-agent/config.go
+++ b/cmd/everoute-agent/config.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"net/url"
 	"os"
 	"strings"
 
@@ -138,12 +137,6 @@ func (o *Options) complete() error {
 		}
 		o.namespace = ns
 		return o.cniConfigCheck()
-	}
-
-	if o.Config.APIServer != "" {
-		if _, err := url.Parse(o.Config.APIServer); err != nil {
-			return fmt.Errorf("can't set invalid apiServer %s, err: %s", o.Config.APIServer, err)
-		}
 	}
 
 	return nil

--- a/cmd/everoute-controller/config.go
+++ b/cmd/everoute-controller/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -99,12 +98,6 @@ func (o *Options) complete() error {
 			return fmt.Errorf("can't get controller namespace from env")
 		}
 		o.namespace = ns
-	}
-
-	if o.Config.APIServer != "" {
-		if _, err := url.Parse(o.Config.APIServer); err != nil {
-			return fmt.Errorf("can't set invalid apiServer %s, err: %s", o.Config.APIServer, err)
-		}
 	}
 
 	return o.cniConfigCheck()


### PR DESCRIPTION
这个url的check有问题，它不支持ip:port格式会报错，只能是单个ip或者完整url http://ip:port

apiserver 可选的填写方式为 ip:port 或者ip（默认端口是6443）

如果参数填错，无法连接apiserver， 进程起不来。所以这里可以不加校验