### PR TITLE
fix(er-1678): skip crc watcher when tower cache sync is unavailable

### DIFF
--- a/plugin/tower/pkg/register/manager.go
+++ b/plugin/tower/pkg/register/manager.go
@@ -146,12 +146,14 @@ func AddToManager(opts *Options, mgr manager.Manager) error {
 		go func() {
 			synced := opts.SharedFactory.WaitForCacheSync(ctx.Done())
 			if len(synced) == 0 {
-				klog.Fatalf("no started tower informers found before starting crc watcher")
+				klog.Warning("no started tower informers found before starting crc watcher, skip starting crc watcher")
+				return
 			}
 			for informerType, ok := range synced {
 				klog.Infof("tower informer %s cache sync result before starting crc watcher: %t", informerType, ok)
 				if !ok {
-					klog.Fatalf("tower informer %s cache sync failed before starting crc watcher", informerType)
+					klog.Warningf("tower informer %s cache sync failed before starting crc watcher, skip starting crc watcher", informerType)
+					return
 				}
 			}
 			crcFactory.Start(ctx.Done())


### PR DESCRIPTION
## Purpose
Fix er-1678: avoid crashing when tower informer cache is not started or cache sync fails before crc watcher starts.

## Changes
- Replace fatal exits with warning logs in `AddToManager` tower cache sync pre-check.
- Skip starting crc watcher when no informer is started or any informer cache sync fails.

## Tests
- Built and deployed debug image `registry.smtx.io/everoute/debug:4eaf358`.
- Verified controller rollout on 172.21.150.120-122 via `eradm update --allow-pull`.
- Checked controller container status and logs after rollout.
