### PR TITLE
build: goproxy fallback on error

### DIFF
--- a/build/images/generate/Dockerfile
+++ b/build/images/generate/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.19
 
-ENV GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct
+ENV GOPROXY=https://goproxy.cn|https://proxy.golang.org|direct
 ENV K8S_VERSION=1.27.7
 RUN go install github.com/99designs/gqlgen@v0.17.16 && \
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 && \


### PR DESCRIPTION
Use next GOPROXY url if resources are existed but not useful