### PR TITLE
fix(ER-1519): use type alias without pointer to proxy unmarshal struct

### DIFF
--- a/pkg/apis/agent/v1alpha1/types.go
+++ b/pkg/apis/agent/v1alpha1/types.go
@@ -110,8 +110,15 @@ func (in *IPInfo) UnmarshalJSON(data []byte) error {
 	if err == nil {
 		return nil
 	}
-	type ipInfoAlias *IPInfo
-	return json.Unmarshal(data, ipInfoAlias(in))
+	// same as IPInfo
+	type ipInfoAlias IPInfo
+	alias := ipInfoAlias(*in)
+	err = json.Unmarshal(data, &alias)
+	if err != nil {
+		return err
+	}
+	*in = IPInfo(alias)
+	return nil
 }
 
 type AgentConditionType string


### PR DESCRIPTION
IPInfo 类型的 JSON 反序列化函数会在 JSON v2 中出现无限递归现象，提前修复此问题，避免未来升级 Go 编译器版本后出现问题。

http://jira.smartx.com/browse/ER-1519