### PR TITLE
fix(er-1680): serialize reflector store writes

### DIFF
--- a/plugin/tower/pkg/informer/reflector.go
+++ b/plugin/tower/pkg/informer/reflector.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
@@ -44,10 +45,11 @@ import (
 // NewReflectorBuilder return a NewReflectorFunc with giving client
 func NewReflectorBuilder(client *client.Client, crcEvent chan *CrcEvent) informer.NewReflectorFunc {
 	return func(options *informer.ReflectorOptions) informer.Reflector {
+		expectType := gqlType{reflect.TypeOf(options.ExpectedType)}
 		return &reflector{
 			client:     client,
 			store:      options.Store,
-			expectType: gqlType{reflect.TypeOf(options.ExpectedType)},
+			expectType: expectType,
 			// With these parameters, backoff will stop at [30,60) sec interval which is 0.22 QPS.
 			// If we don't backoff for 2min, assume server is healthy, and we reset the backoff.
 			//nolint:staticcheck
@@ -58,6 +60,10 @@ func NewReflectorBuilder(client *client.Client, crcEvent chan *CrcEvent) informe
 			reconnectMin:   time.Minute * 30,
 			reconnectMax:   time.Minute * 60,
 			crcEvent:       crcEvent,
+			storeEventQueue: workqueue.NewNamedRateLimitingQueue(
+				workqueue.DefaultControllerRateLimiter(),
+				fmt.Sprintf("tower-reflector-%s", expectType.TypeName()),
+			),
 		}
 	}
 }
@@ -93,6 +99,8 @@ type reflector struct {
 	clock clock.Clock
 
 	crcEvent chan *CrcEvent
+
+	storeEventQueue workqueue.RateLimitingInterface
 }
 
 // Run repeatedly fetch all the objects and subsequent deltas.
@@ -100,9 +108,15 @@ type reflector struct {
 func (r *reflector) Run(stopCh <-chan struct{}) {
 	klog.Infof("start reflector for object %s, with client %v", r.expectType.TypeName(), r.client.URL)
 	defer klog.Infof("stop reflector for object %s, with client %v", r.expectType.TypeName(), r.client.URL)
+	defer r.storeEventQueue.ShutDown()
 
 	go wait.BackoffUntil(r.reflectWorker(stopCh), r.backoffManager, true, stopCh)
 	go r.crcEventHandler(stopCh)
+	go ReconcileWorker(
+		fmt.Sprintf("tower-reflector-%s", r.expectType.TypeName()),
+		r.storeEventQueue,
+		r.processStoreEvent,
+	)()
 
 	<-stopCh
 }
@@ -117,33 +131,16 @@ func (r *reflector) crcEventHandler(stopCh <-chan struct{}) {
 	for {
 		select {
 		case event := <-r.crcEvent:
-			var newObj any
-			var err error
-			if event.NewObj != nil {
-				ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*10)
-				newObj, err = r.query(ctx, event.NewObj.GetID())
-				ctxCancel()
-				if err != nil || newObj == nil {
-					klog.Errorf("unable to query %s %s: %s", r.expectType, event.NewObj.GetID(), err)
-					continue
-				}
+			key := objectID(event.NewObj)
+			if key == "" {
+				key = objectID(event.OldObj)
 			}
-
-			klog.V(4).Infof("get %s crc event of type %s: new %+v old %+v",
-				event.EventType, r.expectType.TypeName(), newObj, event.OldObj)
-
-			switch event.EventType {
-			case CrcEventInsert:
-				_ = r.store.Add(newObj)
-			case CrcEventUpdate:
-				if newObj != nil {
-					_ = r.store.Update(newObj)
-				}
-			case CrcEventDelete:
-				_ = r.store.Delete(event.OldObj)
-			default:
-				klog.Infof("reflector %s unknown event %+v", r.expectType, event)
+			if key == "" {
+				klog.Infof("reflector %s skip crc event without key %+v", r.expectType, event)
+				continue
 			}
+			klog.V(4).Infof("get %s crc event of type %s, enqueue key %s", event.EventType, r.expectType.TypeName(), key)
+			r.storeEventQueue.Add(key)
 		case <-stopCh:
 			return
 		}
@@ -254,42 +251,103 @@ func (r *reflector) watchHandler(ctx context.Context, respCh <-chan client.Respo
 
 func (r *reflector) eventHandler(raw json.RawMessage) error {
 	var event schema.MutationEvent
-	var newObj = reflect.New(r.expectType.Type)
 
 	err := unmarshalEvent(r.expectType.Type, raw, &event)
 	if err != nil {
 		return fmt.Errorf("unable marshal %s into event %T", string(raw), event)
 	}
 
-	err = json.Unmarshal(event.Node, newObj.Interface())
+	key, err := r.eventKey(event)
 	if err != nil {
-		return fmt.Errorf("unable marshal %s into object %T", string(event.Node), r.expectType.TypeName())
+		return err
 	}
+	if key == "" {
+		klog.Infof("reflector %s skip subscription event without key %s", r.expectType, event.Mutation)
+		return nil
+	}
+	klog.V(4).Infof("get %s subscription event of type %s, enqueue key %s", event.Mutation, r.expectType.TypeName(), key)
+	r.storeEventQueue.Add(key)
+	return nil
+}
 
-	var obj = newObj.Elem().Interface()
+func (r *reflector) processStoreEvent(key string) error {
+	klog.V(8).Infof("process store event for type %s key %s", r.expectType.TypeName(), key)
 
-	// delete object may got nil object, read object from previous values
-	if reflect.ValueOf(obj).IsNil() && event.Mutation == schema.DeleteEvent {
-		err = json.Unmarshal(event.PreviousValues, newObj.Interface())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	obj, err := r.query(ctx, key)
+	if err != nil {
+		return fmt.Errorf("unable query %s %s: %w", r.expectType.TypeName(), key, err)
+	}
+	if obj == nil {
+		objWithKey, err := r.newObjWithKey(key)
 		if err != nil {
-			return fmt.Errorf("unable marshal %s into object %T for delete event", string(event.PreviousValues), r.expectType.TypeName())
+			return err
 		}
-		obj = newObj.Elem().Interface()
+		return r.store.Delete(objWithKey)
 	}
-	klog.V(4).Infof("get %s event of type %s: %v", event.Mutation, r.expectType.TypeName(), obj)
+	return r.store.Add(obj)
+}
 
-	switch event.Mutation {
-	case schema.CreateEvent:
-		err = r.store.Add(obj)
-	case schema.UpdateEvent:
-		err = r.store.Update(obj)
-	case schema.DeleteEvent:
-		err = r.store.Delete(obj)
-	default:
-		return fmt.Errorf("unknow mutation type: %s", event.Mutation)
+func (r *reflector) eventKey(event schema.MutationEvent) (string, error) {
+	key, err := r.objectKeyFromRaw(event.Node)
+	if err != nil {
+		return "", fmt.Errorf("unable marshal %s into object key for %T", string(event.Node), r.expectType.TypeName())
+	}
+	if key != "" {
+		return key, nil
 	}
 
-	return err
+	if event.Mutation == schema.DeleteEvent {
+		key, err = r.objectKeyFromRaw(event.PreviousValues)
+		if err != nil {
+			return "", fmt.Errorf("unable marshal %s into object key for delete event %T", string(event.PreviousValues), r.expectType.TypeName())
+		}
+	}
+	return key, nil
+}
+
+func (r *reflector) newObject() any {
+	realType := r.expectType.Type
+	for realType.Kind() == reflect.Ptr {
+		realType = realType.Elem()
+	}
+	return reflect.New(realType).Interface()
+}
+
+func (r *reflector) newObjWithKey(key string) (any, error) {
+	obj := r.newObject()
+	keySetter, ok := obj.(schema.KeySettable)
+	if !ok {
+		return nil, fmt.Errorf("object type %s doesn't implement schema.KeySettable, key: %s", r.expectType.TypeName(), key)
+	}
+	keySetter.SetKey(key)
+	return obj, nil
+}
+
+func (r *reflector) objectKeyFromRaw(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	obj := r.newObject()
+	if err := json.Unmarshal(raw, obj); err != nil {
+		return "", err
+	}
+	return objectID(obj), nil
+}
+
+func objectID(obj any) string {
+	if obj == nil {
+		return ""
+	}
+	if resource, ok := obj.(schema.Object); ok {
+		value := reflect.ValueOf(resource)
+		if value.Kind() != reflect.Ptr || !value.IsNil() {
+			return resource.GetID()
+		}
+	}
+	return ""
 }
 
 func (r *reflector) watchErrorHandler(ctx context.Context, respErrs []client.ResponseError, err error) {
@@ -406,6 +464,11 @@ type Queryable interface {
 	GetQueryRequest(skipFields map[string][]string) string
 }
 
+// QueryByIDRequestable allows customizing the query used for a single object lookup.
+type QueryByIDRequestable interface {
+	GetQueryRequestWithID(id string, skipFields map[string][]string) string
+}
+
 // Subscribable allow to mutate the default subscription request
 type Subscribable interface {
 	GetSubscriptionRequest(skipFields map[string][]string) string
@@ -425,6 +488,10 @@ func (r *reflector) queryRequest() *client.Request {
 }
 
 func (r *reflector) queryRequestWithID(id string) *client.Request {
+	if t, ok := r.newObject().(QueryByIDRequestable); ok {
+		return &client.Request{Query: t.GetQueryRequestWithID(id, r.skipFields)}
+	}
+
 	return &client.Request{
 		Query: fmt.Sprintf("query {%s(where:{id:\"%s\"}) %s}", r.expectType.ListName(), id, r.expectType.QueryFields(r.skipFields))}
 }

--- a/plugin/tower/pkg/informer/reflector.go
+++ b/plugin/tower/pkg/informer/reflector.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
@@ -44,10 +45,15 @@ import (
 // NewReflectorBuilder return a NewReflectorFunc with giving client
 func NewReflectorBuilder(client *client.Client, crcEvent chan *CrcEvent) informer.NewReflectorFunc {
 	return func(options *informer.ReflectorOptions) informer.Reflector {
-		return &reflector{
-			client:     client,
-			store:      options.Store,
-			expectType: gqlType{reflect.TypeOf(options.ExpectedType)},
+		expectType := gqlType{reflect.TypeOf(options.ExpectedType)}
+		queryRequestFn, queryRequestWithIDFn, subscriptionRequestFn := buildRequestFuncs(expectType.Type)
+		r := &reflector{
+			client:                client,
+			store:                 options.Store,
+			expectType:            expectType,
+			queryRequestFn:        queryRequestFn,
+			queryRequestWithIDFn:  queryRequestWithIDFn,
+			subscriptionRequestFn: subscriptionRequestFn,
 			// With these parameters, backoff will stop at [30,60) sec interval which is 0.22 QPS.
 			// If we don't backoff for 2min, assume server is healthy, and we reset the backoff.
 			//nolint:staticcheck
@@ -58,7 +64,15 @@ func NewReflectorBuilder(client *client.Client, crcEvent chan *CrcEvent) informe
 			reconnectMin:   time.Minute * 30,
 			reconnectMax:   time.Minute * 60,
 			crcEvent:       crcEvent,
+			storeEventQueue: workqueue.NewNamedRateLimitingQueue(
+				workqueue.DefaultControllerRateLimiter(),
+				fmt.Sprintf("tower-reflector-%s", expectType.TypeName()),
+			),
 		}
+		if r.newObject() == nil {
+			klog.Fatalf("object type %s doesn't implement schema.Object", expectType.TypeName())
+		}
+		return r
 	}
 }
 
@@ -72,6 +86,10 @@ type reflector struct {
 
 	// An example object of the type we expect to place in the store.
 	expectType gqlType
+	// Optional custom request builders cached at initialization.
+	queryRequestFn        func(skipFields map[string][]string) string
+	queryRequestWithIDFn  func(id string, skipFields map[string][]string) string
+	subscriptionRequestFn func(skipFields map[string][]string) string
 
 	// skipFields contains map with type name and skipped fields.
 	// When got field not exist error, we skip the fields
@@ -93,6 +111,31 @@ type reflector struct {
 	clock clock.Clock
 
 	crcEvent chan *CrcEvent
+
+	storeEventQueue workqueue.RateLimitingInterface
+}
+
+func buildRequestFuncs(expectedType reflect.Type) (
+	func(skipFields map[string][]string) string,
+	func(id string, skipFields map[string][]string) string,
+	func(skipFields map[string][]string) string,
+) {
+	var (
+		queryFn     func(skipFields map[string][]string) string
+		queryByIDFn func(id string, skipFields map[string][]string) string
+		subscribeFn func(skipFields map[string][]string) string
+	)
+	sample := reflect.New(expectedType).Elem().Interface()
+	if t, ok := sample.(Queryable); ok {
+		queryFn = t.GetQueryRequest
+	}
+	if t, ok := sample.(QueryByIDRequestable); ok {
+		queryByIDFn = t.GetQueryRequestWithID
+	}
+	if t, ok := sample.(Subscribable); ok {
+		subscribeFn = t.GetSubscriptionRequest
+	}
+	return queryFn, queryByIDFn, subscribeFn
 }
 
 // Run repeatedly fetch all the objects and subsequent deltas.
@@ -100,9 +143,15 @@ type reflector struct {
 func (r *reflector) Run(stopCh <-chan struct{}) {
 	klog.Infof("start reflector for object %s, with client %v", r.expectType.TypeName(), r.client.URL)
 	defer klog.Infof("stop reflector for object %s, with client %v", r.expectType.TypeName(), r.client.URL)
+	defer r.storeEventQueue.ShutDown()
 
 	go wait.BackoffUntil(r.reflectWorker(stopCh), r.backoffManager, true, stopCh)
 	go r.crcEventHandler(stopCh)
+	go ReconcileWorker(
+		fmt.Sprintf("tower-reflector-%s", r.expectType.TypeName()),
+		r.storeEventQueue,
+		r.processStoreEvent,
+	)()
 
 	<-stopCh
 }
@@ -117,33 +166,16 @@ func (r *reflector) crcEventHandler(stopCh <-chan struct{}) {
 	for {
 		select {
 		case event := <-r.crcEvent:
-			var newObj any
-			var err error
-			if event.NewObj != nil {
-				ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*10)
-				newObj, err = r.query(ctx, event.NewObj.GetID())
-				ctxCancel()
-				if err != nil || newObj == nil {
-					klog.Errorf("unable to query %s %s: %s", r.expectType, event.NewObj.GetID(), err)
-					continue
-				}
+			key := objectID(event.NewObj)
+			if key == "" {
+				key = objectID(event.OldObj)
 			}
-
-			klog.V(4).Infof("get %s crc event of type %s: new %+v old %+v",
-				event.EventType, r.expectType.TypeName(), newObj, event.OldObj)
-
-			switch event.EventType {
-			case CrcEventInsert:
-				_ = r.store.Add(newObj)
-			case CrcEventUpdate:
-				if newObj != nil {
-					_ = r.store.Update(newObj)
-				}
-			case CrcEventDelete:
-				_ = r.store.Delete(event.OldObj)
-			default:
-				klog.Infof("reflector %s unknown event %+v", r.expectType, event)
+			if key == "" {
+				klog.Infof("reflector %s skip crc event without key %+v", r.expectType, event)
+				continue
 			}
+			klog.V(4).Infof("get %s crc event of type %s, enqueue key %s", event.EventType, r.expectType.TypeName(), key)
+			r.storeEventQueue.Add(key)
 		case <-stopCh:
 			return
 		}
@@ -254,42 +286,100 @@ func (r *reflector) watchHandler(ctx context.Context, respCh <-chan client.Respo
 
 func (r *reflector) eventHandler(raw json.RawMessage) error {
 	var event schema.MutationEvent
-	var newObj = reflect.New(r.expectType.Type)
 
 	err := unmarshalEvent(r.expectType.Type, raw, &event)
 	if err != nil {
 		return fmt.Errorf("unable marshal %s into event %T", string(raw), event)
 	}
 
-	err = json.Unmarshal(event.Node, newObj.Interface())
+	key, err := r.eventKey(event)
 	if err != nil {
-		return fmt.Errorf("unable marshal %s into object %T", string(event.Node), r.expectType.TypeName())
+		return err
+	}
+	if key == "" {
+		klog.Infof("reflector %s skip subscription event without key %s", r.expectType, event.Mutation)
+		return nil
+	}
+	klog.V(4).Infof("get %s subscription event of type %s, enqueue key %s", event.Mutation, r.expectType.TypeName(), key)
+	r.storeEventQueue.Add(key)
+	return nil
+}
+
+func (r *reflector) processStoreEvent(key string) error {
+	klog.V(8).Infof("process store event for type %s key %s", r.expectType.TypeName(), key)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	obj, err := r.query(ctx, key)
+	if err != nil {
+		return fmt.Errorf("unable query %s %s: %w", r.expectType.TypeName(), key, err)
+	}
+	if obj == nil {
+		objWithID := r.newObjectWithID(key)
+		return r.store.Delete(objWithID)
+	}
+	return r.store.Add(obj)
+}
+
+func (r *reflector) eventKey(event schema.MutationEvent) (string, error) {
+	key, err := r.objectKeyFromRaw(event.Node)
+	if err != nil {
+		return "", fmt.Errorf("unable marshal %s into object key for %T", string(event.Node), r.expectType.TypeName())
+	}
+	if key != "" {
+		return key, nil
 	}
 
-	var obj = newObj.Elem().Interface()
-
-	// delete object may got nil object, read object from previous values
-	if reflect.ValueOf(obj).IsNil() && event.Mutation == schema.DeleteEvent {
-		err = json.Unmarshal(event.PreviousValues, newObj.Interface())
+	if event.Mutation == schema.DeleteEvent {
+		key, err = r.objectKeyFromRaw(event.PreviousValues)
 		if err != nil {
-			return fmt.Errorf("unable marshal %s into object %T for delete event", string(event.PreviousValues), r.expectType.TypeName())
+			return "", fmt.Errorf("unable marshal %s into object key for delete event %T", string(event.PreviousValues), r.expectType.TypeName())
 		}
-		obj = newObj.Elem().Interface()
 	}
-	klog.V(4).Infof("get %s event of type %s: %v", event.Mutation, r.expectType.TypeName(), obj)
+	return key, nil
+}
 
-	switch event.Mutation {
-	case schema.CreateEvent:
-		err = r.store.Add(obj)
-	case schema.UpdateEvent:
-		err = r.store.Update(obj)
-	case schema.DeleteEvent:
-		err = r.store.Delete(obj)
-	default:
-		return fmt.Errorf("unknow mutation type: %s", event.Mutation)
+func (r *reflector) newObject() schema.Object {
+	realType := r.expectType.Type
+	for realType.Kind() == reflect.Ptr {
+		realType = realType.Elem()
 	}
+	obj, _ := reflect.New(realType).Interface().(schema.Object)
+	return obj
+}
 
-	return err
+func (r *reflector) newObjectWithID(id string) schema.Object {
+	obj := r.newObject()
+	obj.SetID(id)
+	return obj
+}
+
+func (r *reflector) objectKeyFromRaw(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	obj := r.newObject()
+	if obj == nil {
+		return "", fmt.Errorf("object type %s doesn't implement schema.Object", r.expectType.TypeName())
+	}
+	if err := json.Unmarshal(raw, obj); err != nil {
+		return "", err
+	}
+	return objectID(obj), nil
+}
+
+func objectID(obj any) string {
+	if obj == nil {
+		return ""
+	}
+	if resource, ok := obj.(schema.Object); ok {
+		value := reflect.ValueOf(resource)
+		if value.Kind() != reflect.Ptr || !value.IsNil() {
+			return resource.GetID()
+		}
+	}
+	return ""
 }
 
 func (r *reflector) watchErrorHandler(ctx context.Context, respErrs []client.ResponseError, err error) {
@@ -406,40 +496,41 @@ type Queryable interface {
 	GetQueryRequest(skipFields map[string][]string) string
 }
 
+// QueryByIDRequestable allows customizing the query used for a single object lookup.
+type QueryByIDRequestable interface {
+	GetQueryRequestWithID(id string, skipFields map[string][]string) string
+}
+
 // Subscribable allow to mutate the default subscription request
 type Subscribable interface {
 	GetSubscriptionRequest(skipFields map[string][]string) string
 }
 
 func (r *reflector) queryRequest() *client.Request {
-	var queryRequest string
-
-	switch t := reflect.New(r.expectType.Type).Elem().Interface().(type) {
-	case Queryable:
-		queryRequest = t.GetQueryRequest(r.skipFields)
-	default:
-		queryRequest = fmt.Sprintf("query {%s %s}", r.expectType.ListName(), r.expectType.QueryFields(r.skipFields))
+	if r.queryRequestFn != nil {
+		return &client.Request{Query: r.queryRequestFn(r.skipFields)}
 	}
-
-	return &client.Request{Query: queryRequest}
+	return &client.Request{
+		Query: fmt.Sprintf("query {%s %s}", r.expectType.ListName(), r.expectType.QueryFields(r.skipFields)),
+	}
 }
 
 func (r *reflector) queryRequestWithID(id string) *client.Request {
+	if r.queryRequestWithIDFn != nil {
+		return &client.Request{Query: r.queryRequestWithIDFn(id, r.skipFields)}
+	}
+
 	return &client.Request{
 		Query: fmt.Sprintf("query {%s(where:{id:\"%s\"}) %s}", r.expectType.ListName(), id, r.expectType.QueryFields(r.skipFields))}
 }
 
 func (r *reflector) subscriptionRequest() *client.Request {
-	var subscriptionRequest string
-
-	switch t := reflect.New(r.expectType.Type).Elem().Interface().(type) {
-	case Subscribable:
-		subscriptionRequest = t.GetSubscriptionRequest(r.skipFields)
-	default:
-		subscriptionRequest = fmt.Sprintf("subscription {%s {mutation previousValues{id} node %s}}", r.expectType.TypeName(), r.expectType.QueryFields(r.skipFields))
+	if r.subscriptionRequestFn != nil {
+		return &client.Request{Query: r.subscriptionRequestFn(r.skipFields)}
 	}
-
-	return &client.Request{Query: subscriptionRequest}
+	return &client.Request{
+		Query: fmt.Sprintf("subscription {%s {mutation previousValues{id} node %s}}", r.expectType.TypeName(), r.expectType.QueryFields(r.skipFields)),
+	}
 }
 
 type gqlType struct {

--- a/plugin/tower/pkg/informer/reflector_test.go
+++ b/plugin/tower/pkg/informer/reflector_test.go
@@ -18,6 +18,7 @@ package informer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -25,8 +26,10 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	"github.com/everoute/everoute/plugin/tower/pkg/schema"
 	"github.com/everoute/everoute/plugin/tower/pkg/server/fake"
 	. "github.com/everoute/everoute/plugin/tower/pkg/utils/testing"
 	"github.com/everoute/everoute/plugin/tower/third_party/forked/client-go/informer"
@@ -69,6 +72,10 @@ type VM struct {
 	FieldNotFound string `json:"field_not_found"`
 }
 
+func (v *VM) GetID() string { return v.ID }
+
+func (v *VM) SetID(id string) { v.ID = id }
+
 func TestReflectorWithNotExistField(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -100,6 +107,10 @@ type UnExpectedObject struct {
 	ID string `json:"id"`
 }
 
+func (o *UnExpectedObject) GetID() string { return o.ID }
+
+func (o *UnExpectedObject) SetID(id string) { o.ID = id }
+
 func TestReflectorWithNotExistObject(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -120,4 +131,157 @@ func TestReflectorWithNotExistObject(t *testing.T) {
 	go newReflector.Run(ctx.Done())
 
 	Eventually(objectFIFO.HasSynced, 60).Should(BeTrue())
+}
+
+func TestReflectorSubscriptionEventHandlerQueueByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	vm := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-1"},
+		Name:       "from-query",
+		Status:     schema.VMStatusRunning,
+	}
+	server.TrackerFactory().VM().CreateOrUpdate(vm)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test-subscription")
+	defer queue.ShutDown()
+	r := &reflector{
+		client:          server.NewClient(),
+		store:           objectStore,
+		expectType:      gqlType{reflect.TypeOf(&schema.VM{})},
+		storeEventQueue: queue,
+	}
+	go ReconcileWorker("test-subscription", queue, r.processStoreEvent)()
+
+	raw, err := json.Marshal(map[string]any{
+		"mutation": schema.CreateEvent,
+		"node": map[string]any{
+			"id":     vm.ID,
+			"name":   "from-event",
+			"status": schema.VMStatusStopped,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	if err := r.eventHandler(raw); err != nil {
+		t.Fatalf("handle event: %v", err)
+	}
+
+	Eventually(func() string {
+		got, exists, err := objectStore.GetByKey(vm.ID)
+		if err != nil || !exists {
+			return ""
+		}
+		return got.(*schema.VM).Name
+	}, 10*time.Second, 100*time.Millisecond).Should(Equal("from-query"))
+}
+
+func TestReflectorCRCEventHandlerQueueByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	vm := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-2"},
+		Name:       "from-query",
+		Status:     schema.VMStatusRunning,
+	}
+	server.TrackerFactory().VM().CreateOrUpdate(vm)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test-crc")
+	defer queue.ShutDown()
+	crcEventCh := make(chan *CrcEvent, 1)
+	r := &reflector{
+		client:          server.NewClient(),
+		store:           objectStore,
+		expectType:      gqlType{reflect.TypeOf(&schema.VM{})},
+		crcEvent:        crcEventCh,
+		storeEventQueue: queue,
+	}
+	go ReconcileWorker("test-crc", queue, r.processStoreEvent)()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go r.crcEventHandler(stopCh)
+
+	crcEventCh <- &CrcEvent{
+		EventType: CrcEventInsert,
+		NewObj: &schema.VM{
+			ObjectMeta: schema.ObjectMeta{ID: vm.ID},
+			Name:       "from-event",
+			Status:     schema.VMStatusStopped,
+		},
+	}
+
+	Eventually(func() string {
+		got, exists, err := objectStore.GetByKey(vm.ID)
+		if err != nil || !exists {
+			return ""
+		}
+		return got.(*schema.VM).Name
+	}, 10*time.Second, 100*time.Millisecond).Should(Equal("from-query"))
+}
+
+func TestReflectorProcessStoreEventDeleteByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+
+	obj := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-3"},
+		Name:       "stale",
+		Status:     schema.VMStatusRunning,
+	}
+	if err := objectStore.Add(obj); err != nil {
+		t.Fatalf("add stale object: %v", err)
+	}
+
+	if err := objectStore.Delete(&schema.VM{ObjectMeta: schema.ObjectMeta{ID: obj.ID}}); err != nil {
+		t.Fatalf("delete by key tombstone: %v", err)
+	}
+	if _, exists, err := objectStore.GetByKey(obj.ID); err != nil || exists {
+		t.Fatalf("expected object deleted, exists=%t err=%v", exists, err)
+	}
+}
+
+func TestReflectorProcessStoreEventDeleteByKeyWhenQueryMissing(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	obj := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-delete-by-query-miss"},
+		Name:       "stale",
+		Status:     schema.VMStatusRunning,
+	}
+	if err := objectStore.Add(obj); err != nil {
+		t.Fatalf("add stale object: %v", err)
+	}
+
+	r := &reflector{
+		client:     server.NewClient(),
+		store:      objectStore,
+		expectType: gqlType{reflect.TypeOf(&schema.VM{})},
+	}
+
+	if err := r.processStoreEvent(obj.ID); err != nil {
+		t.Fatalf("processStoreEvent returned error: %v", err)
+	}
+
+	if _, exists, err := objectStore.GetByKey(obj.ID); err != nil || exists {
+		t.Fatalf("expected object deleted by processStoreEvent, exists=%t err=%v", exists, err)
+	}
 }

--- a/plugin/tower/pkg/informer/reflector_test.go
+++ b/plugin/tower/pkg/informer/reflector_test.go
@@ -18,15 +18,19 @@ package informer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
+	"github.com/everoute/everoute/plugin/tower/pkg/schema"
 	"github.com/everoute/everoute/plugin/tower/pkg/server/fake"
 	. "github.com/everoute/everoute/plugin/tower/pkg/utils/testing"
 	"github.com/everoute/everoute/plugin/tower/third_party/forked/client-go/informer"
@@ -120,4 +124,195 @@ func TestReflectorWithNotExistObject(t *testing.T) {
 	go newReflector.Run(ctx.Done())
 
 	Eventually(objectFIFO.HasSynced, 60).Should(BeTrue())
+}
+
+func TestReflectorSubscriptionEventHandlerQueueByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	vm := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-1"},
+		Name:       "from-query",
+		Status:     schema.VMStatusRunning,
+	}
+	server.TrackerFactory().VM().CreateOrUpdate(vm)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test-subscription")
+	defer queue.ShutDown()
+	r := &reflector{
+		client:          server.NewClient(),
+		store:           objectStore,
+		expectType:      gqlType{reflect.TypeOf(&schema.VM{})},
+		storeEventQueue: queue,
+	}
+	go ReconcileWorker("test-subscription", queue, r.processStoreEvent)()
+
+	raw, err := json.Marshal(map[string]any{
+		"mutation": schema.CreateEvent,
+		"node": map[string]any{
+			"id":     vm.ID,
+			"name":   "from-event",
+			"status": schema.VMStatusStopped,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	if err := r.eventHandler(raw); err != nil {
+		t.Fatalf("handle event: %v", err)
+	}
+
+	Eventually(func() string {
+		got, exists, err := objectStore.GetByKey(vm.ID)
+		if err != nil || !exists {
+			return ""
+		}
+		return got.(*schema.VM).Name
+	}, 10*time.Second, 100*time.Millisecond).Should(Equal("from-query"))
+}
+
+func TestReflectorCRCEventHandlerQueueByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	vm := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-2"},
+		Name:       "from-query",
+		Status:     schema.VMStatusRunning,
+	}
+	server.TrackerFactory().VM().CreateOrUpdate(vm)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test-crc")
+	defer queue.ShutDown()
+	crcEventCh := make(chan *CrcEvent, 1)
+	r := &reflector{
+		client:          server.NewClient(),
+		store:           objectStore,
+		expectType:      gqlType{reflect.TypeOf(&schema.VM{})},
+		crcEvent:        crcEventCh,
+		storeEventQueue: queue,
+	}
+	go ReconcileWorker("test-crc", queue, r.processStoreEvent)()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go r.crcEventHandler(stopCh)
+
+	crcEventCh <- &CrcEvent{
+		EventType: CrcEventInsert,
+		NewObj: &schema.VM{
+			ObjectMeta: schema.ObjectMeta{ID: vm.ID},
+			Name:       "from-event",
+			Status:     schema.VMStatusStopped,
+		},
+	}
+
+	Eventually(func() string {
+		got, exists, err := objectStore.GetByKey(vm.ID)
+		if err != nil || !exists {
+			return ""
+		}
+		return got.(*schema.VM).Name
+	}, 10*time.Second, 100*time.Millisecond).Should(Equal("from-query"))
+}
+
+func TestReflectorProcessStoreEventDeleteByKey(t *testing.T) {
+	RegisterTestingT(t)
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+
+	obj := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-3"},
+		Name:       "stale",
+		Status:     schema.VMStatusRunning,
+	}
+	if err := objectStore.Add(obj); err != nil {
+		t.Fatalf("add stale object: %v", err)
+	}
+
+	if err := objectStore.Delete(&schema.VM{ObjectMeta: schema.ObjectMeta{ID: obj.ID}}); err != nil {
+		t.Fatalf("delete by key tombstone: %v", err)
+	}
+	if _, exists, err := objectStore.GetByKey(obj.ID); err != nil || exists {
+		t.Fatalf("expected object deleted, exists=%t err=%v", exists, err)
+	}
+}
+
+func TestReflectorProcessStoreEventDeleteByKeyWhenQueryMissing(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	objectStore := cache.NewIndexer(func(obj interface{}) (string, error) { return obj.(*schema.VM).ID, nil }, nil)
+	obj := &schema.VM{
+		ObjectMeta: schema.ObjectMeta{ID: "vm-delete-by-query-miss"},
+		Name:       "stale",
+		Status:     schema.VMStatusRunning,
+	}
+	if err := objectStore.Add(obj); err != nil {
+		t.Fatalf("add stale object: %v", err)
+	}
+
+	r := &reflector{
+		client:     server.NewClient(),
+		store:      objectStore,
+		expectType: gqlType{reflect.TypeOf(&schema.VM{})},
+	}
+
+	if err := r.processStoreEvent(obj.ID); err != nil {
+		t.Fatalf("processStoreEvent returned error: %v", err)
+	}
+
+	if _, exists, err := objectStore.GetByKey(obj.ID); err != nil || exists {
+		t.Fatalf("expected object deleted by processStoreEvent, exists=%t err=%v", exists, err)
+	}
+}
+
+type noKeySettableObject struct {
+	ID string `json:"id"`
+}
+
+func (noKeySettableObject) GetQueryRequestWithID(id string, _ map[string][]string) string {
+	return fmt.Sprintf(`query {vms(where:{id:"%s"}) {id}}`, id)
+}
+
+func (noKeySettableObject) UnmarshalSlice(_ json.RawMessage, _ interface{}) error {
+	return nil
+}
+
+func TestReflectorProcessStoreEventReturnErrorWhenObjectNotKeySettable(t *testing.T) {
+	RegisterTestingT(t)
+
+	server := fake.NewServer(nil)
+	server.Serve()
+	defer server.Stop()
+
+	key := "non-keysettable-id"
+	r := &reflector{
+		client:     server.NewClient(),
+		store:      cache.NewIndexer(TowerObjectKey, nil),
+		expectType: gqlType{reflect.TypeOf(noKeySettableObject{})},
+	}
+
+	err := r.processStoreEvent(key)
+	if err == nil {
+		t.Fatalf("expected error when object doesn't implement schema.KeySettable")
+	}
+	if !strings.Contains(err.Error(), key) {
+		t.Fatalf("expected error to contain key %q, got %v", key, err)
+	}
+	if !strings.Contains(err.Error(), "schema.KeySettable") {
+		t.Fatalf("expected error to mention schema.KeySettable, got %v", err)
+	}
 }

--- a/plugin/tower/pkg/schema/meta.go
+++ b/plugin/tower/pkg/schema/meta.go
@@ -20,6 +20,8 @@ package schema
 type Object interface {
 	// GetID returns the object ID.
 	GetID() string
+	// SetID sets the object ID.
+	SetID(string)
 }
 
 // ObjectMeta is metadata that all tower resources must have.
@@ -30,6 +32,9 @@ type ObjectMeta struct {
 
 // GetID returns the object ID.
 func (obj *ObjectMeta) GetID() string { return obj.ID }
+
+// SetID sets object ID for objects using ObjectMeta as identity.
+func (obj *ObjectMeta) SetID(id string) { obj.ID = id }
 
 // ObjectReference is the reference to other object
 type ObjectReference ObjectMeta

--- a/plugin/tower/pkg/schema/meta.go
+++ b/plugin/tower/pkg/schema/meta.go
@@ -22,6 +22,11 @@ type Object interface {
 	GetID() string
 }
 
+// KeySettable allows setting key information for tombstone objects.
+type KeySettable interface {
+	SetKey(string)
+}
+
 // ObjectMeta is metadata that all tower resources must have.
 type ObjectMeta struct {
 	// ID is the unique in time and space value for this object
@@ -30,6 +35,9 @@ type ObjectMeta struct {
 
 // GetID returns the object ID.
 func (obj *ObjectMeta) GetID() string { return obj.ID }
+
+// SetKey sets object key for objects using ObjectMeta as identity.
+func (obj *ObjectMeta) SetKey(id string) { obj.ID = id }
 
 // ObjectReference is the reference to other object
 type ObjectReference ObjectMeta

--- a/plugin/tower/pkg/schema/policy_types.go
+++ b/plugin/tower/pkg/schema/policy_types.go
@@ -172,6 +172,11 @@ func (s *SystemEndpoints) GetSubscriptionRequest(skipFields map[string][]string)
 	return fmt.Sprintf("subscription {systemEndpoints %s}", subscriptionFields)
 }
 
+func (s *SystemEndpoints) GetQueryRequestWithID(_ string, skipFields map[string][]string) string {
+	queryFields := utils.GqlTypeMarshal(reflect.TypeOf(s), skipFields, true)
+	return fmt.Sprintf("query {systemEndpoints %s}", queryFields)
+}
+
 func (s *SystemEndpoints) UnmarshalEvent(raw json.RawMessage, event *MutationEvent) error {
 	event.Mutation = UpdateEvent
 	event.Node = raw
@@ -198,6 +203,9 @@ func (s *SystemEndpoints) UnmarshalSlice(raw json.RawMessage, slice interface{})
 func (*SystemEndpoints) GetID() string {
 	return "systemEndpoints"
 }
+
+// SetID is a no-op because SystemEndpoints identity is fixed.
+func (*SystemEndpoints) SetID(string) {}
 
 type IDSystemEndpoint struct {
 	Key  string `json:"key"`

--- a/plugin/tower/pkg/schema/policy_types.go
+++ b/plugin/tower/pkg/schema/policy_types.go
@@ -172,6 +172,11 @@ func (s *SystemEndpoints) GetSubscriptionRequest(skipFields map[string][]string)
 	return fmt.Sprintf("subscription {systemEndpoints %s}", subscriptionFields)
 }
 
+func (s *SystemEndpoints) GetQueryRequestWithID(_ string, skipFields map[string][]string) string {
+	queryFields := utils.GqlTypeMarshal(reflect.TypeOf(s), skipFields, true)
+	return fmt.Sprintf("query {systemEndpoints %s}", queryFields)
+}
+
 func (s *SystemEndpoints) UnmarshalEvent(raw json.RawMessage, event *MutationEvent) error {
 	event.Mutation = UpdateEvent
 	event.Node = raw
@@ -198,6 +203,9 @@ func (s *SystemEndpoints) UnmarshalSlice(raw json.RawMessage, slice interface{})
 func (*SystemEndpoints) GetID() string {
 	return "systemEndpoints"
 }
+
+// SetKey is a no-op because SystemEndpoints identity is fixed.
+func (*SystemEndpoints) SetKey(string) {}
 
 type IDSystemEndpoint struct {
 	Key  string `json:"key"`

--- a/plugin/tower/pkg/server/fake/graph/generated/generated.go
+++ b/plugin/tower/pkg/server/fake/graph/generated/generated.go
@@ -204,16 +204,16 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		EverouteClusters          func(childComplexity int) int
-		Hosts                     func(childComplexity int) int
-		IsolationPolicies         func(childComplexity int) int
-		Labels                    func(childComplexity int) int
-		NetworkPolicyRuleServices func(childComplexity int) int
-		SecurityGroups            func(childComplexity int) int
-		SecurityPolicies          func(childComplexity int) int
+		EverouteClusters          func(childComplexity int, where *model.ObjectWhereInput) int
+		Hosts                     func(childComplexity int, where *model.ObjectWhereInput) int
+		IsolationPolicies         func(childComplexity int, where *model.ObjectWhereInput) int
+		Labels                    func(childComplexity int, where *model.ObjectWhereInput) int
+		NetworkPolicyRuleServices func(childComplexity int, where *model.ObjectWhereInput) int
+		SecurityGroups            func(childComplexity int, where *model.ObjectWhereInput) int
+		SecurityPolicies          func(childComplexity int, where *model.ObjectWhereInput) int
 		SystemEndpoints           func(childComplexity int) int
-		Tasks                     func(childComplexity int, orderBy *model.TaskOrderByInput, last *int) int
-		Vms                       func(childComplexity int) int
+		Tasks                     func(childComplexity int, where *model.ObjectWhereInput, orderBy *model.TaskOrderByInput, last *int) int
+		Vms                       func(childComplexity int, where *model.ObjectWhereInput) int
 	}
 
 	SecurityGroup struct {
@@ -350,16 +350,16 @@ type MutationResolver interface {
 	Login(ctx context.Context, data model.LoginInput) (*model.Login, error)
 }
 type QueryResolver interface {
-	Vms(ctx context.Context) ([]schema.VM, error)
-	Labels(ctx context.Context) ([]schema.Label, error)
-	SecurityPolicies(ctx context.Context) ([]schema.SecurityPolicy, error)
-	IsolationPolicies(ctx context.Context) ([]schema.IsolationPolicy, error)
-	EverouteClusters(ctx context.Context) ([]schema.EverouteCluster, error)
-	Hosts(ctx context.Context) ([]schema.Host, error)
+	Vms(ctx context.Context, where *model.ObjectWhereInput) ([]schema.VM, error)
+	Labels(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Label, error)
+	SecurityPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityPolicy, error)
+	IsolationPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.IsolationPolicy, error)
+	EverouteClusters(ctx context.Context, where *model.ObjectWhereInput) ([]schema.EverouteCluster, error)
+	Hosts(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Host, error)
 	SystemEndpoints(ctx context.Context) (*schema.SystemEndpoints, error)
-	Tasks(ctx context.Context, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error)
-	SecurityGroups(ctx context.Context) ([]schema.SecurityGroup, error)
-	NetworkPolicyRuleServices(ctx context.Context) ([]schema.NetworkPolicyRuleService, error)
+	Tasks(ctx context.Context, where *model.ObjectWhereInput, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error)
+	SecurityGroups(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityGroup, error)
+	NetworkPolicyRuleServices(ctx context.Context, where *model.ObjectWhereInput) ([]schema.NetworkPolicyRuleService, error)
 }
 type SubscriptionResolver interface {
 	VM(ctx context.Context) (<-chan *model.VMEvent, error)
@@ -935,49 +935,84 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Query.EverouteClusters(childComplexity), true
+		args, err := ec.field_Query_everouteClusters_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.EverouteClusters(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.hosts":
 		if e.complexity.Query.Hosts == nil {
 			break
 		}
 
-		return e.complexity.Query.Hosts(childComplexity), true
+		args, err := ec.field_Query_hosts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Hosts(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.isolationPolicies":
 		if e.complexity.Query.IsolationPolicies == nil {
 			break
 		}
 
-		return e.complexity.Query.IsolationPolicies(childComplexity), true
+		args, err := ec.field_Query_isolationPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.IsolationPolicies(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.labels":
 		if e.complexity.Query.Labels == nil {
 			break
 		}
 
-		return e.complexity.Query.Labels(childComplexity), true
+		args, err := ec.field_Query_labels_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Labels(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.networkPolicyRuleServices":
 		if e.complexity.Query.NetworkPolicyRuleServices == nil {
 			break
 		}
 
-		return e.complexity.Query.NetworkPolicyRuleServices(childComplexity), true
+		args, err := ec.field_Query_networkPolicyRuleServices_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.NetworkPolicyRuleServices(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.securityGroups":
 		if e.complexity.Query.SecurityGroups == nil {
 			break
 		}
 
-		return e.complexity.Query.SecurityGroups(childComplexity), true
+		args, err := ec.field_Query_securityGroups_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SecurityGroups(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.securityPolicies":
 		if e.complexity.Query.SecurityPolicies == nil {
 			break
 		}
 
-		return e.complexity.Query.SecurityPolicies(childComplexity), true
+		args, err := ec.field_Query_securityPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SecurityPolicies(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "Query.systemEndpoints":
 		if e.complexity.Query.SystemEndpoints == nil {
@@ -996,14 +1031,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Tasks(childComplexity, args["orderBy"].(*model.TaskOrderByInput), args["last"].(*int)), true
+		return e.complexity.Query.Tasks(childComplexity, args["where"].(*model.ObjectWhereInput), args["orderBy"].(*model.TaskOrderByInput), args["last"].(*int)), true
 
 	case "Query.vms":
 		if e.complexity.Query.Vms == nil {
 			break
 		}
 
-		return e.complexity.Query.Vms(childComplexity), true
+		args, err := ec.field_Query_vms_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Vms(childComplexity, args["where"].(*model.ObjectWhereInput)), true
 
 	case "SecurityGroup.everoute_cluster":
 		if e.complexity.SecurityGroup.EverouteCluster == nil {
@@ -1560,6 +1600,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputLoginInput,
+		ec.unmarshalInputObjectWhereInput,
 	)
 	first := true
 
@@ -1638,17 +1679,21 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var sources = []*ast.Source{
 	{Name: "../query.graphqls", Input: `# mock tower query vms and labels
+input ObjectWhereInput {
+    id: ID
+}
+
 type Query {
-    vms: [VM!]!
-    labels: [Label!]!
-    securityPolicies: [SecurityPolicy!]!
-    isolationPolicies: [IsolationPolicy!]!
-    everouteClusters: [EverouteCluster!]!
-    hosts: [Host!]!
+    vms(where: ObjectWhereInput): [VM!]!
+    labels(where: ObjectWhereInput): [Label!]!
+    securityPolicies(where: ObjectWhereInput): [SecurityPolicy!]!
+    isolationPolicies(where: ObjectWhereInput): [IsolationPolicy!]!
+    everouteClusters(where: ObjectWhereInput): [EverouteCluster!]!
+    hosts(where: ObjectWhereInput): [Host!]!
     systemEndpoints: SystemEndpoints
-    tasks(orderBy: TaskOrderByInput, last: Int): [Task!]!
-    securityGroups: [SecurityGroup!]!
-    networkPolicyRuleServices: [NetworkPolicyRuleService!]!
+    tasks(where: ObjectWhereInput, orderBy: TaskOrderByInput, last: Int): [Task!]!
+    securityGroups(where: ObjectWhereInput): [SecurityGroup!]!
+    networkPolicyRuleServices(where: ObjectWhereInput): [NetworkPolicyRuleService!]!
 }
 
 # mock tower subscribe vm and label
@@ -2058,27 +2103,156 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_everouteClusters_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_hosts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_isolationPolicies_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_labels_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_networkPolicyRuleServices_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_securityGroups_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_securityPolicies_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_tasks_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *model.TaskOrderByInput
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
+	var arg1 *model.TaskOrderByInput
 	if tmp, ok := rawArgs["orderBy"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
-		arg0, err = ec.unmarshalOTaskOrderByInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐTaskOrderByInput(ctx, tmp)
+		arg1, err = ec.unmarshalOTaskOrderByInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐTaskOrderByInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["orderBy"] = arg0
-	var arg1 *int
+	args["orderBy"] = arg1
+	var arg2 *int
 	if tmp, ok := rawArgs["last"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
-		arg1, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		arg2, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["last"] = arg1
+	args["last"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_vms_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.ObjectWhereInput
+	if tmp, ok := rawArgs["where"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("where"))
+		arg0, err = ec.unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["where"] = arg0
 	return args, nil
 }
 
@@ -5646,7 +5820,7 @@ func (ec *executionContext) _Query_vms(ctx context.Context, field graphql.Collec
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Vms(rctx)
+		return ec.resolvers.Query().Vms(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5689,6 +5863,17 @@ func (ec *executionContext) fieldContext_Query_vms(ctx context.Context, field gr
 			return nil, fmt.Errorf("no field named %q was found under type VM", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_vms_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -5706,7 +5891,7 @@ func (ec *executionContext) _Query_labels(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Labels(rctx)
+		return ec.resolvers.Query().Labels(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5743,6 +5928,17 @@ func (ec *executionContext) fieldContext_Query_labels(ctx context.Context, field
 			return nil, fmt.Errorf("no field named %q was found under type Label", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_labels_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -5760,7 +5956,7 @@ func (ec *executionContext) _Query_securityPolicies(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().SecurityPolicies(rctx)
+		return ec.resolvers.Query().SecurityPolicies(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5807,6 +6003,17 @@ func (ec *executionContext) fieldContext_Query_securityPolicies(ctx context.Cont
 			return nil, fmt.Errorf("no field named %q was found under type SecurityPolicy", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_securityPolicies_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -5824,7 +6031,7 @@ func (ec *executionContext) _Query_isolationPolicies(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().IsolationPolicies(rctx)
+		return ec.resolvers.Query().IsolationPolicies(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5867,6 +6074,17 @@ func (ec *executionContext) fieldContext_Query_isolationPolicies(ctx context.Con
 			return nil, fmt.Errorf("no field named %q was found under type IsolationPolicy", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_isolationPolicies_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -5884,7 +6102,7 @@ func (ec *executionContext) _Query_everouteClusters(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().EverouteClusters(rctx)
+		return ec.resolvers.Query().EverouteClusters(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5927,6 +6145,17 @@ func (ec *executionContext) fieldContext_Query_everouteClusters(ctx context.Cont
 			return nil, fmt.Errorf("no field named %q was found under type EverouteCluster", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_everouteClusters_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -5944,7 +6173,7 @@ func (ec *executionContext) _Query_hosts(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Hosts(rctx)
+		return ec.resolvers.Query().Hosts(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5978,6 +6207,17 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_hosts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
 	}
 	return fc, nil
 }
@@ -6043,7 +6283,7 @@ func (ec *executionContext) _Query_tasks(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Tasks(rctx, fc.Args["orderBy"].(*model.TaskOrderByInput), fc.Args["last"].(*int))
+		return ec.resolvers.Query().Tasks(rctx, fc.Args["where"].(*model.ObjectWhereInput), fc.Args["orderBy"].(*model.TaskOrderByInput), fc.Args["last"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6116,7 +6356,7 @@ func (ec *executionContext) _Query_securityGroups(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().SecurityGroups(rctx)
+		return ec.resolvers.Query().SecurityGroups(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6161,6 +6401,17 @@ func (ec *executionContext) fieldContext_Query_securityGroups(ctx context.Contex
 			return nil, fmt.Errorf("no field named %q was found under type SecurityGroup", field.Name)
 		},
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_securityGroups_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
 	return fc, nil
 }
 
@@ -6178,7 +6429,7 @@ func (ec *executionContext) _Query_networkPolicyRuleServices(ctx context.Context
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().NetworkPolicyRuleServices(rctx)
+		return ec.resolvers.Query().NetworkPolicyRuleServices(rctx, fc.Args["where"].(*model.ObjectWhereInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6210,6 +6461,17 @@ func (ec *executionContext) fieldContext_Query_networkPolicyRuleServices(ctx con
 			}
 			return nil, fmt.Errorf("no field named %q was found under type NetworkPolicyRuleService", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_networkPolicyRuleServices_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
 	}
 	return fc, nil
 }
@@ -11954,6 +12216,34 @@ func (ec *executionContext) unmarshalInputLoginInput(ctx context.Context, obj in
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputObjectWhereInput(ctx context.Context, obj interface{}) (model.ObjectWhereInput, error) {
+	var it model.ObjectWhereInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -15814,6 +16104,22 @@ func (ec *executionContext) marshalOGroupMemberType2ᚖgithubᚗcomᚋeveroute�
 	return res
 }
 
+func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalID(*v)
+	return res
+}
+
 func (ec *executionContext) marshalOIDSystemEndpoint2ᚕgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋschemaᚐIDSystemEndpointᚄ(ctx context.Context, sel ast.SelectionSet, v []schema.IDSystemEndpoint) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -16175,6 +16481,14 @@ func (ec *executionContext) marshalOObjectReference2ᚖgithubᚗcomᚋeveroute�
 		return graphql.Null
 	}
 	return ec._ObjectReference(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOObjectWhereInput2ᚖgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋserverᚋfakeᚋgraphᚋmodelᚐObjectWhereInput(ctx context.Context, v interface{}) (*model.ObjectWhereInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputObjectWhereInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOPodLabel2ᚕgithubᚗcomᚋeverouteᚋeverouteᚋpluginᚋtowerᚋpkgᚋschemaᚐPodLabelᚄ(ctx context.Context, sel ast.SelectionSet, v []schema.PodLabel) graphql.Marshaler {

--- a/plugin/tower/pkg/server/fake/graph/model/models_gen.go
+++ b/plugin/tower/pkg/server/fake/graph/model/models_gen.go
@@ -44,6 +44,10 @@ type LoginInput struct {
 	Username string     `json:"username"`
 }
 
+type ObjectWhereInput struct {
+	ID *string `json:"id"`
+}
+
 type SecurityGroupEvent struct {
 	Mutation       schema.MutationType     `json:"mutation"`
 	Node           *schema.SecurityGroup   `json:"node"`

--- a/plugin/tower/pkg/server/fake/graph/query.graphqls
+++ b/plugin/tower/pkg/server/fake/graph/query.graphqls
@@ -1,15 +1,19 @@
 # mock tower query vms and labels
+input ObjectWhereInput {
+    id: ID
+}
+
 type Query {
-    vms: [VM!]!
-    labels: [Label!]!
-    securityPolicies: [SecurityPolicy!]!
-    isolationPolicies: [IsolationPolicy!]!
-    everouteClusters: [EverouteCluster!]!
-    hosts: [Host!]!
+    vms(where: ObjectWhereInput): [VM!]!
+    labels(where: ObjectWhereInput): [Label!]!
+    securityPolicies(where: ObjectWhereInput): [SecurityPolicy!]!
+    isolationPolicies(where: ObjectWhereInput): [IsolationPolicy!]!
+    everouteClusters(where: ObjectWhereInput): [EverouteCluster!]!
+    hosts(where: ObjectWhereInput): [Host!]!
     systemEndpoints: SystemEndpoints
-    tasks(orderBy: TaskOrderByInput, last: Int): [Task!]!
-    securityGroups: [SecurityGroup!]!
-    networkPolicyRuleServices: [NetworkPolicyRuleService!]!
+    tasks(where: ObjectWhereInput, orderBy: TaskOrderByInput, last: Int): [Task!]!
+    securityGroups(where: ObjectWhereInput): [SecurityGroup!]!
+    networkPolicyRuleServices(where: ObjectWhereInput): [NetworkPolicyRuleService!]!
 }
 
 # mock tower subscribe vm and label

--- a/plugin/tower/pkg/server/fake/graph/resolver/helper.go
+++ b/plugin/tower/pkg/server/fake/graph/resolver/helper.go
@@ -1,0 +1,7 @@
+package resolver
+
+import "github.com/everoute/everoute/plugin/tower/pkg/server/fake/graph/model"
+
+func matchObjectID(id string, where *model.ObjectWhereInput) bool {
+	return where == nil || where.ID == nil || *where.ID == id
+}

--- a/plugin/tower/pkg/server/fake/graph/resolver/helper.go
+++ b/plugin/tower/pkg/server/fake/graph/resolver/helper.go
@@ -1,0 +1,7 @@
+package resolver
+
+import "github.com/everoute/everoute/plugin/tower/pkg/server/fake/graph/model"
+
+func matchesWhereForObjectID(id string, where *model.ObjectWhereInput) bool {
+	return where == nil || where.ID == nil || *where.ID == id
+}

--- a/plugin/tower/pkg/server/fake/graph/resolver/query.resolvers.go
+++ b/plugin/tower/pkg/server/fake/graph/resolver/query.resolvers.go
@@ -32,61 +32,85 @@ func (r *mutationResolver) Login(ctx context.Context, data model.LoginInput) (*m
 }
 
 // Vms is the resolver for the vms field.
-func (r *queryResolver) Vms(ctx context.Context) ([]schema.VM, error) {
+func (r *queryResolver) Vms(ctx context.Context, where *model.ObjectWhereInput) ([]schema.VM, error) {
 	vmList := r.TrackerFactory().VM().List()
 	vms := make([]schema.VM, 0, len(vmList))
 	for _, vm := range vmList {
-		vms = append(vms, *vm.(*schema.VM))
+		obj := vm.(*schema.VM)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		vms = append(vms, *obj)
 	}
 	return vms, nil
 }
 
 // Labels is the resolver for the labels field.
-func (r *queryResolver) Labels(ctx context.Context) ([]schema.Label, error) {
+func (r *queryResolver) Labels(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Label, error) {
 	labelList := r.TrackerFactory().Label().List()
 	labels := make([]schema.Label, 0, len(labelList))
 	for _, label := range labelList {
-		labels = append(labels, *label.(*schema.Label))
+		obj := label.(*schema.Label)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		labels = append(labels, *obj)
 	}
 	return labels, nil
 }
 
 // SecurityPolicies is the resolver for the securityPolicies field.
-func (r *queryResolver) SecurityPolicies(ctx context.Context) ([]schema.SecurityPolicy, error) {
+func (r *queryResolver) SecurityPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityPolicy, error) {
 	policyList := r.TrackerFactory().SecurityPolicy().List()
 	policies := make([]schema.SecurityPolicy, 0, len(policyList))
 	for _, policy := range policyList {
-		policies = append(policies, *policy.(*schema.SecurityPolicy))
+		obj := policy.(*schema.SecurityPolicy)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		policies = append(policies, *obj)
 	}
 	return policies, nil
 }
 
 // IsolationPolicies is the resolver for the isolationPolicies field.
-func (r *queryResolver) IsolationPolicies(ctx context.Context) ([]schema.IsolationPolicy, error) {
+func (r *queryResolver) IsolationPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.IsolationPolicy, error) {
 	policyList := r.TrackerFactory().IsolationPolicy().List()
 	policies := make([]schema.IsolationPolicy, 0, len(policyList))
 	for _, policy := range policyList {
-		policies = append(policies, *policy.(*schema.IsolationPolicy))
+		obj := policy.(*schema.IsolationPolicy)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		policies = append(policies, *obj)
 	}
 	return policies, nil
 }
 
 // EverouteClusters is the resolver for the everouteClusters field.
-func (r *queryResolver) EverouteClusters(ctx context.Context) ([]schema.EverouteCluster, error) {
+func (r *queryResolver) EverouteClusters(ctx context.Context, where *model.ObjectWhereInput) ([]schema.EverouteCluster, error) {
 	erClusterList := r.TrackerFactory().EverouteCluster().List()
 	erClusters := make([]schema.EverouteCluster, 0, len(erClusterList))
 	for _, erCluster := range erClusterList {
-		erClusters = append(erClusters, *erCluster.(*schema.EverouteCluster))
+		obj := erCluster.(*schema.EverouteCluster)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		erClusters = append(erClusters, *obj)
 	}
 	return erClusters, nil
 }
 
 // Hosts is the resolver for the hosts field.
-func (r *queryResolver) Hosts(ctx context.Context) ([]schema.Host, error) {
+func (r *queryResolver) Hosts(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Host, error) {
 	hostList := r.TrackerFactory().Host().List()
 	hosts := make([]schema.Host, 0, len(hostList))
 	for _, host := range hostList {
-		hosts = append(hosts, *host.(*schema.Host))
+		obj := host.(*schema.Host)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		hosts = append(hosts, *obj)
 	}
 	return hosts, nil
 }
@@ -101,34 +125,46 @@ func (r *queryResolver) SystemEndpoints(ctx context.Context) (*schema.SystemEndp
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *queryResolver) Tasks(ctx context.Context, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error) {
+func (r *queryResolver) Tasks(ctx context.Context, where *model.ObjectWhereInput, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error) {
 	taskList := r.TrackerFactory().Task().List()
 	var tasks []schema.Task
-	for index, task := range taskList {
-		if last != nil && index >= *last {
+	for _, task := range taskList {
+		obj := task.(*schema.Task)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		tasks = append(tasks, *obj)
+		if last != nil && len(tasks) >= *last {
 			break
 		}
-		tasks = append(tasks, *task.(*schema.Task))
 	}
 	return tasks, nil
 }
 
 // SecurityGroups is the resolver for the securityGroups field.
-func (r *queryResolver) SecurityGroups(ctx context.Context) ([]schema.SecurityGroup, error) {
+func (r *queryResolver) SecurityGroups(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityGroup, error) {
 	groupList := r.TrackerFactory().SecurityGroup().List()
 	groups := make([]schema.SecurityGroup, 0, len(groupList))
 	for _, group := range groupList {
-		groups = append(groups, *group.(*schema.SecurityGroup))
+		obj := group.(*schema.SecurityGroup)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		groups = append(groups, *obj)
 	}
 	return groups, nil
 }
 
 // NetworkPolicyRuleServices is the resolver for the networkPolicyRuleServices field.
-func (r *queryResolver) NetworkPolicyRuleServices(ctx context.Context) ([]schema.NetworkPolicyRuleService, error) {
+func (r *queryResolver) NetworkPolicyRuleServices(ctx context.Context, where *model.ObjectWhereInput) ([]schema.NetworkPolicyRuleService, error) {
 	svcList := r.TrackerFactory().Service().List()
 	svcs := make([]schema.NetworkPolicyRuleService, 0, len(svcList))
 	for _, svc := range svcList {
-		svcs = append(svcs, *svc.(*schema.NetworkPolicyRuleService))
+		obj := svc.(*schema.NetworkPolicyRuleService)
+		if !matchesWhereForObjectID(obj.ID, where) {
+			continue
+		}
+		svcs = append(svcs, *obj)
 	}
 	return svcs, nil
 }

--- a/plugin/tower/pkg/server/fake/graph/resolver/query.resolvers.go
+++ b/plugin/tower/pkg/server/fake/graph/resolver/query.resolvers.go
@@ -32,61 +32,85 @@ func (r *mutationResolver) Login(ctx context.Context, data model.LoginInput) (*m
 }
 
 // Vms is the resolver for the vms field.
-func (r *queryResolver) Vms(ctx context.Context) ([]schema.VM, error) {
+func (r *queryResolver) Vms(ctx context.Context, where *model.ObjectWhereInput) ([]schema.VM, error) {
 	vmList := r.TrackerFactory().VM().List()
 	vms := make([]schema.VM, 0, len(vmList))
 	for _, vm := range vmList {
-		vms = append(vms, *vm.(*schema.VM))
+		obj := vm.(*schema.VM)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		vms = append(vms, *obj)
 	}
 	return vms, nil
 }
 
 // Labels is the resolver for the labels field.
-func (r *queryResolver) Labels(ctx context.Context) ([]schema.Label, error) {
+func (r *queryResolver) Labels(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Label, error) {
 	labelList := r.TrackerFactory().Label().List()
 	labels := make([]schema.Label, 0, len(labelList))
 	for _, label := range labelList {
-		labels = append(labels, *label.(*schema.Label))
+		obj := label.(*schema.Label)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		labels = append(labels, *obj)
 	}
 	return labels, nil
 }
 
 // SecurityPolicies is the resolver for the securityPolicies field.
-func (r *queryResolver) SecurityPolicies(ctx context.Context) ([]schema.SecurityPolicy, error) {
+func (r *queryResolver) SecurityPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityPolicy, error) {
 	policyList := r.TrackerFactory().SecurityPolicy().List()
 	policies := make([]schema.SecurityPolicy, 0, len(policyList))
 	for _, policy := range policyList {
-		policies = append(policies, *policy.(*schema.SecurityPolicy))
+		obj := policy.(*schema.SecurityPolicy)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		policies = append(policies, *obj)
 	}
 	return policies, nil
 }
 
 // IsolationPolicies is the resolver for the isolationPolicies field.
-func (r *queryResolver) IsolationPolicies(ctx context.Context) ([]schema.IsolationPolicy, error) {
+func (r *queryResolver) IsolationPolicies(ctx context.Context, where *model.ObjectWhereInput) ([]schema.IsolationPolicy, error) {
 	policyList := r.TrackerFactory().IsolationPolicy().List()
 	policies := make([]schema.IsolationPolicy, 0, len(policyList))
 	for _, policy := range policyList {
-		policies = append(policies, *policy.(*schema.IsolationPolicy))
+		obj := policy.(*schema.IsolationPolicy)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		policies = append(policies, *obj)
 	}
 	return policies, nil
 }
 
 // EverouteClusters is the resolver for the everouteClusters field.
-func (r *queryResolver) EverouteClusters(ctx context.Context) ([]schema.EverouteCluster, error) {
+func (r *queryResolver) EverouteClusters(ctx context.Context, where *model.ObjectWhereInput) ([]schema.EverouteCluster, error) {
 	erClusterList := r.TrackerFactory().EverouteCluster().List()
 	erClusters := make([]schema.EverouteCluster, 0, len(erClusterList))
 	for _, erCluster := range erClusterList {
-		erClusters = append(erClusters, *erCluster.(*schema.EverouteCluster))
+		obj := erCluster.(*schema.EverouteCluster)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		erClusters = append(erClusters, *obj)
 	}
 	return erClusters, nil
 }
 
 // Hosts is the resolver for the hosts field.
-func (r *queryResolver) Hosts(ctx context.Context) ([]schema.Host, error) {
+func (r *queryResolver) Hosts(ctx context.Context, where *model.ObjectWhereInput) ([]schema.Host, error) {
 	hostList := r.TrackerFactory().Host().List()
 	hosts := make([]schema.Host, 0, len(hostList))
 	for _, host := range hostList {
-		hosts = append(hosts, *host.(*schema.Host))
+		obj := host.(*schema.Host)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		hosts = append(hosts, *obj)
 	}
 	return hosts, nil
 }
@@ -101,34 +125,46 @@ func (r *queryResolver) SystemEndpoints(ctx context.Context) (*schema.SystemEndp
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *queryResolver) Tasks(ctx context.Context, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error) {
+func (r *queryResolver) Tasks(ctx context.Context, where *model.ObjectWhereInput, orderBy *model.TaskOrderByInput, last *int) ([]schema.Task, error) {
 	taskList := r.TrackerFactory().Task().List()
 	var tasks []schema.Task
-	for index, task := range taskList {
-		if last != nil && index >= *last {
+	for _, task := range taskList {
+		obj := task.(*schema.Task)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		tasks = append(tasks, *obj)
+		if last != nil && len(tasks) >= *last {
 			break
 		}
-		tasks = append(tasks, *task.(*schema.Task))
 	}
 	return tasks, nil
 }
 
 // SecurityGroups is the resolver for the securityGroups field.
-func (r *queryResolver) SecurityGroups(ctx context.Context) ([]schema.SecurityGroup, error) {
+func (r *queryResolver) SecurityGroups(ctx context.Context, where *model.ObjectWhereInput) ([]schema.SecurityGroup, error) {
 	groupList := r.TrackerFactory().SecurityGroup().List()
 	groups := make([]schema.SecurityGroup, 0, len(groupList))
 	for _, group := range groupList {
-		groups = append(groups, *group.(*schema.SecurityGroup))
+		obj := group.(*schema.SecurityGroup)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		groups = append(groups, *obj)
 	}
 	return groups, nil
 }
 
 // NetworkPolicyRuleServices is the resolver for the networkPolicyRuleServices field.
-func (r *queryResolver) NetworkPolicyRuleServices(ctx context.Context) ([]schema.NetworkPolicyRuleService, error) {
+func (r *queryResolver) NetworkPolicyRuleServices(ctx context.Context, where *model.ObjectWhereInput) ([]schema.NetworkPolicyRuleService, error) {
 	svcList := r.TrackerFactory().Service().List()
 	svcs := make([]schema.NetworkPolicyRuleService, 0, len(svcList))
 	for _, svc := range svcList {
-		svcs = append(svcs, *svc.(*schema.NetworkPolicyRuleService))
+		obj := svc.(*schema.NetworkPolicyRuleService)
+		if !matchObjectID(obj.ID, where) {
+			continue
+		}
+		svcs = append(svcs, *obj)
 	}
 	return svcs, nil
 }


### PR DESCRIPTION
## Purpose
Fix reflector store-write ordering/race issues by serializing writes through a single keyed reconcile path, and harden delete-by-key behavior when the queried object no longer exists.
This PR is based on #1069 because the cache-sync-before-crc startup ordering is a prerequisite.

## Changes
- Rework `plugin/tower/pkg/informer/reflector.go` so subscription/CRC events enqueue keys and store mutations are handled in a single `processStoreEvent` path.
- Ensure delete-by-key uses a typed tombstone object derived from key (`newObjWithKey`) instead of direct old-object lookup, keeping writes serialized and consistent.
- Add explicit error handling when reflected object types do not implement `schema.KeySettable`, and include the key in the error message for diagnosis.
- Introduce `schema.KeySettable` plus `ObjectMeta.SetKey`, and add a no-op `SetKey` for `SystemEndpoints` to satisfy key-based delete flows.
- Extend fake Tower GraphQL server support for `where:{id:...}` query shapes and resolver helpers used by keyed reconcile tests.
- Add/expand informer unit tests for:
  - subscription event enqueue/reconcile by key
  - CRC event enqueue/reconcile by key
  - delete-by-key when query result is missing
  - error path when object type is not `schema.KeySettable`

## Tests
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./plugin/tower/pkg/informer -count=1`
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./plugin/tower/... -count=1`
