### PR TITLE
fix(er-1678): start crc watch after tower cache sync

### DIFF
--- a/plugin/tower/pkg/register/manager.go
+++ b/plugin/tower/pkg/register/manager.go
@@ -134,7 +134,6 @@ func AddToManager(opts *Options, mgr manager.Manager) error {
 		return err
 	}
 	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		crcFactory.Start(ctx.Done())
 		opts.SharedFactory.Start(ctx.Done())
 		crdFactory.Start(ctx.Done())
 		k8sFactory.Start(ctx.Done())
@@ -144,7 +143,19 @@ func AddToManager(opts *Options, mgr manager.Manager) error {
 				klog.Fatalf("Failed to start cloudPlatform k8s apiServer manager: %s", err)
 			}
 		}()
-
+		go func() {
+			synced := opts.SharedFactory.WaitForCacheSync(ctx.Done())
+			if len(synced) == 0 {
+				klog.Fatalf("no started tower informers found before starting crc watcher")
+			}
+			for informerType, ok := range synced {
+				klog.Infof("tower informer %s cache sync result before starting crc watcher: %t", informerType, ok)
+				if !ok {
+					klog.Fatalf("tower informer %s cache sync failed before starting crc watcher", informerType)
+				}
+			}
+			crcFactory.Start(ctx.Done())
+		}()
 		go endpointController.Run(opts.WorkerNumber, ctx.Done())
 		go policyController.Run(opts.WorkerNumber, ctx.Done())
 		go globalController.Run(opts.WorkerNumber, ctx.Done())


### PR DESCRIPTION
修改方案：
tower-plugin 在 tower informer cache 同步后在启动 watch crc
自测：
启动 controller， leader 节点日志表明 cache 同步后启动 watch crc，之后产生 crc事件
<img width="1405" height="421" alt="image" src="https://github.com/user-attachments/assets/7f1c907e-2ed7-4f5b-bdac-7342351c53a7" />
也是在 cache 同步之后才有 endpoint 消费事件
<img width="1433" height="173" alt="image" src="https://github.com/user-attachments/assets/5ff53956-dfb2-4118-8452-759de6a60453" />

同时在环境中实际没有安全策略或虚拟机 网卡ip 变更的情况下，重启controller 在 everoute-agent 日志中也不会观察到安全策略流表变更
