### PR TITLE
refactor: modify datapath data model to reduce memory usage for evero…

### DIFF
--- a/pkg/agent/controller/policy/cache/rule.go
+++ b/pkg/agent/controller/policy/cache/rule.go
@@ -59,6 +59,7 @@ const (
 type PolicyRule struct {
 	// Name format policyNamespace/policyName/policyType/ruleName-flowKey
 	Name   string     `json:"name"`
+	Policy string     `json:"policy"`
 	Action RuleAction `json:"action"`
 
 	// match fields
@@ -81,6 +82,7 @@ type PolicyRule struct {
 func (p *PolicyRule) DeepCopy() *PolicyRule {
 	return &PolicyRule{
 		Name:            p.Name,
+		Policy:          p.Policy,
 		RuleType:        p.RuleType,
 		Tier:            p.Tier,
 		PriorityOffset:  p.PriorityOffset,
@@ -137,6 +139,7 @@ func (p *PolicyRule) ReverseForIcmp() []*PolicyRule {
 	res := []*PolicyRule{}
 	rBase := &PolicyRule{
 		RuleType:        p.RuleType,
+		Policy:          p.Policy,
 		Tier:            p.Tier,
 		PriorityOffset:  p.PriorityOffset,
 		EnforcementMode: p.EnforcementMode,
@@ -170,6 +173,7 @@ func (p *PolicyRule) ReverseForTCP() *PolicyRule {
 		return nil
 	}
 	res := &PolicyRule{
+		Policy:          p.Policy,
 		RuleType:        p.RuleType,
 		Tier:            p.Tier,
 		PriorityOffset:  p.PriorityOffset,
@@ -239,6 +243,7 @@ type CompleteRule struct {
 
 	// RuleID is a unique identifier of rule, it's always set to policyNamespace/policyName/policyType/ruleName.
 	RuleID string
+	Policy string
 
 	Tier            string
 	Priority        int32
@@ -296,6 +301,7 @@ func (rule *CompleteRule) Clone() *CompleteRule {
 
 	return &CompleteRule{
 		RuleID:            rule.RuleID,
+		Policy:            rule.Policy,
 		Tier:              rule.Tier,
 		Priority:          rule.Priority,
 		EnforcementMode:   rule.EnforcementMode,
@@ -399,6 +405,7 @@ func (rule *CompleteRule) generateRule(srcIPBlock, dstIPBlock string, direction 
 	}
 
 	policyRule := PolicyRule{
+		Policy:          rule.Policy,
 		Direction:       direction,
 		RuleType:        ruleType,
 		Tier:            rule.Tier,
@@ -469,8 +476,7 @@ func groupIndexFunc(obj interface{}) ([]string, error) {
 
 func policyIndexFunc(obj interface{}) ([]string, error) {
 	rule := obj.(*CompleteRule)
-	policyNamespaceName := strings.Join(strings.Split(rule.RuleID, "/")[:2], "/")
-	return []string{policyNamespaceName}, nil
+	return []string{rule.Policy}, nil
 }
 
 func resolveDstPort(port RulePort, namedPorts []securityv1alpha1.NamedPort) []RulePort {
@@ -503,6 +509,8 @@ func NewCompleteRuleCache() cache.Indexer {
 func GenerateFlowKey(rule PolicyRule) string {
 	// ignore rule.Name and rule.Namespace from generate flowkey
 	rule.Name = ""
+	// ignore rule.Policy
+	rule.Policy = ""
 	// We consider PolicyRule with the same spec but different action as the same flow.
 	// Some we remove the action to generate FlowKey here.
 	rule.Action = ""

--- a/pkg/agent/controller/policy/cache/rule_test.go
+++ b/pkg/agent/controller/policy/cache/rule_test.go
@@ -327,6 +327,7 @@ func TestRuleReverseForTCP(t *testing.T) {
 			name: "without port",
 			rule: PolicyRule{
 				Name:            "default/test/normal/ingress.ingress1",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -338,7 +339,8 @@ func TestRuleReverseForTCP(t *testing.T) {
 				DstIPAddr:       "0.0.0.0/32",
 			},
 			exp: &PolicyRule{
-				Name:            "default/test/normal/ingress.ingress1.rev-ycpj5nwmp19cvivz0kxwbjkvulr395so",
+				Name:            "default/test/normal/ingress.ingress1.rev-xj366200eug1bi61excphjg9dpiq8fum",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -354,6 +356,7 @@ func TestRuleReverseForTCP(t *testing.T) {
 			name: "with dst port",
 			rule: PolicyRule{
 				Name:            "default/test/normal/egress.egress1",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -366,7 +369,8 @@ func TestRuleReverseForTCP(t *testing.T) {
 				DstPortMask:     0xfffe,
 			},
 			exp: &PolicyRule{
-				Name:            "default/test/normal/egress.egress1.rev-46mz6ug658rilqvqfrnvaftj3xbfm4wg",
+				Name:            "default/test/normal/egress.egress1.rev-rnq0iizl0tn0t2c6jg3kbkixmj06nowy",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -383,6 +387,7 @@ func TestRuleReverseForTCP(t *testing.T) {
 			name: "with udp protocol",
 			rule: PolicyRule{
 				Name:            "default/test/normal/egress.egress1",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -401,6 +406,7 @@ func TestRuleReverseForTCP(t *testing.T) {
 			name: "without Protocol",
 			rule: PolicyRule{
 				Name:            "default/test/normal/egress.egress1",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,
@@ -413,7 +419,8 @@ func TestRuleReverseForTCP(t *testing.T) {
 				DstPortMask:     0xfffe,
 			},
 			exp: &PolicyRule{
-				Name:            "default/test/normal/egress.egress1.rev-5oxwoabwts7k9a6qsw1evzkacpqmu36h",
+				Name:            "default/test/normal/egress.egress1.rev-rgmvatzmxh9xu944t54nu4n97sh1l68u",
+				Policy:          "default/test",
 				Action:          RuleActionDrop,
 				PriorityOffset:  30,
 				RuleType:        RuleTypeNormalRule,

--- a/pkg/agent/controller/policy/global_policy_controller.go
+++ b/pkg/agent/controller/policy/global_policy_controller.go
@@ -105,6 +105,7 @@ func newGlobalPolicyRulePair(policy securityv1alpha1.GlobalPolicy) []cache.Polic
 	var ingressRule, egressRule cache.PolicyRule
 
 	ingressRule = cache.PolicyRule{
+		Policy:          "/" + DefaultGlobalPolicyName,
 		Direction:       cache.RuleDirectionIn,
 		RuleType:        cache.RuleTypeGlobalDefaultRule,
 		Tier:            constants.Tier2,
@@ -115,6 +116,7 @@ func newGlobalPolicyRulePair(policy securityv1alpha1.GlobalPolicy) []cache.Polic
 	ingressRule.Name = fmt.Sprintf("/%s/%s/global.ingress/-%s", DefaultGlobalPolicyName, cache.GlobalPolicy, cache.GenerateFlowKey(ingressRule))
 
 	egressRule = cache.PolicyRule{
+		Policy:          "/" + DefaultGlobalPolicyName,
 		Direction:       cache.RuleDirectionOut,
 		RuleType:        cache.RuleTypeGlobalDefaultRule,
 		Tier:            constants.Tier2,

--- a/pkg/agent/controller/policy/policy_controller_test.go
+++ b/pkg/agent/controller/policy/policy_controller_test.go
@@ -1717,7 +1717,7 @@ var _ = Describe("CompleteRuleCache", func() {
 			srcGroup = rand.String(6)
 			dstGroup = rand.String(6)
 
-			Expect(completeRuleCache.Add(newTestCompleteRule(ruleID, srcGroup, dstGroup))).Should(Succeed())
+			Expect(completeRuleCache.Add(newTestCompleteRule(ruleID, srcGroup, dstGroup, policyNamespacedName))).Should(Succeed())
 		})
 		AfterEach(func() {
 			Expect(completeRuleCache.Delete(&cache.CompleteRule{RuleID: ruleID})).Should(Succeed())
@@ -1923,9 +1923,10 @@ func newTestGroupMembers(revision int32, members ...*groupv1alpha1.GroupMember) 
 	return testGroup
 }
 
-func newTestCompleteRule(ruleId string, srcGroup, dstGroup string) *cache.CompleteRule {
+func newTestCompleteRule(ruleId string, srcGroup, dstGroup string, policy string) *cache.CompleteRule {
 	return &cache.CompleteRule{
 		RuleID:    ruleId,
+		Policy:    policy,
 		SrcGroups: sets.New[string](srcGroup),
 		DstGroups: sets.New[string](dstGroup),
 	}

--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -42,7 +42,6 @@ import (
 	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -143,6 +142,8 @@ const (
 	NatToUplinkSuffix   = "nat-to-uplink"
 	UplinkToNatSuffix   = "uplink-to-nat"
 
+	InternalIngressPolicy     = "/INTERNAL_INGRESS_POLICY"
+	InternalEgressPolicy      = "/INTERNAL_EGRESS_POLICY"
 	InternalIngressRulePrefix = "/INTERNAL_INGRESS_POLICY/internal/ingress/-"
 	InternalEgressRulePrefix  = "/INTERNAL_EGRESS_POLICY/internal/egress/-"
 
@@ -233,7 +234,9 @@ type DpManager struct {
 	ofPortIPAddressUpdateChan chan *types.EndpointIP // map bridgename-ofport to endpoint ips
 	Config                    *DpManagerConfig
 	Info                      *DpManagerInfo
-	Rules                     cache.Indexer // store *EveroutePolicyRuleEntry
+	Rules                     map[string]*EveroutePolicyRuleEntry // rules database
+	FlowIDToRules             map[uint64]*EveroutePolicyRuleEntry
+	policyRuleNums            map[string]int
 	flowReplayMutex           *lock.CASMutex
 
 	flushMutex         *lock.ChanMutex
@@ -333,13 +336,25 @@ type FlowEntry struct {
 	FlowID   uint64
 }
 
+type PolicyRuleRef struct {
+	Policy string
+	Rule   string
+}
+
+type RuleBaseInfo struct {
+	Ref       PolicyRuleRef
+	Direction uint8
+	Tier      uint8
+	Mode      string
+}
+
 type EveroutePolicyRuleEntry struct {
 	EveroutePolicyRule  *EveroutePolicyRule
 	Direction           uint8
 	Tier                uint8
 	Mode                string
 	RuleFlowMap         map[string]*FlowEntry
-	PolicyRuleReference sets.String
+	PolicyRuleReference map[PolicyRuleRef]struct{}
 }
 
 type RoundInfo struct {
@@ -373,30 +388,6 @@ const (
 	PolicyRuleIndex = "policy-rule-index"
 )
 
-func ruleKeyFunc(obj interface{}) (string, error) {
-	return obj.(*EveroutePolicyRuleEntry).EveroutePolicyRule.RuleID, nil
-}
-
-func flowIDIndexFunc(obj interface{}) ([]string, error) {
-	var ret []string
-	for _, item := range obj.(*EveroutePolicyRuleEntry).RuleFlowMap {
-		ret = append(ret, strconv.FormatUint(item.FlowID, 10))
-	}
-	return ret, nil
-}
-
-func policyRuleIndexFunc(obj interface{}) ([]string, error) {
-	var ret []string
-	for _, item := range obj.(*EveroutePolicyRuleEntry).PolicyRuleReference.List() {
-		nameList := strings.Split(item, "/")
-		if len(nameList) < 2 {
-			continue
-		}
-		ret = append(ret, nameList[0]+"/"+nameList[1])
-	}
-	return ret, nil
-}
-
 // Datapath manager act as openflow controller:
 // 1. event driven local endpoint info crud and related flow update,
 // 2. collect local endpoint ip learned from different ovsbr(1 per vds), and sync it to management plane
@@ -406,9 +397,9 @@ func NewDatapathManager(datapathConfig *DpManagerConfig, ofPortIPAddressUpdateCh
 	datapathManager.BridgeChainPortMap = make(map[string]map[string]uint32)
 	datapathManager.OvsdbDriverMap = make(map[string]map[string]*ovsdbDriver.OvsDriver)
 	datapathManager.ControllerMap = make(map[string]map[string]*ofctrl.Controller)
-	datapathManager.Rules = cache.NewIndexer(ruleKeyFunc, cache.Indexers{
-		FlowIDIndex:     flowIDIndexFunc,
-		PolicyRuleIndex: policyRuleIndexFunc})
+	datapathManager.Rules = make(map[string]*EveroutePolicyRuleEntry)
+	datapathManager.FlowIDToRules = make(map[uint64]*EveroutePolicyRuleEntry)
+	datapathManager.policyRuleNums = make(map[string]int)
 	datapathManager.Config = datapathConfig
 	datapathManager.localEndpointDB = cmap.New()
 	datapathManager.Info = new(DpManagerInfo)
@@ -531,21 +522,23 @@ func (datapathManager *DpManager) GetPolicyByFlowID(flowID ...uint64) []*PolicyI
 		if id == 0 {
 			continue
 		}
-		item := datapathManager.GetRuleEntryByFlowID(id)
+		item := datapathManager.FlowIDToRules[id]
 		if item != nil {
 			policyInfo := &PolicyInfo{
-				Dir:      item.Direction,
-				Action:   item.EveroutePolicyRule.Action,
-				Mode:     item.Mode,
-				FlowID:   id,
-				Tier:     item.Tier,
-				Priority: item.EveroutePolicyRule.Priority,
+				Dir:    item.Direction,
+				Action: item.EveroutePolicyRule.Action,
+				Mode:   item.Mode,
+				FlowID: id,
 			}
-			for _, p := range item.PolicyRuleReference.List() {
+			for p, _ := range item.PolicyRuleReference {
+				res := strings.Split(p.Rule, "/")
+				if len(res) < 3 {
+					continue
+				}
 				policyInfo.Item = append(policyInfo.Item, PolicyItem{
-					Name:       strings.Split(p, "/")[1],
-					Namespace:  strings.Split(p, "/")[0],
-					PolicyType: policycache.PolicyType(strings.Split(p, "/")[2]),
+					Name:       res[1],
+					Namespace:  res[0],
+					PolicyType: policycache.PolicyType(res[2]),
 				})
 			}
 			policyInfoList = append(policyInfoList, policyInfo)
@@ -560,7 +553,7 @@ func (datapathManager *DpManager) GetRulesByFlowIDs(flowIDs ...uint64) []*v1alph
 	defer datapathManager.flowReplayMutex.RUnlock()
 	ans := []*v1alpha1.RuleEntry{}
 	for _, id := range flowIDs {
-		if entry := datapathManager.GetRuleEntryByFlowID(id); entry != nil {
+		if entry := datapathManager.FlowIDToRules[id]; entry != nil {
 			ans = append(ans, datapathRule2RpcRule(entry))
 		}
 	}
@@ -572,7 +565,7 @@ func (datapathManager *DpManager) GetRulesByRuleIDs(ruleIDs ...string) []*v1alph
 	defer datapathManager.flowReplayMutex.RUnlock()
 	ans := []*v1alpha1.RuleEntry{}
 	for _, id := range ruleIDs {
-		if entry := datapathManager.GetRuleEntryByRuleID(id); entry != nil {
+		if entry := datapathManager.Rules[id]; entry != nil {
 			ans = append(ans, datapathRule2RpcRule(entry))
 		}
 	}
@@ -583,7 +576,7 @@ func (datapathManager *DpManager) GetAllRules() []*v1alpha1.RuleEntry {
 	datapathManager.lockRflowReplayWithTimeout()
 	defer datapathManager.flowReplayMutex.RUnlock()
 	ans := []*v1alpha1.RuleEntry{}
-	for _, entry := range datapathManager.ListRuleEntry() {
+	for _, entry := range datapathManager.Rules {
 		ans = append(ans, datapathRule2RpcRule(entry))
 	}
 	return ans
@@ -915,7 +908,7 @@ func (datapathManager *DpManager) ReplayVDSLocalEndpointFlow(vdsID string, keyWo
 
 func (datapathManager *DpManager) ReplayVDSMicroSegmentFlow(vdsID string) error {
 	var errs error
-	for _, entry := range datapathManager.ListRuleEntry() {
+	for ruleID, entry := range datapathManager.Rules {
 		// Add new policy rule flow to datapath
 		flowEntry, err := datapathManager.BridgeChainMap[vdsID][POLICY_BRIDGE_KEYWORD].AddMicroSegmentRule(context.Background(), entry.EveroutePolicyRule,
 			entry.Direction, entry.Tier, entry.Mode)
@@ -926,10 +919,11 @@ func (datapathManager *DpManager) ReplayVDSMicroSegmentFlow(vdsID string) error 
 			continue
 		}
 
-		entry.RuleFlowMap[vdsID] = flowEntry
-		if err = datapathManager.Rules.Update(entry); err != nil {
-			errs = errors.Join(errs, err)
-		}
+		// udpate new policy rule flow to datapath flow cache
+		datapathManager.Rules[ruleID].RuleFlowMap[vdsID] = flowEntry
+
+		// update new flowID to policy entry map
+		datapathManager.FlowIDToRules[flowEntry.FlowID] = entry
 	}
 
 	// TODO: clear except table if we support helpers
@@ -1205,23 +1199,52 @@ func (datapathManager *DpManager) RemoveLocalEndpoint(endpoint *Endpoint) error 
 	return nil
 }
 
+func (datapathManager *DpManager) updatePolicyRuleNumForAddRule(policyName string, oriRuleRef map[PolicyRuleRef]struct{}) {
+	for k, _ := range oriRuleRef {
+		if k.Policy == policyName {
+			return
+		}
+	}
+	datapathManager.policyRuleNums[policyName]++
+}
+
+func (datapathManager *DpManager) updatePolicyRuleNumForRemoveRule(policyName string, policyRef map[PolicyRuleRef]struct{}) {
+	for k, _ := range policyRef {
+		if k.Policy == policyName {
+			return
+		}
+	}
+	datapathManager.decPolicyRuleNum(policyName)
+}
+
+func (datapathManager *DpManager) decPolicyRuleNum(policyName string) {
+	if datapathManager.policyRuleNums[policyName] > 0 {
+		datapathManager.policyRuleNums[policyName]--
+	}
+	if datapathManager.policyRuleNums[policyName] <= 0 {
+		delete(datapathManager.policyRuleNums, policyName)
+	}
+}
+
 //nolint:all
-func (datapathManager *DpManager) AddEveroutePolicyRule(ctx context.Context, rule *EveroutePolicyRule, ruleName string, direction uint8, tier uint8, mode string) error {
-	log := ctrl.LoggerFrom(ctx, "ruleName", ruleName, "newRule", rule, "direction", direction, "tier", tier, "mode", mode)
+func (datapathManager *DpManager) AddEveroutePolicyRule(ctx context.Context, rule *EveroutePolicyRule, ruleBase RuleBaseInfo) error {
+	log := ctrl.LoggerFrom(ctx, "ruleBase", ruleBase, "newRule", rule)
 	datapathManager.lockflowReplayWithTimeout()
 	defer datapathManager.flowReplayMutex.Unlock()
 	if !datapathManager.IsBridgesConnected() {
 		datapathManager.WaitForBridgeConnected()
 	}
 
+	policyRef := ruleBase.Ref
 	// check if we already have the rule
-	ruleEntry := datapathManager.GetRuleEntryByRuleID(rule.RuleID).Clone()
+	ruleEntry := datapathManager.Rules[rule.RuleID]
 	var oldRule *EveroutePolicyRule
 	if ruleEntry != nil {
 		if RuleIsSame(ruleEntry.EveroutePolicyRule, rule) {
-			ruleEntry.PolicyRuleReference.Insert(ruleName)
+			datapathManager.updatePolicyRuleNumForAddRule(policyRef.Policy, ruleEntry.PolicyRuleReference)
+			ruleEntry.PolicyRuleReference[policyRef] = struct{}{}
 			log.Info("Rule already exists, skip add flow")
-			return datapathManager.Rules.Update(ruleEntry)
+			return nil
 		}
 		oldRule = ruleEntry.EveroutePolicyRule
 	}
@@ -1233,7 +1256,7 @@ func (datapathManager *DpManager) AddEveroutePolicyRule(ctx context.Context, rul
 	for vdsID, bridgeChain := range datapathManager.BridgeChainMap {
 		logL := ctrl.LoggerFrom(ctx, "vds", vdsID, "bridge", bridgeChain[POLICY_BRIDGE_KEYWORD].GetName())
 		ctxL := ctrl.LoggerInto(ctx, logL)
-		flowEntry, err := bridgeChain[POLICY_BRIDGE_KEYWORD].AddMicroSegmentRule(ctxL, rule, direction, tier, mode)
+		flowEntry, err := bridgeChain[POLICY_BRIDGE_KEYWORD].AddMicroSegmentRule(ctxL, rule, ruleBase.Direction, ruleBase.Tier, ruleBase.Mode)
 		if err != nil {
 			return err
 		}
@@ -1244,29 +1267,36 @@ func (datapathManager *DpManager) AddEveroutePolicyRule(ctx context.Context, rul
 
 	// save the rule. ruleFlowMap need deepcopy, NOTE
 	if ruleEntry == nil {
+		datapathManager.policyRuleNums[policyRef.Policy]++
 		ruleEntry = &EveroutePolicyRuleEntry{
-			PolicyRuleReference: sets.NewString(ruleName),
+			PolicyRuleReference: map[PolicyRuleRef]struct{}{policyRef: struct{}{}},
 		}
 	}
-	ruleEntry.Direction = direction
-	ruleEntry.Tier = tier
-	ruleEntry.Mode = mode
+	ruleEntry.Direction = ruleBase.Direction
+	ruleEntry.Tier = ruleBase.Tier
+	ruleEntry.Mode = ruleBase.Mode
 	ruleEntry.EveroutePolicyRule = rule
 	ruleEntry.RuleFlowMap = ruleFlowMap
+	datapathManager.Rules[rule.RuleID] = ruleEntry
+	// save flowID reference
+	for _, v := range ruleEntry.RuleFlowMap {
+		datapathManager.FlowIDToRules[v.FlowID] = ruleEntry
+	}
 	log.Info("Success to add or update rule")
-	return datapathManager.Rules.Update(ruleEntry)
+	return nil
 }
 
 //nolint:all
-func (datapathManager *DpManager) RemoveEveroutePolicyRule(ctx context.Context, ruleID string, ruleName string) error {
-	log := ctrl.LoggerFrom(ctx, "ruleName", ruleName)
+func (datapathManager *DpManager) RemoveEveroutePolicyRule(ctx context.Context, ruleID string, ruleBase RuleBaseInfo) error {
+	log := ctrl.LoggerFrom(ctx, "ruleBase", ruleBase)
 	datapathManager.lockflowReplayWithTimeout()
 	defer datapathManager.flowReplayMutex.Unlock()
 	if !datapathManager.IsBridgesConnected() {
 		datapathManager.WaitForBridgeConnected()
 	}
 
-	pRule := datapathManager.GetRuleEntryByRuleID(ruleID).Clone()
+	policyRef := ruleBase.Ref
+	pRule := datapathManager.Rules[ruleID]
 	if pRule == nil {
 		log.Error(utils.ErrInternal, "rule not found when deleting", "ruleID", ruleID)
 		return nil
@@ -1274,10 +1304,11 @@ func (datapathManager *DpManager) RemoveEveroutePolicyRule(ctx context.Context, 
 	log = log.WithValues("rule", pRule)
 
 	// check and remove rule reference
-	pRule.PolicyRuleReference.Delete(ruleName)
-	if pRule.PolicyRuleReference.Len() > 0 {
+	delete(pRule.PolicyRuleReference, policyRef)
+	if len(pRule.PolicyRuleReference) > 0 {
+		datapathManager.updatePolicyRuleNumForRemoveRule(policyRef.Policy, pRule.PolicyRuleReference)
 		log.Info("Rule referenced by other policy rules, skip del flow")
-		return datapathManager.Rules.Update(pRule)
+		return nil
 	}
 
 	for vdsID := range datapathManager.BridgeChainMap {
@@ -1287,12 +1318,16 @@ func (datapathManager *DpManager) RemoveEveroutePolicyRule(ctx context.Context, 
 			return err
 		}
 		log.V(2).Info("Success to delete flow for rule", "vdsID", vdsID)
+		// remove flowID reference
+		delete(datapathManager.FlowIDToRules, pRule.RuleFlowMap[vdsID].FlowID)
 	}
 
 	datapathManager.cleanConntrackFlow(ctx, pRule.EveroutePolicyRule)
 
+	delete(datapathManager.Rules, ruleID)
+	datapathManager.decPolicyRuleNum(policyRef.Policy)
 	log.Info("Success delete rule")
-	return datapathManager.Rules.Delete(pRule)
+	return nil
 }
 
 func (datapathManager *DpManager) GetNatBridges() []*NatBridge {
@@ -1343,15 +1378,33 @@ func (datapathManager *DpManager) syncIntenalIPs(stopChan <-chan struct{}) {
 
 func (datapathManager *DpManager) addIntenalIP(ip string, index int) {
 	ruleNameSuffix := fmt.Sprintf("%s-%d", ip, index)
+
+	ruleBase1 := RuleBaseInfo{
+		Ref: PolicyRuleRef{
+			Policy: InternalIngressPolicy,
+			Rule:   InternalIngressRulePrefix + ruleNameSuffix,
+		},
+		Direction: POLICY_DIRECTION_IN,
+		Tier:      POLICY_TIER3,
+		Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+	}
 	// add internal ingress rule
-	err := datapathManager.AddEveroutePolicyRule(context.Background(), newInternalIngressRule(ip),
-		InternalIngressRulePrefix+ruleNameSuffix, POLICY_DIRECTION_IN, POLICY_TIER3, DEFAULT_POLICY_ENFORCEMENT_MODE)
+	err := datapathManager.AddEveroutePolicyRule(context.Background(), newInternalIngressRule(ip), ruleBase1)
 	if err != nil {
 		klog.Fatalf("Failed to add internal whitelist: %s: %v", ip, err)
 	}
+
+	ruleBase2 := RuleBaseInfo{
+		Ref: PolicyRuleRef{
+			Policy: InternalEgressPolicy,
+			Rule:   InternalEgressRulePrefix + ruleNameSuffix,
+		},
+		Direction: POLICY_DIRECTION_OUT,
+		Tier:      POLICY_TIER3,
+		Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+	}
 	// add internal egress rule
-	err = datapathManager.AddEveroutePolicyRule(context.Background(), newInternalEgressRule(ip),
-		InternalEgressRulePrefix+ruleNameSuffix, POLICY_DIRECTION_OUT, POLICY_TIER3, DEFAULT_POLICY_ENFORCEMENT_MODE)
+	err = datapathManager.AddEveroutePolicyRule(context.Background(), newInternalEgressRule(ip), ruleBase2)
 	if err != nil {
 		klog.Fatalf("Failed to add internal whitelist: %s: %v", ip, err)
 	}
@@ -1359,13 +1412,27 @@ func (datapathManager *DpManager) addIntenalIP(ip string, index int) {
 
 func (datapathManager *DpManager) removeIntenalIP(ip string, index int) {
 	ruleNameSuffix := fmt.Sprintf("%s-%d", ip, index)
+
+	ruleBase1 := RuleBaseInfo{
+		Ref: PolicyRuleRef{
+			Policy: InternalEgressPolicy,
+			Rule:   InternalEgressRulePrefix + ruleNameSuffix,
+		},
+	}
 	// del internal ingress rule
-	err := datapathManager.RemoveEveroutePolicyRule(context.Background(), newInternalIngressRule(ip).RuleID, InternalIngressRulePrefix+ruleNameSuffix)
+	err := datapathManager.RemoveEveroutePolicyRule(context.Background(), newInternalIngressRule(ip).RuleID, ruleBase1)
 	if err != nil {
 		klog.Fatalf("Failed to del internal whitelist %s: %v", ip, err)
 	}
+
+	ruleBase2 := RuleBaseInfo{
+		Ref: PolicyRuleRef{
+			Policy: InternalEgressPolicy,
+			Rule:   InternalEgressRulePrefix + ruleNameSuffix,
+		},
+	}
 	// del internal egress rule
-	err = datapathManager.RemoveEveroutePolicyRule(context.Background(), newInternalEgressRule(ip).RuleID, InternalEgressRulePrefix+ruleNameSuffix)
+	err = datapathManager.RemoveEveroutePolicyRule(context.Background(), newInternalEgressRule(ip).RuleID, ruleBase2)
 	if err != nil {
 		klog.Fatalf("Failed to del internal whitelist %s: %v", ip, err)
 	}

--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -291,41 +291,80 @@ func testLocalEndpoint(t *testing.T) {
 
 func testERPolicyRule(t *testing.T) {
 	t.Run("check policy rule work mode", func(t *testing.T) {
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule1, "rule1", POLICY_DIRECTION_IN, POLICY_TIER2, DEFAULT_POLICY_ENFORCEMENT_MODE); err != nil {
+		baseInfo := RuleBaseInfo{
+			Ref:       PolicyRuleRef{Policy: "policy1", Rule: "rule1"},
+			Tier:      POLICY_TIER2,
+			Direction: POLICY_DIRECTION_IN,
+			Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule1, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule1, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule1.RuleID); item == nil {
+		if _, ok := datapathManager.Rules[rule1.RuleID]; !ok {
 			t.Errorf("Failed to add ER policy rule, not found %v in cache", rule1)
 		}
+		if datapathManager.policyRuleNums["policy1"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule1)
+		}
 
-		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule1.RuleID, "rule1"); err != nil {
+		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule1.RuleID, baseInfo); err != nil {
 			t.Errorf("Failed to remove ER policy rule: %v, error: %v", rule1, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule1.RuleID); item != nil {
-			t.Errorf("Failed to remove ER policy rule, rule %v in cache", rule1)
+		if _, ok := datapathManager.Rules[rule1.RuleID]; ok {
+			t.Errorf("Failed to remove ER policy rule %v in cache", rule1)
+		}
+		if _, ok := datapathManager.policyRuleNums["policy1"]; ok {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule1)
 		}
 
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, "rule2", POLICY_DIRECTION_OUT, POLICY_TIER1, DEFAULT_POLICY_ENFORCEMENT_MODE); err != nil {
+		baseInfo = RuleBaseInfo{
+			Ref:       PolicyRuleRef{Policy: "policy2", Rule: "rule2"},
+			Tier:      POLICY_TIER1,
+			Direction: POLICY_DIRECTION_OUT,
+			Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule2, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule2.RuleID); item == nil {
+		if _, ok := datapathManager.Rules[rule2.RuleID]; !ok {
 			t.Errorf("Failed to add ER policy rule, not found %v in cache", rule2)
 		}
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, "rule2", POLICY_DIRECTION_OUT, POLICY_TIER1, DEFAULT_POLICY_ENFORCEMENT_MODE); err != nil {
+		if datapathManager.policyRuleNums["policy2"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule2)
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule2, err)
 		}
+		if datapathManager.policyRuleNums["policy2"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule2)
+		}
 
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule3, "rule3", POLICY_DIRECTION_IN, POLICY_TIER_ECP, DEFAULT_POLICY_ENFORCEMENT_MODE); err != nil {
+		baseInfo = RuleBaseInfo{
+			Ref:       PolicyRuleRef{Policy: "policy2", Rule: "rule3"},
+			Tier:      POLICY_TIER_ECP,
+			Direction: POLICY_DIRECTION_IN,
+			Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule3, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule3, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule3.RuleID); item == nil {
+		if _, ok := datapathManager.Rules[rule3.RuleID]; !ok {
 			t.Errorf("Failed to add ER policy rule, not found %v in cache", rule3)
 		}
-		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule3.RuleID, "rule3"); err != nil {
+		if datapathManager.policyRuleNums["policy2"] != 2 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule3)
+		}
+		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule3.RuleID, baseInfo); err != nil {
 			t.Errorf("Failed to remove ER policy rule: %v, error: %v", rule3, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule3.RuleID); item != nil {
-			t.Errorf("Failed to remove ER policy rule, rule %v in cache", rule3)
+		if _, ok := datapathManager.Rules[rule3.RuleID]; ok {
+			t.Errorf("Failed to remove ER policy rule %v in cache", rule3)
+		}
+		if _, ok := datapathManager.policyRuleNums["policy3"]; ok {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule3)
+		}
+		if datapathManager.policyRuleNums["policy2"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule3)
 		}
 	})
 
@@ -343,7 +382,13 @@ func testERPolicyRule(t *testing.T) {
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
 				Action:     "allow",
 			}
-			err := datapathManager.AddEveroutePolicyRule(ctx, rule, rule.RuleID, POLICY_DIRECTION_IN, POLICY_TIER1, "monitor")
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy1", Rule: rule.RuleID},
+				Direction: POLICY_DIRECTION_IN,
+				Tier:      POLICY_TIER1,
+				Mode:      "monitor",
+			}
+			err := datapathManager.AddEveroutePolicyRule(ctx, rule, baseInfo)
 			Expect(err).Should(HaveOccurred())
 		})
 
@@ -358,14 +403,20 @@ func testERPolicyRule(t *testing.T) {
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
 				Action:     "allow",
 			}
-			err := datapathManager.AddEveroutePolicyRule(ctx, rule, rule.RuleID, POLICY_DIRECTION_IN, POLICY_TIER2, "monitor")
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy1", Rule: rule.RuleID},
+				Direction: POLICY_DIRECTION_IN,
+				Tier:      POLICY_TIER2,
+				Mode:      "monitor",
+			}
+			err := datapathManager.AddEveroutePolicyRule(ctx, rule, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(func() error {
 				return flowValidator([]string{
 					fmt.Sprintf("table=54, priority=%d,ip,nw_src=%s,nw_dst=%s,nw_proto=%d actions=load:0x->NXM_NX_XXREG0[4..31],load:0x->NXM_NX_XXREG0[0..3],goto_table:55", rule.Priority, rule.SrcIPAddr, rule.DstIPAddr, rule.IPProtocol),
 				})
 			}, timeout, interval).ShouldNot(HaveOccurred())
-			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, rule.RuleID)
+			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -380,14 +431,20 @@ func testERPolicyRule(t *testing.T) {
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
 				Action:     "allow",
 			}
-			err := datapathManager.AddEveroutePolicyRule(ctx, rule, rule.RuleID, POLICY_DIRECTION_IN, POLICY_TIER3, "monitor")
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy1", Rule: rule.RuleID},
+				Direction: POLICY_DIRECTION_IN,
+				Tier:      POLICY_TIER3,
+				Mode:      "monitor",
+			}
+			err := datapathManager.AddEveroutePolicyRule(ctx, rule, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(func() error {
 				return flowValidator([]string{
 					fmt.Sprintf("table=59, priority=%d,ip,nw_src=%s,nw_dst=%s,nw_proto=%d actions=load:0x->NXM_NX_XXREG0[32..59],load:0x->NXM_NX_XXREG0[0..3],goto_table:60", rule.Priority, rule.SrcIPAddr, rule.DstIPAddr, rule.IPProtocol),
 				})
 			}, timeout, interval).ShouldNot(HaveOccurred())
-			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, rule.RuleID)
+			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -402,14 +459,20 @@ func testERPolicyRule(t *testing.T) {
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
 				Action:     "deny",
 			}
-			err := datapathManager.AddEveroutePolicyRule(ctx, rule, rule.RuleID, POLICY_DIRECTION_IN, POLICY_TIER3, "monitor")
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy1", Rule: rule.RuleID},
+				Direction: POLICY_DIRECTION_IN,
+				Tier:      POLICY_TIER3,
+				Mode:      "monitor",
+			}
+			err := datapathManager.AddEveroutePolicyRule(ctx, rule, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(func() error {
 				return flowValidator([]string{
 					fmt.Sprintf("table=59, priority=%d,ip,nw_src=%s,nw_dst=%s,nw_proto=%d actions=load:0x->NXM_NX_XXREG0[32..59],load:0x->NXM_NX_XXREG0[126],load:0x->NXM_NX_XXREG0[0..3],goto_table:60", rule.Priority, rule.SrcIPAddr, rule.DstIPAddr, rule.IPProtocol),
 				})
 			}, timeout, interval).ShouldNot(HaveOccurred())
-			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, rule.RuleID)
+			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -424,14 +487,20 @@ func testERPolicyRule(t *testing.T) {
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
 				Action:     "deny",
 			}
-			err := datapathManager.AddEveroutePolicyRule(ctx, rule, rule.RuleID, POLICY_DIRECTION_OUT, POLICY_TIER3, "monitor")
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy1", Rule: rule.RuleID},
+				Direction: POLICY_DIRECTION_OUT,
+				Tier:      POLICY_TIER3,
+				Mode:      "monitor",
+			}
+			err := datapathManager.AddEveroutePolicyRule(ctx, rule, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(func() error {
 				return flowValidator([]string{
 					fmt.Sprintf("table=29, priority=%d,ip,nw_src=%s,nw_dst=%s,nw_proto=%d actions=load:0x->NXM_NX_XXREG0[32..59],load:0x->NXM_NX_XXREG0[126],load:0x->NXM_NX_XXREG0[0..3],goto_table:30", rule.Priority, rule.SrcIPAddr, rule.DstIPAddr, rule.IPProtocol),
 				})
 			}, timeout, interval).ShouldNot(HaveOccurred())
-			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, rule.RuleID)
+			err = datapathManager.RemoveEveroutePolicyRule(ctx, rule.RuleID, baseInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -447,27 +516,48 @@ func testPolicyTableInit(t *testing.T) {
 
 func testMonitorRule(t *testing.T) {
 	t.Run("test ER policy rule with monitor mode", func(t *testing.T) {
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule1, "rule1", POLICY_DIRECTION_IN, POLICY_TIER2, v1alpha1.MonitorMode.String()); err != nil {
+		baseInfo := RuleBaseInfo{
+			Ref:       PolicyRuleRef{Policy: "policy3", Rule: "rule1"},
+			Direction: POLICY_DIRECTION_IN,
+			Tier:      POLICY_TIER2,
+			Mode:      v1alpha1.MonitorMode.String(),
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule1, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule1, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule1.RuleID); item == nil {
+		if _, ok := datapathManager.Rules[rule1.RuleID]; !ok {
 			t.Errorf("Failed to add ER policy rule, not found %v in cache", rule1)
 		}
+		if datapathManager.policyRuleNums["policy3"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule1)
+		}
 
-		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule1.RuleID, "rule1"); err != nil {
+		if err := datapathManager.RemoveEveroutePolicyRule(ctx, rule1.RuleID, baseInfo); err != nil {
 			t.Errorf("Failed to remove ER policy rule: %v, error: %v", rule1, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule1.RuleID); item != nil {
-			t.Errorf("Failed to remove ER policy rule, rule %v in cache", rule1)
+		if _, ok := datapathManager.Rules[rule1.RuleID]; ok {
+			t.Errorf("Failed to remove ER policy rule, not found %v in cache", rule1)
+		}
+		if datapathManager.policyRuleNums["policy3"] != 0 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule1)
 		}
 
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, "rule2", POLICY_DIRECTION_OUT, POLICY_TIER1, v1alpha1.MonitorMode.String()); err != nil {
+		baseInfo = RuleBaseInfo{
+			Ref:       PolicyRuleRef{Policy: "policy3", Rule: "rule2"},
+			Direction: POLICY_DIRECTION_OUT,
+			Tier:      POLICY_TIER1,
+			Mode:      v1alpha1.MonitorMode.String(),
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule2, err)
 		}
-		if item := datapathManager.GetRuleEntryByRuleID(rule2.RuleID); item == nil {
+		if _, ok := datapathManager.Rules[rule2.RuleID]; !ok {
 			t.Errorf("Failed to add ER policy rule, not found %v in cache", rule2)
 		}
-		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, "rule2", POLICY_DIRECTION_OUT, POLICY_TIER1, v1alpha1.MonitorMode.String()); err != nil {
+		if datapathManager.policyRuleNums["policy3"] != 1 {
+			t.Errorf("Failed to update policyruleNums for rule %v", rule2)
+		}
+		if err := datapathManager.AddEveroutePolicyRule(ctx, rule2, baseInfo); err != nil {
 			t.Errorf("Failed to add ER policy rule: %v, error: %v", rule2, err)
 		}
 	})
@@ -482,7 +572,13 @@ func testFlowReplay(t *testing.T) {
 	t.Run("add ER policy rule", func(t *testing.T) {
 		Eventually(func() error {
 			log.Infof("add policy rule to datapath, tier: %d", POLICY_TIER3)
-			return datapathManager.AddEveroutePolicyRule(ctx, rule1, "rule1", POLICY_DIRECTION_IN, POLICY_TIER3, DEFAULT_POLICY_ENFORCEMENT_MODE)
+			baseInfo := RuleBaseInfo{
+				Ref:       PolicyRuleRef{Policy: "policy5", Rule: "rule1"},
+				Direction: POLICY_DIRECTION_IN,
+				Tier:      POLICY_TIER3,
+				Mode:      DEFAULT_POLICY_ENFORCEMENT_MODE,
+			}
+			return datapathManager.AddEveroutePolicyRule(ctx, rule1, baseInfo)
 		}, timeout, interval).Should(Succeed())
 	})
 

--- a/pkg/agent/datapath/utils.go
+++ b/pkg/agent/datapath/utils.go
@@ -237,7 +237,7 @@ func datapathRule2RpcRule(entry *EveroutePolicyRuleEntry) *v1alpha1.RuleEntry {
 	}
 	rpcReference := []*v1alpha1.PolicyRuleReference{}
 	for reference := range entry.PolicyRuleReference {
-		references := strings.Split(reference, "/")
+		references := strings.Split(reference.Rule, "/")
 		if len(references) < 3 {
 			continue
 		}
@@ -559,50 +559,10 @@ func (rule *EveroutePolicyRule) Clone() *EveroutePolicyRule {
 	}
 }
 
-func (e *EveroutePolicyRuleEntry) Clone() *EveroutePolicyRuleEntry {
-	if e == nil {
-		return nil
-	}
-	return &EveroutePolicyRuleEntry{
-		EveroutePolicyRule: e.EveroutePolicyRule.Clone(),
-		Direction:          e.Direction,
-		Tier:               e.Tier,
-		Mode:               e.Mode,
-		// RuleFlowMap will not update inner entry
-		RuleFlowMap:         DeepCopyMap(e.RuleFlowMap).(map[string]*FlowEntry),
-		PolicyRuleReference: e.PolicyRuleReference.Clone(),
-	}
-}
-
 func FlowKeyFromRuleName(ruleName string) string {
 	// rule name format like: policyname-rulename-namehash-flowkey
 	keys := strings.Split(ruleName, "-")
 	return keys[len(keys)-1]
-}
-
-func (dm *DpManager) GetRuleEntryByFlowID(id uint64) *EveroutePolicyRuleEntry {
-	items, err := dm.Rules.ByIndex(FlowIDIndex, strconv.FormatUint(id, 10))
-	if err == nil && len(items) == 1 {
-		return items[0].(*EveroutePolicyRuleEntry)
-	}
-	return nil
-}
-
-func (dm *DpManager) GetRuleEntryByRuleID(id string) *EveroutePolicyRuleEntry {
-	item, exist, err := dm.Rules.GetByKey(id)
-	if err == nil && exist && item != nil {
-		return item.(*EveroutePolicyRuleEntry)
-	}
-	return nil
-}
-
-func (dm *DpManager) ListRuleEntry() []*EveroutePolicyRuleEntry {
-	var ret []*EveroutePolicyRuleEntry
-	items := dm.Rules.List()
-	for _, item := range items {
-		ret = append(ret, item.(*EveroutePolicyRuleEntry))
-	}
-	return ret
 }
 
 // func (dm *DpManager) PolicyRuleLimit(policyIDs []string, addList, deleteList []*policycache.PolicyRule) bool {
@@ -637,14 +597,9 @@ func (dm *DpManager) PolicyRuleLimit(_ []string, _, _ []*policycache.PolicyRule)
 }
 
 func (dm *DpManager) PolicyRuleMetricsUpdate(policyIDs []string, limited bool) {
-	// update rule entry num
-	for _, policyID := range policyIDs {
-		rules, err := dm.Rules.ByIndex(PolicyRuleIndex, policyID)
-		if err != nil {
-			continue
-		}
-		dm.AgentMetric.SetRuleEntryNum(policyID, len(rules), limited)
+	for _, k := range policyIDs {
+		dm.AgentMetric.SetRuleEntryNum(k, dm.policyRuleNums[k], limited)
 	}
 
-	dm.AgentMetric.SetRuleEntryTotalNum(len(dm.ListRuleEntry()))
+	dm.AgentMetric.SetRuleEntryTotalNum(len(dm.Rules))
 }


### PR DESCRIPTION
分析
1. 内存分析发现很大一部分堆内存占用在更新datapath rule cache的index时，进一步测试发现是多层map占用内存较多（set由map实现），cache中index存储结构是 map{index_name: map{index_value: map{data_key: struct{}}，是1个三层的map结构。所以将datapath 中rule cache 改成 map 结构。
2. 原来cache 中包含两个index，flowid 查找 rule 通过另一个map存储；policy 关联的 rule 数量在datapath 增加删除 rule 时增量变更。
3. 修改过后发现，strings.split函数也会产生一定的内存占用，因为在rule entry中直接保存 policy 字段，避免strings.split 函数调用。
<img width="717" alt="image" src="https://github.com/user-attachments/assets/d8c84238-8cb6-4e76-98d9-8b33470a1660">

测试结果
优化前，20万条 rule ，在稳态时占用内存282MB，最高占用内存340MB（与节点上ct数量有关）
<img width="716" alt="image" src="https://github.com/user-attachments/assets/baf9fbea-c875-4a48-97d2-e97018ce5b33">
优化后，20万条rule， 在稳态时占用内存242MB，内存占用少了14%（40MB），最高占用289MB
<img width="716" alt="image" src="https://github.com/user-attachments/assets/6a5e5080-a4be-4439-b136-6a8227fa39ea">

