### PR TITLE
fix(cni): support access to svc from local node

### DIFF
--- a/pkg/agent/proxy/iptables/overlay_mode.go
+++ b/pkg/agent/proxy/iptables/overlay_mode.go
@@ -71,6 +71,7 @@ func (o *overlayIPtables) Update() {
 
 	o.proxy.prerouting(ipt)
 	o.proxy.forward(ipt)
+	o.proxy.output(ipt)
 }
 
 func (o *overlayIPtables) updateEverouteOutputChain(ipt *iptables.IPTables) {

--- a/pkg/agent/proxy/iptables/proxy_iptables.go
+++ b/pkg/agent/proxy/iptables/proxy_iptables.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/everoute/everoute/pkg/constants"
 )
@@ -14,6 +14,7 @@ type proxyIPtables interface {
 	everouteOutput(ipt *iptables.IPTables) []string
 	forward(ipt *iptables.IPTables)
 	prerouting(ipt *iptables.IPTables)
+	output(ipt *iptables.IPTables)
 }
 
 type kubeProxy struct {
@@ -49,6 +50,8 @@ func (k *kubeProxy) prerouting(ipt *iptables.IPTables) {
 	}
 }
 
+func (*kubeProxy) output(*iptables.IPTables) {}
+
 type everouteProxy struct {
 	kubeProxyReplace bool
 	svcInternalIP    string
@@ -58,6 +61,7 @@ func (e *everouteProxy) everouteOutput(ipt *iptables.IPTables) []string {
 	if !e.kubeProxyReplace {
 		return nil
 	}
+
 	if e.svcInternalIP == "" {
 		klog.Error("Doesn't set svcInternalIP when enable kubeProxyReplace")
 		return nil
@@ -74,48 +78,83 @@ func (e *everouteProxy) everouteOutput(ipt *iptables.IPTables) []string {
 func (*everouteProxy) forward(*iptables.IPTables) {}
 
 func (e *everouteProxy) prerouting(ipt *iptables.IPTables) {
+	e.updateSvcIPtables(ipt, "PREROUTING")
+}
+
+func (e *everouteProxy) output(ipt *iptables.IPTables) {
+	e.updateSvcIPtables(ipt, "OUTPUT")
+}
+
+func (e *everouteProxy) updateSvcIPtables(ipt *iptables.IPTables, chain string) {
 	if !e.kubeProxyReplace {
 		return
 	}
 
 	var err error
 	if err = e.createEverouteSvcChain(ipt); err != nil {
+		klog.Errorf("Failed to create iptables chain related to feature: kubeProxyReplace, err: %s", err)
 		return
 	}
-	e.addEverouteSvcToPrerouting(ipt)
-
-	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcTCP)...); err != nil {
-		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with tcp, err: %s", constants.SvcChain, err)
-	}
-	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcUDP)...); err != nil {
-		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with udp, err: %s", constants.SvcChain, err)
-	}
-	if err = ipt.AppendUnique("mangle", constants.SvcChain, getRuleSpecByIPSet(constants.IPSetNameLBSvc)...); err != nil {
-		klog.Errorf("Failed to add iptables rule to %s for loadbalancer svc, err: %s", constants.SvcChain, err)
-	}
+	e.addEverouteSvcToChain(ipt, chain)
+	e.updateEverouteSvcChain(ipt)
 }
 
 func (*everouteProxy) createEverouteSvcChain(ipt *iptables.IPTables) error {
 	var err error
 	var exist bool
 	// check existence of chain EVEROUTE-SVC, if not, then create it
-	if exist, err = ipt.ChainExists("mangle", constants.SvcChain); err != nil {
-		klog.Errorf("Get iptables %s error, error: %s", constants.SvcChain, err)
+	if exist, err = ipt.ChainExists("mangle", constants.IPtSvcChain); err != nil {
+		klog.Errorf("Get iptables %s error, error: %s", constants.IPtSvcChain, err)
 		return err
 	}
 	if !exist {
-		err = ipt.NewChain("mangle", constants.SvcChain)
+		err = ipt.NewChain("mangle", constants.IPtSvcChain)
 		if err != nil {
-			klog.Errorf("Create iptables %s error, error: %s", constants.SvcChain, err)
+			klog.Errorf("Create iptables %s error, error: %s", constants.IPtSvcChain, err)
 			return err
 		}
 	}
+
 	return nil
 }
 
-func (*everouteProxy) addEverouteSvcToPrerouting(ipt *iptables.IPTables) {
-	if err := ipt.InsertUnique("mangle", "PREROUTING", 1, "-j", constants.SvcChain); err != nil {
-		klog.Errorf("insert %s into nat PREROUTING error, err: %s", constants.SvcChain, err)
+func (*everouteProxy) updateEverouteSvcChain(ipt *iptables.IPTables) {
+	var err error
+
+	// lb svc
+	if err = ipt.InsertUnique("mangle", constants.IPtSvcChain, 1, getRuleSpecByIPSet(constants.IPSetNameLBSvc)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for loadbalancer svc, err: %s", constants.IPtSvcChain, err)
+	}
+
+	// create everoute-svc-np chain
+	var exist bool
+	if exist, err = ipt.ChainExists("mangle", constants.IPtNPSvcChain); err != nil {
+		klog.Errorf("Get iptables %s error, error: %s", constants.IPtNPSvcChain, err)
+		return
+	}
+	if !exist {
+		err = ipt.NewChain("mangle", constants.IPtNPSvcChain)
+		if err != nil {
+			klog.Errorf("Create iptables %s error, error: %s", constants.IPtNPSvcChain, err)
+			return
+		}
+	}
+	// add everoute-svc-np to everoute-svc
+	if err = ipt.AppendUnique("mangle", constants.IPtSvcChain, "-m", "addrtype", "--dst-type", "LOCAL", "-j", constants.IPtNPSvcChain); err != nil {
+		klog.Errorf("Failed to add nodeport svc rule to chain %s, err: %s", constants.IPtSvcChain, err)
+	}
+	// update everoute-svc-np chain rule
+	if err = ipt.AppendUnique("mangle", constants.IPtNPSvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcTCP)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with tcp, err: %s", constants.IPtSvcChain, err)
+	}
+	if err = ipt.AppendUnique("mangle", constants.IPtNPSvcChain, getRuleSpecByIPSet(constants.IPSetNameNPSvcUDP)...); err != nil {
+		klog.Errorf("Failed to add iptables rule to %s for nodeport svc with udp, err: %s", constants.IPtSvcChain, err)
+	}
+}
+
+func (*everouteProxy) addEverouteSvcToChain(ipt *iptables.IPTables, chain string) {
+	if err := ipt.InsertUnique("mangle", chain, 1, "-j", constants.IPtSvcChain); err != nil {
+		klog.Errorf("insert %s into nat %s error, err: %s", chain, constants.IPtSvcChain, err)
 	}
 }
 

--- a/pkg/agent/proxy/iptables/route_mode.go
+++ b/pkg/agent/proxy/iptables/route_mode.go
@@ -49,6 +49,7 @@ func (r *RouteIPtables) Update(nodeList corev1.NodeList, thisNode corev1.Node) {
 
 	r.proxy.prerouting(ipt)
 	r.proxy.forward(ipt)
+	r.proxy.output(ipt)
 }
 
 func (r *RouteIPtables) updateEverouteOutputChain(ipt *iptables.IPTables, nodeList corev1.NodeList, thisNode corev1.Node) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,11 +28,11 @@ const (
 
 	IfaceIPTimeoutDuration = 30 * time.Minute
 
-	DefaultMaxConcurrentReconciles   = 4
-	DependentsCleanFinalizer         = "finalizer.everoute.io/dependentsclean"
-	OwnerGroupLabelKey               = "label.everoute.io/ownergroup"
-	OwnerPolicyLabelKey              = "label.everoute.io/ownerpolicy"
-	IsGlobalPolicyRuleLabel          = "label.everoute.io/isglobalpolicy"
+	DefaultMaxConcurrentReconciles = 4
+	DependentsCleanFinalizer       = "finalizer.everoute.io/dependentsclean"
+	OwnerGroupLabelKey             = "label.everoute.io/ownergroup"
+	OwnerPolicyLabelKey            = "label.everoute.io/ownerpolicy"
+	IsGlobalPolicyRuleLabel        = "label.everoute.io/isglobalpolicy"
 
 	// Tier0 used for isolation policy and forensic one side drop
 	Tier0 = "tier0"
@@ -103,7 +103,8 @@ const (
 	IPSetNameNPSvcUDP = "er-npsvc-udp"
 	IPSetNameLBSvc    = "er-lbsvc"
 
-	SvcChain = "EVEROUTE-SVC"
+	IPtSvcChain   = "EVEROUTE-SVC"
+	IPtNPSvcChain = "EVEROUTE-SVC-NP"
 
 	// ct zone used by cni
 	CTZoneNatBrFromLocal  = 65505


### PR DESCRIPTION

修改NodePort svc和 LB SVC 的节点导流 iptables 规则：


<img width="852" alt="image" src="https://github.com/everoute/everoute/assets/26404219/7e2eb66b-8ec0-47eb-9736-5da25812ec0f">
