### PR TITLE
fix(er-1128): return local bridge ID in rpc server

### DIFF
--- a/pkg/agent/rpcserver/collector.go
+++ b/pkg/agent/rpcserver/collector.go
@@ -92,8 +92,12 @@ func (c *Collector) Policy(ctx context.Context, req *v1alpha1.PolicyRequest) (*v
 
 func (c *Collector) GetBridgeIndexWithFlowID(ctx context.Context, req *v1alpha1.BridgeIndexRequest) (*v1alpha1.BridgeIndexResponse, error) {
 	_ = ctx
-	bridgeIndex := c.dpManager.GetBridgeIndexWithFlowID(req.FlowID)
-	return &v1alpha1.BridgeIndexResponse{Index: bridgeIndex}, nil
+	bridgeIndexes := c.dpManager.GetBridgeIndexesWithFlowID(req.FlowID)
+	// Assert there is only one bridge index or empty.
+	if len(bridgeIndexes) == 0 {
+		return &v1alpha1.BridgeIndexResponse{Index: 0}, nil
+	}
+	return &v1alpha1.BridgeIndexResponse{Index: bridgeIndexes[0]}, nil
 }
 
 func NewCollectorServer(datapathManager *datapath.DpManager, stopChan <-chan struct{}) *Collector {


### PR DESCRIPTION
删掉了 FlowIDToVdsID，改为使用朴素实现。
在 BaseBridge上添加了一个函数：GetIndex，用来提供 bridge index