### PR TITLE
fix(er-1687): refactor endpoint agentinfo reconcile init sync

### DIFF
--- a/pkg/common/initsync/tracker.go
+++ b/pkg/common/initsync/tracker.go
@@ -1,0 +1,66 @@
+package initsync
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Tracker tracks whether the initial informer objects have all been processed.
+type Tracker struct {
+	done      atomic.Bool
+	lock      sync.Mutex
+	processed sets.Set[string]
+}
+
+func NewTracker() *Tracker {
+	return &Tracker{}
+}
+
+func (t *Tracker) IsDone() bool {
+	return t.done.Load()
+}
+
+// MarkProcessed records one processed object name.
+// Returns isNew/current/recorded where recorded is false when init is already done.
+func (t *Tracker) MarkProcessed(name string) (bool, []string, bool) {
+	if t.done.Load() {
+		return false, nil, false
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.done.Load() {
+		return false, nil, false
+	}
+	if t.processed == nil {
+		t.processed = sets.New[string]()
+	}
+	isNew := !t.processed.Has(name)
+	t.processed.Insert(name)
+	return isNew, t.processed.UnsortedList(), true
+}
+
+// CheckDone returns ready/justDone/processedOnDone.
+func (t *Tracker) CheckDone(expected sets.Set[string]) (bool, bool, []string) {
+	if t.done.Load() {
+		return true, false, nil
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.done.Load() {
+		return true, false, nil
+	}
+	if t.processed == nil {
+		t.processed = sets.New[string]()
+	}
+	if expected.Len() == 0 || t.processed.IsSuperset(expected) {
+		t.done.Store(true)
+		processed := t.processed.UnsortedList()
+		t.processed = nil
+		return true, true, processed
+	}
+	return false, false, nil
+}

--- a/pkg/common/initsync/tracker_test.go
+++ b/pkg/common/initsync/tracker_test.go
@@ -1,0 +1,94 @@
+package initsync
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestTrackerMarkProcessed(t *testing.T) {
+	tracker := NewTracker()
+	if tracker.IsDone() {
+		t.Fatalf("new tracker should not be done")
+	}
+
+	isNew, current, recorded := tracker.MarkProcessed("a")
+	if !recorded || !isNew {
+		t.Fatalf("first mark should be recorded and new, got recorded=%v isNew=%v", recorded, isNew)
+	}
+	if !sets.New[string](current...).Has("a") {
+		t.Fatalf("first mark should contain a, current=%v", current)
+	}
+
+	isNew, current, recorded = tracker.MarkProcessed("a")
+	if !recorded || isNew {
+		t.Fatalf("second mark should be recorded but not new, got recorded=%v isNew=%v", recorded, isNew)
+	}
+	if len(current) != 1 || current[0] != "a" {
+		t.Fatalf("duplicate mark should keep single entry, current=%v", current)
+	}
+}
+
+func TestTrackerCheckDone(t *testing.T) {
+	tracker := NewTracker()
+	tracker.MarkProcessed("a")
+
+	ready, justDone, processed := tracker.CheckDone(sets.New[string]("a", "b"))
+	if ready || justDone || processed != nil {
+		t.Fatalf("tracker should not be ready before all expected processed, got ready=%v justDone=%v processed=%v", ready, justDone, processed)
+	}
+
+	tracker.MarkProcessed("b")
+	ready, justDone, processed = tracker.CheckDone(sets.New[string]("a", "b"))
+	if !ready || !justDone {
+		t.Fatalf("tracker should be just done when expected all processed, got ready=%v justDone=%v", ready, justDone)
+	}
+	if !sets.New[string](processed...).Equal(sets.New[string]("a", "b")) {
+		t.Fatalf("processed on done mismatch, got=%v", processed)
+	}
+	if !tracker.IsDone() {
+		t.Fatalf("tracker should be done after CheckDone succeeds")
+	}
+
+	ready, justDone, processed = tracker.CheckDone(sets.New[string]("a", "b"))
+	if !ready || justDone || processed != nil {
+		t.Fatalf("done tracker should return ready=true justDone=false processed=nil, got ready=%v justDone=%v processed=%v", ready, justDone, processed)
+	}
+}
+
+func TestTrackerMarkProcessedAfterDone(t *testing.T) {
+	tracker := NewTracker()
+	ready, justDone, processed := tracker.CheckDone(sets.New[string]())
+	if !ready || !justDone || len(processed) != 0 {
+		t.Fatalf("empty expected should mark tracker done, got ready=%v justDone=%v processed=%v", ready, justDone, processed)
+	}
+
+	isNew, current, recorded := tracker.MarkProcessed("a")
+	if recorded || isNew || current != nil {
+		t.Fatalf("mark after done should not record, got recorded=%v isNew=%v current=%v", recorded, isNew, current)
+	}
+}
+
+func TestTrackerConcurrentMarkProcessed(t *testing.T) {
+	tracker := NewTracker()
+	names := []string{"a", "b", "c", "d", "e", "f"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tracker.MarkProcessed(names[idx%len(names)])
+		}(i)
+	}
+	wg.Wait()
+
+	ready, justDone, processed := tracker.CheckDone(sets.New[string](names...))
+	if !ready || !justDone {
+		t.Fatalf("tracker should be done after concurrent marks, got ready=%v justDone=%v", ready, justDone)
+	}
+	if !sets.New[string](processed...).Equal(sets.New[string](names...)) {
+		t.Fatalf("processed on done mismatch after concurrent marks, got=%v", processed)
+	}
+}

--- a/pkg/controller/endpoint/endpoint_controller.go
+++ b/pkg/controller/endpoint/endpoint_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,11 +37,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1alpha1 "github.com/everoute/everoute/pkg/apis/agent/v1alpha1"
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/common/initsync"
 	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/constants/ms"
 	ctrltypes "github.com/everoute/everoute/pkg/controller/types"
@@ -60,11 +61,11 @@ type Reconciler struct {
 
 	ifaceCacheLock sync.RWMutex
 	ifaceCache     cache.Indexer
-	ifaceInitDone  atomic.Bool
-	processedNames sets.Set[string]
+	ifaceInit      *initsync.Tracker
 
 	shareIPCacheLock sync.RWMutex
 	shareIPCache     map[string]shareIP
+	shareIPInit      *initsync.Tracker
 }
 
 type shareIP struct {
@@ -110,6 +111,7 @@ const (
 	agentIndex                   = "agentIndex"
 	IfaceIPAddrCleanInterval int = 5
 	ifaceInitRetryInterval       = 1 * time.Second
+	shareIPInitRetryInterval     = 1 * time.Second
 )
 
 // Reconcile receive endpoint from work queue, synchronize the endpoint status
@@ -117,7 +119,7 @@ const (
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var err error
 	klog.V(4).Infof("Reconciler received endpoint %s reconcile", req.NamespacedName)
-	if !r.ifaceInitDone.Load() {
+	if !r.ifaceInitTracker().IsDone() {
 		ready, err := r.checkIfaceInitDone(ctx)
 		if err != nil {
 			klog.Errorf("unable to check iface cache init status: %s", err.Error())
@@ -183,8 +185,9 @@ func (r *Reconciler) ReconcileShareIP(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Client.Get(ctx, req.NamespacedName, sip); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.shareIPCacheLock.Lock()
-			defer r.shareIPCacheLock.Unlock()
 			delete(r.shareIPCache, req.Name)
+			r.shareIPCacheLock.Unlock()
+			r.markShareIPProcessed(req.Name)
 			log.Info("Delete shareIP from cache")
 			return ctrl.Result{}, nil
 		}
@@ -193,6 +196,29 @@ func (r *Reconciler) ReconcileShareIP(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	r.updateShareIPCache(ctx, sip)
+	r.markShareIPProcessed(sip.Name)
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) ReconcileAgentInfo(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !r.shareIPInitTracker().IsDone() {
+		ready, err := r.checkShareIPInitDone(ctx)
+		if err != nil {
+			klog.Errorf("unable to check shareIP cache init status: %s", err.Error())
+			return ctrl.Result{}, err
+		}
+		if !ready {
+			klog.V(4).Infof("agentinfo reconcile waiting for shareIP cache initialization to complete, agentInfo %s", req.NamespacedName)
+			return ctrl.Result{RequeueAfter: shareIPInitRetryInterval}, nil
+		}
+	}
+
+	var agentInfo agentv1alpha1.AgentInfo
+	if err := r.Get(ctx, req.NamespacedName, &agentInfo); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	r.updateAgentInfo(&agentInfo)
 	return ctrl.Result{}, nil
 }
 
@@ -241,19 +267,42 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			ipAddrIndex:     ipAddrIndexFunc,
 		})
 	}
+	if r.ifaceInit == nil {
+		r.ifaceInit = initsync.NewTracker()
+	}
+	if r.shareIPInit == nil {
+		r.shareIPInit = initsync.NewTracker()
+	}
 
 	err = c.Watch(source.Kind(mgr.GetCache(), &agentv1alpha1.AgentInfo{}), &handler.Funcs{
-		CreateFunc: r.addAgentInfo,
-		UpdateFunc: r.updateAgentInfo,
-		DeleteFunc: r.deleteAgentInfo,
+		CreateFunc: r.onAgentInfoAdd,
+		UpdateFunc: r.onAgentInfoUpdate,
+		DeleteFunc: r.onAgentInfoDelete,
 	})
 	if err != nil {
 		return err
 	}
 
-	err = c.Watch(source.Kind(mgr.GetCache(), &securityv1alpha1.Endpoint{}), &handler.Funcs{
-		CreateFunc: r.addEndpoint,
-		UpdateFunc: r.updateEndpoint,
+	agentInfoCacheC, err := controller.New("agentinfo-controller", mgr, controller.Options{
+		Reconciler: reconcile.Func(r.ReconcileAgentInfo),
+	})
+	if err != nil {
+		return err
+	}
+	err = agentInfoCacheC.Watch(source.Kind(mgr.GetCache(), &agentv1alpha1.AgentInfo{}), &handler.Funcs{
+		UpdateFunc: r.enqueueAgentInfoCacheUpdate,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(source.Kind(mgr.GetCache(), &securityv1alpha1.Endpoint{}), &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
 	})
 	if err != nil {
 		return err
@@ -277,31 +326,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}))
 }
 
-func (r *Reconciler) addEndpoint(_ context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
-	if e.Object == nil {
-		klog.Errorf("AddEndpoint received with no metadata event: %v", e)
-		return
-	}
-
-	q.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{
-		Namespace: e.Object.GetNamespace(),
-		Name:      e.Object.GetName(),
-	}})
-}
-
-func (r *Reconciler) updateEndpoint(_ context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (r *Reconciler) enqueueAgentInfoCacheUpdate(_ context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	if e.ObjectNew == nil {
-		klog.Errorf("UpdateEndpoint received with no metadata event: %v", e)
+		klog.Errorf("enqueueAgentInfoCacheUpdate received with no metadata event: %v", e)
 		return
 	}
 
 	q.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{
-		Namespace: e.ObjectNew.GetNamespace(),
 		Name:      e.ObjectNew.GetName(),
+		Namespace: e.ObjectNew.GetNamespace(),
 	}})
 }
 
-func (r *Reconciler) addAgentInfo(_ context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (r *Reconciler) onAgentInfoAdd(_ context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
 	agentInfo, ok := e.Object.(*agentv1alpha1.AgentInfo)
 	if !ok {
 		klog.Errorf("AddAgentInfo received with unavailable object event: %v", e)
@@ -331,11 +368,11 @@ func (r *Reconciler) addAgentInfo(_ context.Context, e event.CreateEvent, q work
 			}
 		}
 	}
-	r.markAgentProcessedLocked(agentInfo.Name)
+	r.markAgentProcessed(agentInfo.Name)
 	r.enqueueEndpointsOnAgentLocked(epList, agentInfo.Name, q)
 }
 
-func (r *Reconciler) updateAgentInfo(_ context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (r *Reconciler) onAgentInfoUpdate(_ context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	newAgentInfo := e.ObjectNew.(*agentv1alpha1.AgentInfo)
 	oldAgentInfo := e.ObjectOld.(*agentv1alpha1.AgentInfo)
 
@@ -367,9 +404,8 @@ func (r *Reconciler) updateAgentInfo(_ context.Context, e event.UpdateEvent, q w
 			}
 		}
 	}
-	r.markAgentProcessedLocked(newAgentInfo.Name)
+	r.markAgentProcessed(newAgentInfo.Name)
 	r.enqueueEndpointsOnAgentLocked(epList, newAgentInfo.Name, q)
-	r.updateCachedAgentInfo(newAgentInfo, q)
 }
 
 func (r *Reconciler) ipMigrateCountUpdate(srcIPs, expIPs []types.IPAddress, vmID string) {
@@ -381,7 +417,7 @@ func (r *Reconciler) ipMigrateCountUpdate(srcIPs, expIPs []types.IPAddress, vmID
 	}
 }
 
-func (r *Reconciler) deleteAgentInfo(_ context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (r *Reconciler) onAgentInfoDelete(_ context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	agentInfo, ok := e.Object.(*agentv1alpha1.AgentInfo)
 	if !ok {
 		klog.Errorf("DeleteAgentInfo received with unavailable object event: %v", e)
@@ -411,39 +447,64 @@ func (r *Reconciler) checkIfaceInitDone(ctx context.Context) (bool, error) {
 		expectedNames.Insert(agentInfoList.Items[i].Name)
 	}
 
-	r.ifaceCacheLock.Lock()
-	defer r.ifaceCacheLock.Unlock()
-	if r.ifaceInitDone.Load() {
-		return true, nil
+	ready, justDone, processed := r.ifaceInitTracker().CheckDone(expectedNames)
+	if justDone {
+		klog.Infof("endpoint controller iface cache initialization completed, agent info list: %v", processed)
 	}
-	if r.processedNames == nil {
-		r.processedNames = sets.New[string]()
-	}
-	if expectedNames.Len() == 0 || r.processedNames.IsSuperset(expectedNames) {
-		r.ifaceInitDone.Store(true)
-		klog.Infof("endpoint controller iface cache initialization completed, agent info list: %v", r.processedNames.UnsortedList())
-		r.processedNames = nil
-		return true, nil
-	}
-	return false, nil
+	return ready, nil
 }
 
-func (r *Reconciler) markAgentProcessedLocked(agentName string) {
-	if r.ifaceInitDone.Load() {
+func (r *Reconciler) markAgentProcessed(agentName string) {
+	isNew, processed, recorded := r.ifaceInitTracker().MarkProcessed(agentName)
+	if !recorded {
 		return
 	}
-	if r.processedNames == nil {
-		r.processedNames = sets.New[string]()
-	}
-	isNew := !r.processedNames.Has(agentName)
-	r.processedNames.Insert(agentName)
 	klog.Infof(
 		"endpoint controller init processed agentinfo: current=%s, isNew=%t, allProcessed=%v",
-		agentName, isNew, r.processedNames.UnsortedList(),
+		agentName, isNew, processed,
 	)
 }
 
-func (r *Reconciler) updateCachedAgentInfo(agentInfo *agentv1alpha1.AgentInfo, _ workqueue.RateLimitingInterface) {
+func (r *Reconciler) checkShareIPInitDone(ctx context.Context) (bool, error) {
+	var shareIPList securityv1alpha1.ShareIPList
+	if err := r.Client.List(ctx, &shareIPList); err != nil {
+		return false, err
+	}
+	expectedNames := sets.New[string]()
+	for i := range shareIPList.Items {
+		expectedNames.Insert(shareIPList.Items[i].Name)
+	}
+
+	ready, justDone, processed := r.shareIPInitTracker().CheckDone(expectedNames)
+	if justDone {
+		klog.Infof("agentinfo controller shareIP cache initialization completed, shareIP list: %v", processed)
+	}
+	return ready, nil
+}
+
+func (r *Reconciler) markShareIPProcessed(shareIPName string) {
+	isNew, _, recorded := r.shareIPInitTracker().MarkProcessed(shareIPName)
+	if !recorded {
+		return
+	}
+	klog.Infof("agentinfo controller init processed shareIP: current=%s, isNew=%t", shareIPName, isNew)
+}
+
+func (r *Reconciler) ifaceInitTracker() *initsync.Tracker {
+	if r.ifaceInit == nil {
+		r.ifaceInit = initsync.NewTracker()
+	}
+	return r.ifaceInit
+}
+
+func (r *Reconciler) shareIPInitTracker() *initsync.Tracker {
+	if r.shareIPInit == nil {
+		r.shareIPInit = initsync.NewTracker()
+	}
+	return r.shareIPInit
+}
+
+func (r *Reconciler) updateAgentInfo(agentInfo *agentv1alpha1.AgentInfo) {
 	ctx := context.Background()
 	updateAgentInfoList := r.toUpdatedAgentInfo(agentInfo)
 

--- a/pkg/controller/endpoint/endpoint_controller_perf_test.go
+++ b/pkg/controller/endpoint/endpoint_controller_perf_test.go
@@ -25,7 +25,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	agentv1alpha1 "github.com/everoute/everoute/pkg/apis/agent/v1alpha1"
@@ -119,14 +121,14 @@ func TestEndpointReconcilerPerf(t *testing.T) {
 		if err != nil {
 			t.Fatalf("fail to create agentinfo %s, %s", ai.Name, err)
 		}
-		reconciler.addAgentInfo(ctx, event.CreateEvent{Object: ai}, queue)
+		reconciler.onAgentInfoAdd(ctx, event.CreateEvent{Object: ai}, queue)
 	}
 	for _, ep := range endpoints {
 		err := reconciler.Client.Create(context.Background(), ep)
 		if err != nil {
 			t.Fatalf("fail to create endpoint %s, %s", ep.Name, err)
 		}
-		reconciler.addEndpoint(ctx, event.CreateEvent{Object: ep}, queue)
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: ep.Name}})
 	}
 
 	err := processQueue(reconciler, queue)

--- a/pkg/controller/endpoint/endpoint_controller_test.go
+++ b/pkg/controller/endpoint/endpoint_controller_test.go
@@ -42,6 +42,7 @@ import (
 	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
 	"github.com/everoute/everoute/pkg/client/clientset_generated/clientset/scheme"
+	"github.com/everoute/everoute/pkg/common/initsync"
 	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/metrics"
 	"github.com/everoute/everoute/pkg/types"
@@ -408,6 +409,8 @@ func newFakeReconciler(initObjs ...runtime.Object) *Reconciler {
 			externalIDIndex: externalIDIndexFunc,
 			ipAddrIndex:     ipAddrIndexFunc,
 		}),
+		ifaceInit:   initsync.NewTracker(),
+		shareIPInit: initsync.NewTracker(),
 	}
 }
 
@@ -439,7 +442,9 @@ func getFakeAgentInfo(c client.Client, name string) agentv1alpha1.AgentInfo {
 
 func TestEndpointController(t *testing.T) {
 	testCheckIfaceInitDone(t)
+	testCheckShareIPInitDone(t)
 	testReconcileWaitForIfaceInitDone(t)
+	testReconcileAgentInfoWaitForShareIPInitDone(t)
 	testMarkAgentProcessedFromHandlers(t)
 	testProcessAgentinfo(t)
 	testInterfaceIPUpdate(t)
@@ -457,13 +462,11 @@ func testCheckIfaceInitDone(t *testing.T) {
 		if ready {
 			t.Fatalf("expected not ready before processing initial agentinfo")
 		}
-		if r.ifaceInitDone.Load() {
+		if r.ifaceInitTracker().IsDone() {
 			t.Fatalf("ifaceInitDone should be false before initial agentinfo is processed")
 		}
 
-		r.ifaceCacheLock.Lock()
-		r.processedNames = sets.New[string](fakeAgentInfoA.Name)
-		r.ifaceCacheLock.Unlock()
+		r.markAgentProcessed(fakeAgentInfoA.Name)
 
 		ready, err = r.checkIfaceInitDone(context.Background())
 		if err != nil {
@@ -472,13 +475,8 @@ func testCheckIfaceInitDone(t *testing.T) {
 		if !ready {
 			t.Fatalf("expected ready after initial agentinfo is processed")
 		}
-		if !r.ifaceInitDone.Load() {
+		if !r.ifaceInitTracker().IsDone() {
 			t.Fatalf("ifaceInitDone should be true after init check passes")
-		}
-		r.ifaceCacheLock.RLock()
-		defer r.ifaceCacheLock.RUnlock()
-		if r.processedNames != nil {
-			t.Fatalf("processedNames should be cleared after iface init is done")
 		}
 	})
 }
@@ -501,28 +499,95 @@ func testReconcileWaitForIfaceInitDone(t *testing.T) {
 	})
 }
 
+func testCheckShareIPInitDone(t *testing.T) {
+	t.Run("check-shareip-init-done", func(t *testing.T) {
+		shareIP := &securityv1alpha1.ShareIP{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "shareip-a",
+			},
+			Spec: securityv1alpha1.ShareIPSpec{
+				IPs:          []string{"1.1.1.0/24"},
+				InterfaceIDs: []string{"if1", "if2"},
+			},
+		}
+		r := newFakeReconciler(shareIP)
+		ready, err := r.checkShareIPInitDone(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ready {
+			t.Fatalf("expected not ready before processing initial shareIP")
+		}
+		if r.shareIPInitTracker().IsDone() {
+			t.Fatalf("shareIPInitDone should be false before initial shareIP is processed")
+		}
+
+		r.markShareIPProcessed(shareIP.Name)
+
+		ready, err = r.checkShareIPInitDone(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ready {
+			t.Fatalf("expected ready after initial shareIP is processed")
+		}
+		if !r.shareIPInitTracker().IsDone() {
+			t.Fatalf("shareIPInitDone should be true after init check passes")
+		}
+	})
+}
+
+func testReconcileAgentInfoWaitForShareIPInitDone(t *testing.T) {
+	t.Run("reconcile-agentinfo-wait-for-shareip-init", func(t *testing.T) {
+		shareIP := &securityv1alpha1.ShareIP{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "shareip-a",
+			},
+			Spec: securityv1alpha1.ShareIPSpec{
+				IPs:          []string{"1.1.1.0/24"},
+				InterfaceIDs: []string{"if1", "if2"},
+			},
+		}
+		r := newFakeReconciler(fakeAgentInfoA, shareIP)
+		result, err := r.ReconcileAgentInfo(context.Background(), ctrl.Request{
+			NamespacedName: k8stypes.NamespacedName{Name: fakeAgentInfoA.Name},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.RequeueAfter != shareIPInitRetryInterval {
+			t.Fatalf("unexpected requeue duration, got %v want %v", result.RequeueAfter, shareIPInitRetryInterval)
+		}
+		if result.Requeue {
+			t.Fatalf("unexpected immediate requeue")
+		}
+	})
+}
+
 func testMarkAgentProcessedFromHandlers(t *testing.T) {
 	t.Run("mark-agent-processed-from-add-update", func(t *testing.T) {
 		queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 		r := newFakeReconciler(fakeAgentInfoA)
 		ctx := context.Background()
 
-		r.addAgentInfo(ctx, event.CreateEvent{Object: fakeAgentInfoA}, queue)
-		r.ifaceCacheLock.RLock()
-		if r.processedNames == nil || !r.processedNames.Has(fakeAgentInfoA.Name) {
-			r.ifaceCacheLock.RUnlock()
+		r.onAgentInfoAdd(ctx, event.CreateEvent{Object: fakeAgentInfoA}, queue)
+		ready, err := r.checkIfaceInitDone(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ready {
 			t.Fatalf("agent should be marked processed after addAgentInfo")
 		}
-		r.ifaceCacheLock.RUnlock()
+		if !r.ifaceInitTracker().IsDone() {
+			t.Fatalf("iface init should be done after addAgentInfo")
+		}
 
-		r.updateAgentInfo(ctx, event.UpdateEvent{
+		r.onAgentInfoUpdate(ctx, event.UpdateEvent{
 			ObjectOld: fakeAgentInfoA,
 			ObjectNew: fakeAgentInfoB,
 		}, queue)
-		r.ifaceCacheLock.RLock()
-		defer r.ifaceCacheLock.RUnlock()
-		if !r.processedNames.Has(fakeAgentInfoB.Name) {
-			t.Fatalf("agent should be marked processed after updateAgentInfo")
+		if !r.ifaceInitTracker().IsDone() {
+			t.Fatalf("iface init should remain done after updateAgentInfo")
 		}
 	})
 }
@@ -534,26 +599,15 @@ func testProcessAgentinfo(t *testing.T) {
 
 	t.Run("agentinfo-added", func(t *testing.T) {
 		// Fake: endpoint added and agentinfo added event when controller start.
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointA,
-		}, queue)
-
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointB,
-		}, queue)
-
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointD,
-		}, queue)
-
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointE,
-		}, queue)
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointA.Name}})
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointB.Name}})
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointD.Name}})
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointE.Name}})
 
 		_ = r.Client.Update(context.Background(), fakeEndpointD)
 		_ = r.Client.Update(context.Background(), fakeEndpointE)
 
-		r.addAgentInfo(ctx, event.CreateEvent{
+		r.onAgentInfoAdd(ctx, event.CreateEvent{
 			Object: fakeAgentInfoA,
 		}, queue)
 
@@ -605,7 +659,7 @@ func testProcessAgentinfo(t *testing.T) {
 		}
 
 		// Fake: agent will update information when ovsinfo changes.
-		r.updateAgentInfo(ctx, event.UpdateEvent{
+		r.onAgentInfoUpdate(ctx, event.UpdateEvent{
 			ObjectOld: fakeAgentInfoA,
 
 			ObjectNew: fakeAgentInfoB,
@@ -645,7 +699,7 @@ func testProcessAgentinfo(t *testing.T) {
 
 	t.Run("agentinfo-deleted", func(t *testing.T) {
 		// Fake: agent removed from cluster delete agentinfo.
-		r.deleteAgentInfo(ctx, event.DeleteEvent{
+		r.onAgentInfoDelete(ctx, event.DeleteEvent{
 			Object: fakeAgentInfoA,
 		}, queue)
 
@@ -680,17 +734,13 @@ func testInterfaceIPUpdate(t *testing.T) {
 	ctx := context.Background()
 	t.Run("interface ipset update", func(t *testing.T) {
 		// agentinfo added event when controller start.
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointA,
-		}, queue)
-		r.addAgentInfo(ctx, event.CreateEvent{
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointA.Name}})
+		r.onAgentInfoAdd(ctx, event.CreateEvent{
 			Object: fakeAgentInfoA,
 		}, queue)
 
-		r.addEndpoint(ctx, event.CreateEvent{
-			Object: fakeEndpointC,
-		}, queue)
-		r.addAgentInfo(ctx, event.CreateEvent{
+		queue.Add(ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: fakeEndpointC.Name}})
+		r.onAgentInfoAdd(ctx, event.CreateEvent{
 			Object: fakeAgentInfoC,
 		}, queue)
 		// process new agentinfo create request from queue
@@ -698,13 +748,25 @@ func testInterfaceIPUpdate(t *testing.T) {
 			t.Errorf("failed to process add agentinfo request")
 		}
 
-		r.updateAgentInfo(ctx, event.UpdateEvent{
+		r.onAgentInfoUpdate(ctx, event.UpdateEvent{
 			ObjectOld: fakeAgentInfoC,
 			ObjectNew: updatedfakeAgentInfoC,
 		}, queue)
+		agentInfoC := getFakeAgentInfo(r.Client, fakeAgentInfoC.Name)
+		agentInfoC.OVSInfo = updatedfakeAgentInfoC.OVSInfo
+		agentInfoC.Conditions = updatedfakeAgentInfoC.Conditions
+		if err := r.Client.Update(ctx, &agentInfoC); err != nil {
+			t.Fatalf("failed to update fake agentinfo: %v", err)
+		}
 		// process new agentinfo create request from queue
 		if err := processQueue(r, queue); err != nil {
 			t.Errorf("failed to process add agentinfo request")
+		}
+
+		if _, err := r.ReconcileAgentInfo(ctx, ctrl.Request{
+			NamespacedName: k8stypes.NamespacedName{Name: updatedfakeAgentInfoC.Name},
+		}); err != nil {
+			t.Fatalf("failed to process agentinfo reconcile: %v", err)
 		}
 
 		agentInfoA := getFakeAgentInfo(r.Client, fakeAgentInfoA.Name)
@@ -877,6 +939,102 @@ var _ = Describe("shareIP-unit-test", func() {
 				_, ok := r.shareIPCache[key]
 				Expect(ok).Should(BeFalse())
 			})
+		})
+	})
+
+	Context("ReconcileShareIP", func() {
+		key := "test-shareip"
+
+		newReq := func(name string) ctrl.Request {
+			return ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: name}}
+		}
+
+		It("should reconcile normal shareIP and update cache", func() {
+			obj := &securityv1alpha1.ShareIP{
+				ObjectMeta: v1.ObjectMeta{
+					Name: key,
+				},
+				Spec: securityv1alpha1.ShareIPSpec{
+					IPs:          []string{"1.1.1.0/24", "fe80::5054:ff:feea:e3fc/128"},
+					InterfaceIDs: []string{"id1", "id2", "id3"},
+				},
+			}
+			r := newFakeReconciler(obj)
+			r.shareIPCache = make(map[string]shareIP)
+
+			_, err := r.ReconcileShareIP(context.Background(), newReq(key))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			res, ok := r.shareIPCache[key]
+			Expect(ok).Should(BeTrue())
+			Expect(res.ips.UnsortedList()).Should(ConsistOf("1.1.1.0/24", "fe80::5054:ff:feea:e3fc/128"))
+			Expect(res.interfaceIDs.UnsortedList()).Should(ConsistOf("id1", "id2", "id3"))
+
+			ready, err := r.checkShareIPInitDone(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ready).Should(BeTrue())
+		})
+
+		It("should reconcile invalid shareIP and keep cache empty", func() {
+			obj := &securityv1alpha1.ShareIP{
+				ObjectMeta: v1.ObjectMeta{
+					Name: key,
+				},
+				Spec: securityv1alpha1.ShareIPSpec{
+					IPs:          []string{"1.1.1.0/24"},
+					InterfaceIDs: []string{"id1"},
+				},
+			}
+			r := newFakeReconciler(obj)
+			r.shareIPCache = make(map[string]shareIP)
+
+			_, err := r.ReconcileShareIP(context.Background(), newReq(key))
+			Expect(err).ShouldNot(HaveOccurred())
+			_, ok := r.shareIPCache[key]
+			Expect(ok).Should(BeFalse())
+
+			ready, err := r.checkShareIPInitDone(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ready).Should(BeTrue())
+		})
+
+		It("should reconcile notfound shareIP and delete stale cache entry", func() {
+			r := newFakeReconciler()
+			r.shareIPCache = map[string]shareIP{
+				key: {ips: sets.New[string]("10.10.10.0/24")},
+			}
+
+			_, err := r.ReconcileShareIP(context.Background(), newReq(key))
+			Expect(err).ShouldNot(HaveOccurred())
+			_, ok := r.shareIPCache[key]
+			Expect(ok).Should(BeFalse())
+		})
+
+		It("should not block when reconciling shareIP", func() {
+			obj := &securityv1alpha1.ShareIP{
+				ObjectMeta: v1.ObjectMeta{
+					Name: key,
+				},
+				Spec: securityv1alpha1.ShareIPSpec{
+					IPs:          []string{"1.1.1.0/24"},
+					InterfaceIDs: []string{"id1", "id2"},
+				},
+			}
+			r := newFakeReconciler(obj)
+			r.shareIPCache = make(map[string]shareIP)
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := r.ReconcileShareIP(context.Background(), newReq(key))
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				Expect(err).ShouldNot(HaveOccurred())
+			case <-time.After(1 * time.Second):
+				Fail("ReconcileShareIP timed out, possible lock contention or deadlock")
+			}
 		})
 	})
 


### PR DESCRIPTION
## Purpose
Fix endpoint controller initialization ordering for update agentinfo

## Changes
- Introduce a shared init-sync tracker
     Add a reusable initsync.Tracker (pkg/common/initsync/tracker.go) to manage initialization progress with thread-safe state transitions (MarkProcessed, CheckDone, IsDone),
     plus dedicated unit tests (tracker_test.go).
- Refactor endpoint controller init flow
     Rework endpoint-controller initialization to use the shared tracker for AgentInfo/ShareIP readiness, add a dedicated ReconcileAgentInfo path, and gate AgentInfo cleanup
     reconcile on ShareIP cache initialization completion by reorganizing watch/reconcile responsibilities.

## Tests
- `go test ./pkg/common/initsync -count=1`
- `go test ./pkg/controller/endpoint -count=1`

## Environment Validation
- Built and pushed debug image: `registry.smtx.io/everoute/debug:056e52f`.
- Deployed to controller VMs `172.21.150.120-122` via `eradm update --allow-pull`.
- Verified runtime image on all 3 nodes:
  - `registry.smtx.io/everoute/debug:056e52f` (`RUNNING`)
- Verified log behavior on leader (`172.21.150.120`):
  - `agentinfo controller init processed shareIP` appears.
  - No further `agentinfo reconcile waiting for shareIP cache initialization to complete` after init processing time.
