### PR TITLE
fix(ER-1688): handle +rpl rematch commit direction

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -166,7 +166,7 @@ var (
 		`actions=load:0x->NXM_NX_XXREG0[60..87],load:0x->NXM_NX_XXREG0[0..3],goto_table:70`
 	rule1v6Flow = `table=60, priority=200,icmp6,ipv6_src=2401::10:100:100:1,ipv6_dst=2401::10:100:100:2 ` +
 		`actions=load:0x->NXM_NX_XXREG0[60..87],load:0x->NXM_NX_XXREG0[0..3],goto_table:70`
-	rule2WorkModeFlow              = `table=20, priority=0,udp,nw_src=10.100.100.0/24 actions=load:0x->NXM_NX_XXREG0[60..87],load:0x->NXM_NX_XXREG0[0..3],load:0x->NXM_NX_XXREG0[5],load:0x->NXM_NX_XXREG0[127],load:0x20->NXM_NX_REG4[0..15],goto_table:70`
+	rule2WorkModeFlow              = `table=20, priority=0,udp,nw_src=10.100.100.0/24 actions=load:0x->NXM_NX_XXREG0[60..87],load:0x->NXM_NX_XXREG0[0..3],load:0x->NXM_NX_XXREG0[127],load:0x20->NXM_NX_REG4[0..15],goto_table:70`
 	ep1VlanInputFlow               = "table=0, priority=200,in_port=11 actions=push_vlan:0x8100,set_field:4097->vlan_vid,load:0x2->NXM_NX_PKT_MARK[17..18],load:0xb->NXM_NX_PKT_MARK[0..15],resubmit(,10),resubmit(,15)"
 	ep1LocalToLocalFlow            = "table=5, priority=200,dl_vlan=1,dl_src=00:00:aa:aa:aa:aa actions=load:0xb->NXM_OF_IN_PORT[],load:0->NXM_OF_VLAN_TCI[0..12],NORMAL"
 	ep2VlanInputFlow               = "table=0, priority=200,in_port=22,vlan_tci=0x1000/0x1000 actions=load:0x1->NXM_NX_REG3[0..1],load:0x2->NXM_NX_PKT_MARK[17..18],load:0x16->NXM_NX_PKT_MARK[0..15],resubmit(,1)"
@@ -192,6 +192,17 @@ var (
 		"table=10, priority=200,in_port=2 actions=load:0x1->NXM_NX_REG5[8],goto_table:50",
 	}
 
+	policyCTStateTableFlows = []string{
+		"table=1, priority=300,ct_state=+est-rel-rpl,ct_label=0/0x40,in_port=1 actions=goto_table:10",
+		"table=1, priority=300,ct_state=+est-rel-rpl,ct_label=0/0x80,in_port=2 actions=goto_table:10",
+		"table=1, priority=300,ct_state=+rpl+trk,ct_label=0x90/0x90,in_port=1 actions=goto_table:10",
+		"table=1, priority=300,ct_state=+rpl+trk,ct_label=0x60/0x60,in_port=2 actions=goto_table:10",
+		"table=1, priority=200,ct_state=-new+est actions=goto_table:69",
+		"table=1, priority=200,ct_state=+rel+trk actions=goto_table:69",
+		"table=1, priority=10,ip actions=goto_table:10",
+		"table=1, priority=10,ipv6 actions=goto_table:10",
+	}
+
 	policyActionUpdateTableFlows = []string{
 		"table=69, priority=200,ct_state=-rpl+trk,ct_label=0x30000000000000000000000000000020/0xb0000000000000000000000000000020,ip,in_port=1 actions=ct(commit,table=70,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_CT_LABEL[5]->NXM_NX_CT_LABEL[127],load:0->NXM_NX_CT_LABEL[6..7]))",
 		"table=69, priority=200,ct_state=-rpl+trk,ct_label=0x30000000000000000000000000000020/0xb0000000000000000000000000000020,ipv6,in_port=1 actions=ct(commit,table=70,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_CT_LABEL[5]->NXM_NX_CT_LABEL[127],load:0->NXM_NX_CT_LABEL[6..7]))",
@@ -211,6 +222,47 @@ var (
 		"table=69, priority=200,ct_state=+rpl+trk,ct_label=0xb0000000000000000000000000000000/0xb0000000000000000000000000000010,ipv6,in_port=1 actions=ct(commit,table=70,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_CT_LABEL[4]->NXM_NX_CT_LABEL[127],load:0->NXM_NX_CT_LABEL[6..7]))",
 		"table=69, priority=100,ct_state=+new+trk actions=load:0x1->NXM_NX_REG5[8],goto_table:70",
 		"table=69, priority=10 actions=goto_table:70",
+	}
+
+	policyForwardingTableFlows = []string{
+		"table=70, priority=10 actions=goto_table:71",
+		"table=70, priority=200,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,ip,reg5=0/0x100 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]))",
+		"table=70, priority=200,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,ipv6,reg5=0/0x100 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]))",
+		"table=70, priority=200,ct_state=+rpl+trk,ip,reg4=0/0xffff,reg5=0x100/0x100,in_port=1 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]))",
+		"table=70, priority=200,ct_state=+rpl+trk,ip,reg4=0/0xffff,reg5=0x100/0x100,in_port=2 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]))",
+		"table=70, priority=200,ct_state=+rpl+trk,ipv6,reg4=0/0xffff,reg5=0x100/0x100,in_port=1 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]))",
+		"table=70, priority=200,ct_state=+rpl+trk,ipv6,reg4=0/0xffff,reg5=0x100/0x100,in_port=2 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]))",
+		"table=70, priority=200,ct_state=-rpl+trk,ip,reg5=0x100/0x100,in_port=1 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]))",
+		"table=70, priority=200,ct_state=-rpl+trk,ip,reg5=0x100/0x100,in_port=2 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]))",
+		"table=70, priority=200,ct_state=-rpl+trk,ipv6,reg5=0x100/0x100,in_port=1 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]))",
+		"table=70, priority=200,ct_state=-rpl+trk,ipv6,reg5=0x100/0x100,in_port=2 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]))",
+		"table=70, priority=300,ct_label=0x80000000000000000000000000000000/0x80000000000000000000000000000000,ip,reg5=0/0x100 actions=load:0x20->NXM_NX_REG4[0..15],goto_table:71",
+		"table=70, priority=300,ct_label=0x80000000000000000000000000000000/0x80000000000000000000000000000000,ipv6,reg5=0/0x100 actions=load:0x20->NXM_NX_REG4[0..15],goto_table:71",
+		"table=70, priority=300,ct_state=+new+trk,tcp,reg4=0x20/0xffff,tcp_flags=-syn actions=goto_table:71",
+		"table=70, priority=300,ct_state=+new+trk,tcp6,reg4=0x20/0xffff,tcp_flags=-syn actions=goto_table:71",
+	}
+
+	policyForwardingTableALGFlows = []string{
+		"table=70, priority=203,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,tcp,reg5=0/0x100,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,tcp6,reg5=0/0x100,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,udp,reg5=0/0x100,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]),alg=tftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,ct_label=0/0xffff000000000000000000000000000,udp6,reg5=0/0x100,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125]),alg=tftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,tcp,reg4=0/0xffff,reg5=0x100/0x100,in_port=1,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,tcp,reg4=0/0xffff,reg5=0x100/0x100,in_port=2,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,tcp6,reg4=0/0xffff,reg5=0x100/0x100,in_port=1,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,tcp6,reg4=0/0xffff,reg5=0x100/0x100,in_port=2,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=ftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,udp,reg4=0/0xffff,reg5=0x100/0x100,in_port=1,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=tftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,udp,reg4=0/0xffff,reg5=0x100/0x100,in_port=2,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=tftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,udp6,reg4=0/0xffff,reg5=0x100/0x100,in_port=1,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=tftp)",
+		"table=70, priority=203,ct_state=+rpl+trk,udp6,reg4=0/0xffff,reg5=0x100/0x100,in_port=2,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=tftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,tcp,reg5=0x100/0x100,in_port=1,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=ftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,tcp,reg5=0x100/0x100,in_port=2,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=ftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,tcp6,reg5=0x100/0x100,in_port=1,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=ftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,tcp6,reg5=0x100/0x100,in_port=2,tp_dst=21 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=ftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,udp,reg5=0x100/0x100,in_port=1,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=tftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,udp,reg5=0x100/0x100,in_port=2,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=tftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,udp6,reg5=0x100/0x100,in_port=1,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[5],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[6]),alg=tftp)",
+		"table=70, priority=203,ct_state=-rpl+trk,udp6,reg5=0x100/0x100,in_port=2,tp_dst=69 actions=ct(commit,table=71,zone=NXM_NX_REG4[16..31],exec(move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127],move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87],move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3],move:NXM_NX_XXREG0[127]->NXM_NX_CT_LABEL[4],move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89],move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107],load:0->NXM_NX_CT_LABEL[90..91],load:0->NXM_NX_CT_LABEL[108..123],load:0x3->NXM_NX_CT_LABEL[124..125],load:0x1->NXM_NX_CT_LABEL[7]),alg=tftp)",
 	}
 )
 
@@ -1265,104 +1317,16 @@ func testUplinkBridgeMarkFlows(t *testing.T) {
 	})
 }
 
-func containsAll(flow string, strs ...string) bool {
-	for _, str := range strs {
-		if !strings.Contains(flow, str) {
-			return false
-		}
-	}
-	return true
-}
-
-func isOriginFlow(flow string) bool {
-	checkCommit := strings.Contains(flow, "reg5=0x100/0x100")
-	checkOriginActions := containsAll(flow,
-		"move:NXM_NX_XXREG0[126..127]->NXM_NX_CT_LABEL[126..127]", // final policy actions
-		"move:NXM_NX_XXREG0[4..5]->NXM_NX_CT_LABEL[4..5]",         // mark policy actions
-		"move:NXM_NX_XXREG0[0..3]->NXM_NX_CT_LABEL[0..3]",         // round number
-		"move:NXM_NX_XXREG0[32..87]->NXM_NX_CT_LABEL[32..87]",     // flow IDs
-		"load:0x3->NXM_NX_CT_LABEL[124..125]",                     // mark micro-segment
-		"move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[88..89]",   // origin packet source
-		"load:0->NXM_NX_CT_LABEL[90..91]",                         // reset reply packet source
-		"move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[92..107]",   // origin inport
-		"load:0->NXM_NX_CT_LABEL[108..123]",                       // reset reply inport
-	)
-	return checkCommit && checkOriginActions
-}
-
-func isRplFlow(flow string) bool {
-	checkRpl := strings.Contains(flow, "ct_state=+rpl+trk")
-	checkActions := containsAll(flow,
-		"load:0x3->NXM_NX_CT_LABEL[124..125]",                    // mark micro-segment
-		"move:NXM_NX_PKT_MARK[17..18]->NXM_NX_CT_LABEL[90..91]",  // reply packet source
-		"move:NXM_NX_PKT_MARK[0..15]->NXM_NX_CT_LABEL[108..123]", // reply inport
-	)
-	return checkRpl && checkActions
-}
-
-func isIp(flow string) bool {
-	return strings.Contains(flow, "ip") && !isIp6(flow)
-}
-
-func isIp6(flow string) bool {
-	return strings.Contains(flow, "ipv6")
-}
-
-func isTcp(flow string) bool {
-	return strings.Contains(flow, "tcp") && !isTcp6(flow)
-}
-
-func isTcp6(flow string) bool {
-	return strings.Contains(flow, "tcp6")
-}
-
-func isUdp(flow string) bool {
-	return strings.Contains(flow, "udp") && !isUdp6(flow)
-}
-
-func isUdp6(flow string) bool {
-	return strings.Contains(flow, "udp6")
-}
-
-func hasTpDst(flow string, port int) bool {
-	return strings.Contains(flow, fmt.Sprintf("tp_dst=%d", port))
-}
-
 func TestPolicyBridgeFlows(t *testing.T) {
 	t.Run("test policy bridge general flows", func(t *testing.T) {
 		RegisterTestingT(t)
 		flows, err := dumpAllFlows("ovsbr0-policy")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(flows).ShouldNot(BeEmpty())
-		table70Flows := []string{}
-		for _, flow := range flows {
-			// skip ALG flows and it should be in table 70
-			if strings.Contains(flow, "table=70,") && !strings.Contains(flow, "tp_dst") {
-				table70Flows = append(table70Flows, flow)
-			}
-		}
-		var (
-			ipOriginFlow   = false
-			ipv6OriginFlow = false
-			ipRplFlow      = false
-			ipv6RplFlow    = false
-		)
-		for _, flow := range table70Flows {
-			switch {
-			case isIp(flow) && isOriginFlow(flow):
-				ipOriginFlow = true
-			case isIp6(flow) && isOriginFlow(flow):
-				ipv6OriginFlow = true
-			case isIp(flow) && isRplFlow(flow):
-				ipRplFlow = true
-			case isIp6(flow) && isRplFlow(flow):
-				ipv6RplFlow = true
-			}
-		}
-		Expect(ipOriginFlow).Should(BeTrue())
-		Expect(ipv6OriginFlow).Should(BeTrue())
-		Expect(ipRplFlow).Should(BeTrue())
-		Expect(ipv6RplFlow).Should(BeTrue())
+		currentTable70Flows := lo.Filter(flows, func(f string, _ int) bool {
+			return strings.HasPrefix(f, "table=70,") && !strings.Contains(f, "tp_dst")
+		})
+		Expect(currentTable70Flows).Should(ConsistOf(policyForwardingTableFlows))
 	})
 
 	t.Run("test policy bridge ALG flows", func(t *testing.T) {
@@ -1370,50 +1334,10 @@ func TestPolicyBridgeFlows(t *testing.T) {
 		flows, err := dumpAllFlows("ovsbr0-policy")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(flows).ShouldNot(BeEmpty())
-		table70Flows := []string{}
-		for _, flow := range flows {
-			if strings.Contains(flow, "table=70,") && strings.Contains(flow, "tp_dst") {
-				table70Flows = append(table70Flows, flow)
-			}
-		}
-		var (
-			ftpOriginFlow   = false // tcp 21
-			ftp6OriginFlow  = false // tcp6 21
-			tftpOriginFlow  = false // udp 69
-			tftp6OriginFlow = false // udp6 69
-			ftpRplFlow      = false // tcp 21
-			ftp6RplFlow     = false // tcp6 21
-			tftpRplFlow     = false // udp 69
-			tftp6RplFlow    = false // udp6 69
-		)
-		for _, flow := range table70Flows {
-			switch {
-			case isTcp(flow) && hasTpDst(flow, 21) && isOriginFlow(flow):
-				ftpOriginFlow = true
-			case isTcp6(flow) && hasTpDst(flow, 21) && isOriginFlow(flow):
-				ftp6OriginFlow = true
-			case isUdp(flow) && hasTpDst(flow, 69) && isOriginFlow(flow):
-				tftpOriginFlow = true
-			case isUdp6(flow) && hasTpDst(flow, 69) && isOriginFlow(flow):
-				tftp6OriginFlow = true
-			case isTcp(flow) && hasTpDst(flow, 21) && isRplFlow(flow):
-				ftpRplFlow = true
-			case isTcp6(flow) && hasTpDst(flow, 21) && isRplFlow(flow):
-				ftp6RplFlow = true
-			case isUdp(flow) && hasTpDst(flow, 69) && isRplFlow(flow):
-				tftpRplFlow = true
-			case isUdp6(flow) && hasTpDst(flow, 69) && isRplFlow(flow):
-				tftp6RplFlow = true
-			}
-		}
-		Expect(ftpOriginFlow).Should(BeTrue())
-		Expect(ftp6OriginFlow).Should(BeTrue())
-		Expect(tftpOriginFlow).Should(BeTrue())
-		Expect(tftp6OriginFlow).Should(BeTrue())
-		Expect(ftpRplFlow).Should(BeTrue())
-		Expect(ftp6RplFlow).Should(BeTrue())
-		Expect(tftpRplFlow).Should(BeTrue())
-		Expect(tftp6RplFlow).Should(BeTrue())
+		currentTable70ALGFlows := lo.Filter(flows, func(f string, _ int) bool {
+			return strings.HasPrefix(f, "table=70,") && strings.Contains(f, "tp_dst")
+		})
+		Expect(currentTable70ALGFlows).Should(ConsistOf(policyForwardingTableALGFlows))
 	})
 
 	t.Run("test policy bridge ct state flows", func(t *testing.T) {
@@ -1424,39 +1348,7 @@ func TestPolicyBridgeFlows(t *testing.T) {
 		Expect(currentFlows).ShouldNot(BeEmpty())
 
 		currentTable1Flows := lo.Filter(currentFlows, func(f string, _ int) bool { return strings.HasPrefix(f, "table=1,") })
-
-		var (
-			hasRematchFromLocal bool
-			hasRematchFromCls   bool
-			hasEstState         bool
-			hasRelState         bool
-			hasIPv4Default      bool
-			hasIPv6Default      bool
-		)
-
-		for _, f := range currentTable1Flows {
-			switch {
-			case containsAll(f, "table=1", "priority=300", "ct_state=+est-rel-rpl", "in_port=1", "ct_label=0/"):
-				hasRematchFromLocal = true
-			case containsAll(f, "table=1", "priority=300", "ct_state=+est-rel-rpl", "in_port=2", "ct_label=0/"):
-				hasRematchFromCls = true
-			case containsAll(f, "table=1", "priority=200", "ct_state=-new+est", "actions=goto_table:69"):
-				hasEstState = true
-			case containsAll(f, "table=1", "priority=200", "ct_state=+rel+trk", "actions=goto_table:69"):
-				hasRelState = true
-			case containsAll(f, "table=1", "priority=10", "ip actions=goto_table:10"):
-				hasIPv4Default = true
-			case containsAll(f, "table=1", "priority=10", "ipv6 actions=goto_table:10"):
-				hasIPv6Default = true
-			}
-		}
-
-		Expect(hasRematchFromLocal).Should(BeTrue())
-		Expect(hasRematchFromCls).Should(BeTrue())
-		Expect(hasEstState).Should(BeTrue())
-		Expect(hasRelState).Should(BeTrue())
-		Expect(hasIPv4Default).Should(BeTrue())
-		Expect(hasIPv6Default).Should(BeTrue())
+		Expect(currentTable1Flows).Should(ConsistOf(policyCTStateTableFlows))
 	})
 
 	t.Run("test policy bridge direction selection flows", func(t *testing.T) {

--- a/pkg/agent/datapath/policyBridge.go
+++ b/pkg/agent/datapath/policyBridge.go
@@ -95,9 +95,6 @@ const (
 	FinalPolicyActionXXREG0BitStart     = MonitorTier3PolicyActionXXREG0Bit
 	FinalPolicyActionXXREG0BitEnd       = WorkPolicyActionXXREG0Bit
 	FinalPolicyActionXXREG0BitSize      = FinalPolicyActionXXREG0BitEnd - FinalPolicyActionXXREG0BitStart + 1
-	MarkPolicyActionXXREG0BitStart      = TargetWorkPolicyActionXXREG0Bit
-	MarkPolicyActionXXREG0BitEnd        = SourceWorkPolicyActionXXREG0Bit
-	MarkPolicyActionXXREG0BitSize       = MarkPolicyActionXXREG0BitEnd - MarkPolicyActionXXREG0BitStart + 1
 
 	// packet source
 	OriginPacketSourceXXREG0BitStart = 88
@@ -161,8 +158,6 @@ var (
 	MonitorTier3FlowSpaceNXRange    = openflow13.NewNXRange(MonitorTier3FlowSpaceXXREG0BitStart, MonitorTier3FlowSpaceXXREG0BitEnd)
 	WorkPolicyActionNXRange         = openflow13.NewNXRange(WorkPolicyActionXXREG0Bit, WorkPolicyActionXXREG0Bit)
 	MonitorTier3PolicyActionNXRange = openflow13.NewNXRange(MonitorTier3PolicyActionXXREG0Bit, MonitorTier3PolicyActionXXREG0Bit)
-	SourceWorkPolicyActionNXRange   = openflow13.NewNXRange(SourceWorkPolicyActionXXREG0Bit, SourceWorkPolicyActionXXREG0Bit)
-	TargetWorkPolicyActionNXRange   = openflow13.NewNXRange(TargetWorkPolicyActionXXREG0Bit, TargetWorkPolicyActionXXREG0Bit)
 	EgressTreatedNXRange            = openflow13.NewNXRange(EgressTreatedXXREG0Bit, EgressTreatedXXREG0Bit)
 	IngressTreatedNXRange           = openflow13.NewNXRange(IngressTreatedXXREG0Bit, IngressTreatedXXREG0Bit)
 	OriginShouldCommitCTReg5NXRange = openflow13.NewNXRange(OriginShouldCommitCTREG5Bit, OriginShouldCommitCTREG5Bit)
@@ -818,6 +813,32 @@ func (p *PolicyBridge) initCtStateTableRematchPolicyFlow() error {
 		return fmt.Errorf("failed to install from cls ingress flow: %w", err)
 	}
 
+	// Fixes ER-1688:
+	// For reply packets, re-match policies when action match drop
+	ctRplState := ctRplTrkState()
+
+	fromLocalRplFlow, _ := p.ctStateTable.NewFlow(ofctrl.FlowMatch{
+		Priority:    HIGH_MATCH_FLOW_PRIORITY,
+		InputPort:   p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToLocalSuffix],
+		CtStates:    ctRplState,
+		CTLabel:     bytesArray16BitOR(&TargetWorkModeActionMatchCTLabel, &IngressTreatedMatchCTLabel),
+		CTLabelMask: bytesArray16BitOR(&TargetWorkModeActionMatchCTLabelMask, &IngressTreatedMatchCTLabelMask),
+	})
+	if err := fromLocalRplFlow.Next(p.directionSelectionTable); err != nil {
+		return fmt.Errorf("failed to install from local rpl rematch flow: %w", err)
+	}
+
+	fromClsRplFlow, _ := p.ctStateTable.NewFlow(ofctrl.FlowMatch{
+		Priority:    HIGH_MATCH_FLOW_PRIORITY,
+		InputPort:   p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToClsSuffix],
+		CtStates:    ctRplState,
+		CTLabel:     bytesArray16BitOR(&SourceWorkModeActionMatchCTLabel, &EgressTreatedMatchCTLabel),
+		CTLabelMask: bytesArray16BitOR(&SourceWorkModeActionMatchCTLabelMask, &EgressTreatedMatchCTLabelMask),
+	})
+	if err := fromClsRplFlow.Next(p.directionSelectionTable); err != nil {
+		return fmt.Errorf("failed to install from cls rpl rematch flow: %w", err)
+	}
+
 	return nil
 }
 
@@ -887,6 +908,38 @@ func ctRelTrkState() *openflow13.CTStates {
 	state.SetRel()
 	state.SetTrk()
 	return state
+}
+
+func ctNoRplTrkState() *openflow13.CTStates {
+	state := openflow13.NewCTStates()
+	state.SetTrk()
+	state.UnsetRpl()
+	return state
+}
+
+type ctCommitDirection struct {
+	inputPort        uint32
+	treatedAct       *openflow13.NXActionRegLoad
+	replyTreatedAct  *openflow13.NXActionRegLoad
+	originWorkAction openflow13.Action
+	replyWorkAction  openflow13.Action
+}
+
+func setCtFlowMatchDstPort(match *ofctrl.FlowMatch, dstPort uint16, ipProto uint8) {
+	switch ipProto {
+	case PROTOCOL_TCP:
+		match.IpProto = ipProto
+		match.TcpDstPort = dstPort
+		match.TcpDstPortMask = PortMaskMatchFullBit
+		match.UdpDstPort = 0
+		match.UdpDstPortMask = 0
+	case PROTOCOL_UDP:
+		match.IpProto = ipProto
+		match.UdpDstPort = dstPort
+		match.UdpDstPortMask = PortMaskMatchFullBit
+		match.TcpDstPort = 0
+		match.TcpDstPortMask = 0
+	}
 }
 
 // Table 70 conntrack commit table
@@ -981,13 +1034,6 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 		NXM_NX_XXREG0,
 		NXM_NX_CT_LABEL,
 	)
-	moveMarkActionAct := openflow13.NewNXActionRegMove(
-		MarkPolicyActionXXREG0BitSize,
-		MarkPolicyActionXXREG0BitStart,
-		MarkPolicyActionXXREG0BitStart,
-		NXM_NX_XXREG0,
-		NXM_NX_CT_LABEL,
-	)
 	movePolicyAct := openflow13.NewNXActionRegMove(
 		AllFlowSpaceXXREG0BitSize,
 		AllFlowSpaceXXREG0BitStart,
@@ -1031,6 +1077,34 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 		NXM_NX_CT_LABEL,
 		0,
 	)
+	setSourceWorkActionAct := openflow13.NewNXActionRegMove(
+		WorkPolicyActionXXREG0BitSize,
+		WorkPolicyActionXXREG0Bit,
+		SourceWorkPolicyActionXXREG0Bit,
+		NXM_NX_XXREG0,
+		NXM_NX_CT_LABEL,
+	)
+	setTargetWorkActionAct := openflow13.NewNXActionRegMove(
+		WorkPolicyActionXXREG0BitSize,
+		WorkPolicyActionXXREG0Bit,
+		TargetWorkPolicyActionXXREG0Bit,
+		NXM_NX_XXREG0,
+		NXM_NX_CT_LABEL,
+	)
+	markReplySourceAct := openflow13.NewNXActionRegMove(
+		PacketSourcePKTMARKBitSize,
+		PacketSourcePKTMARKBitStart,
+		ReplyPacketSourceXXREG0BitStart,
+		NXM_NX_PKT_MARK,
+		NXM_NX_CT_LABEL,
+	)
+	markReplyInportAct := openflow13.NewNXActionRegMove(
+		InportPKTMARKBitSize,
+		InportPKTMARKBitStart,
+		ReplyInportXXREG0BitStart,
+		NXM_NX_PKT_MARK,
+		NXM_NX_CT_LABEL,
+	)
 	// mark 0x3(micro segmentation) to ct label[124..125]
 	markMSAct := openflow13.NewNXActionRegLoad(
 		openflow13.NewNXRange(EncodingSchemeXXREG0BitStart, EncodingSchemeXXREG0BitEnd).ToOfsBits(),
@@ -1051,9 +1125,9 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 		IngressTreatedXXREG0BitSize,
 	)
 
-	flowMatch := ofctrl.FlowMatch{
+	originFlowMatch := ofctrl.FlowMatch{
 		Priority: MID_MATCH_FLOW_PRIORITY,
-		// set ether type later
+		CtStates: ctNoRplTrkState(),
 		// fix: ER-1499
 		// should commit ct when commit ct flag has been set
 		Regs: []*ofctrl.NXRegister{
@@ -1064,33 +1138,57 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 			},
 		},
 	}
+	rplRematchFlowMatch := ofctrl.FlowMatch{
+		Priority: MID_MATCH_FLOW_PRIORITY,
+		CtStates: ctRplTrkState(),
+		Regs: []*ofctrl.NXRegister{
+			{
+				RegID: constants.OVSReg4,
+				Data:  0,
+				Range: openflow13.NewNXRange(0, 15),
+			},
+			{
+				RegID: constants.OVSReg5,
+				Data:  OriginShouldCommitCTReg5NXRange.ToUint32Mask(),
+				Range: OriginShouldCommitCTReg5NXRange,
+			},
+		},
+		// only re-commit +rpl traffic when current packet action is allow.
+		// reg4[0..15]=0 means no deny/fallback action was set by policy matching.
+	}
 
 	var (
 		ethertypes = [...]uint16{protocol.IPv4_MSG, protocol.IPv6_MSG}
-		directions = [...]lo.Tuple2[uint32, *openflow13.NXActionRegLoad]{
-			lo.T2(
-				p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToLocalSuffix],
-				maskEgressTreatedAct,
-			),
-			lo.T2(
-				p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToClsSuffix],
-				maskIngressTreatedAct,
-			),
+		directions = [...]ctCommitDirection{
+			{
+				inputPort:        p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToLocalSuffix],
+				treatedAct:       maskEgressTreatedAct,
+				replyTreatedAct:  maskIngressTreatedAct,
+				originWorkAction: setSourceWorkActionAct,
+				replyWorkAction:  setTargetWorkActionAct,
+			},
+			{
+				inputPort:        p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToClsSuffix],
+				treatedAct:       maskIngressTreatedAct,
+				replyTreatedAct:  maskEgressTreatedAct,
+				originWorkAction: setTargetWorkActionAct,
+				replyWorkAction:  setSourceWorkActionAct,
+			},
 		}
 	)
 
 	for _, ethertype := range ethertypes {
-		flowMatch.Ethertype = ethertype
+		originFlowMatch.Ethertype = ethertype
 		for _, direction := range directions {
-			flowMatch.InputPort = direction.A
-			treatedAct := direction.B
-			ctCommitFlow, _ := p.ctCommitTable.NewFlow(flowMatch)
+			originFlowMatch.InputPort = direction.inputPort
+			ctCommitFlow, _ := p.ctCommitTable.NewFlow(originFlowMatch)
 			ctCommitAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
-				moveFinalActionAct, moveMarkActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+				moveFinalActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+				direction.originWorkAction,         // src/dst action
 				markOriginSourceAct, markInportAct, // inport and origin source bridge
 				markResetOriginSourceAct, markResetInportAct, // reset origin source and inport
-				markMSAct,  // micro segmentation
-				treatedAct, // ER-1177 mask the flow processed with policies in egress.
+				markMSAct,            // micro segmentation
+				direction.treatedAct, // ER-1177 mask the flow processed with policies in egress.
 			)
 			if err := ctCommitFlow.SetConntrack(ctCommitAction); err != nil {
 				return fmt.Errorf("failed to set ct normal commit action, error: %v", err)
@@ -1100,21 +1198,20 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 			}
 		}
 	}
-
-	markReplySourceAct := openflow13.NewNXActionRegMove(
-		PacketSourcePKTMARKBitSize,
-		PacketSourcePKTMARKBitStart,
-		ReplyPacketSourceXXREG0BitStart,
-		NXM_NX_PKT_MARK,
-		NXM_NX_CT_LABEL,
-	)
-	markReplyInportAct := openflow13.NewNXActionRegMove(
-		InportPKTMARKBitSize,
-		InportPKTMARKBitStart,
-		ReplyInportXXREG0BitStart,
-		NXM_NX_PKT_MARK,
-		NXM_NX_CT_LABEL,
-	)
+	if err := p.initCtCommitTableRplRematchFlow(
+		rplRematchFlowMatch,
+		ethertypes[:],
+		directions[:],
+		ctDropTable,
+		moveFinalActionAct,
+		movePolicyAct,
+		moveRoundNumAct,
+		markReplySourceAct,
+		markReplyInportAct,
+		markMSAct,
+	); err != nil {
+		return fmt.Errorf("failed to init ct rpl rematch flow: %w", err)
+	}
 
 	ctCommitRplAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
 		markReplySourceAct, markReplyInportAct, // inport and reply source bridge
@@ -1122,9 +1219,16 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 	)
 
 	ctCommitReplyFlow, _ := p.ctCommitTable.NewFlow(ofctrl.FlowMatch{
-		Priority:    MID_MATCH_FLOW_PRIORITY,
-		Ethertype:   protocol.IPv4_MSG,
-		CtStates:    ctRplTrkState(),
+		Priority:  MID_MATCH_FLOW_PRIORITY,
+		Ethertype: protocol.IPv4_MSG,
+		CtStates:  ctRplTrkState(),
+		Regs: []*ofctrl.NXRegister{
+			{
+				RegID: constants.OVSReg5,
+				Data:  0,
+				Range: OriginShouldCommitCTReg5NXRange,
+			},
+		},
 		CTLabel:     &NoReplyMatchCTLabel,
 		CTLabelMask: &NoReplyMatchCTLabelMask,
 	})
@@ -1184,6 +1288,82 @@ func (p *PolicyBridge) initCTFlow(_ *ofctrl.OFSwitch) error {
 		return fmt.Errorf("failed to install egress tier3 drop table flow, error: %v", err)
 	}
 
+	return nil
+}
+
+func (p *PolicyBridge) initCtCommitTableRplRematchFlow(
+	flowMatch ofctrl.FlowMatch,
+	ethertypes []uint16,
+	directions []ctCommitDirection,
+	ctDropTable uint8,
+	moveFinalActionAct openflow13.Action,
+	movePolicyAct openflow13.Action,
+	moveRoundNumAct openflow13.Action,
+	markReplySourceAct openflow13.Action,
+	markReplyInportAct openflow13.Action,
+	markMSAct openflow13.Action,
+) error {
+	for _, ethertype := range ethertypes {
+		flowMatch.Ethertype = ethertype
+		for _, direction := range directions {
+			flowMatch.InputPort = direction.inputPort
+			ctRplRematchFlow, _ := p.ctCommitTable.NewFlow(flowMatch)
+			ctRplRematchAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
+				moveFinalActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+				direction.replyWorkAction,              // src/dst action
+				markReplySourceAct, markReplyInportAct, // inport and reply source bridge
+				markMSAct,                 // micro segmentation
+				direction.replyTreatedAct, // mark policy treated state
+			)
+			if err := ctRplRematchFlow.SetConntrack(ctRplRematchAction); err != nil {
+				return fmt.Errorf("failed to set ct rpl rematch commit action, error: %v", err)
+			}
+			if err := ctRplRematchFlow.Next(ofctrl.NewEmptyElem()); err != nil {
+				return fmt.Errorf("failed to install ct rpl rematch flow, error: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (p *PolicyBridge) initCtCommitTableALGRplRematchFlow(
+	baseFlowMatch ofctrl.FlowMatch,
+	algProtocols []lo.Tuple2[uint16, uint8],
+	ethertypes []uint16,
+	directions []ctCommitDirection,
+	ctDropTable uint8,
+	moveFinalActionAct openflow13.Action,
+	movePolicyAct openflow13.Action,
+	moveRoundNumAct openflow13.Action,
+	markReplySourceAct openflow13.Action,
+	markReplyInportAct openflow13.Action,
+	markMSAct openflow13.Action,
+) error {
+	for _, algProtocol := range algProtocols {
+		dstPort := algProtocol.A
+		ipProto := algProtocol.B
+		flowMatch := baseFlowMatch
+		setCtFlowMatchDstPort(&flowMatch, dstPort, ipProto)
+		for _, ethertype := range ethertypes {
+			flowMatch.Ethertype = ethertype
+			for _, direction := range directions {
+				flowMatch.InputPort = direction.inputPort
+				rplRematchFlow, _ := p.ctCommitTable.NewFlow(flowMatch)
+				rplRematchAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
+					moveFinalActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+					direction.replyWorkAction,              // src/dst action
+					markReplySourceAct, markReplyInportAct, // inport and reply source bridge
+					markMSAct,                 // micro segmentation
+					direction.replyTreatedAct, // mark policy treated state
+				)
+				rplRematchAction.SetAlg(dstPort)
+				_ = rplRematchFlow.SetConntrack(rplRematchAction)
+				if err := rplRematchFlow.Next(ofctrl.NewEmptyElem()); err != nil {
+					return fmt.Errorf("failed to install alg rpl rematch flow, err: %v", err)
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -1387,13 +1567,6 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 		NXM_NX_XXREG0,
 		NXM_NX_CT_LABEL,
 	)
-	moveMarkActionAct := openflow13.NewNXActionRegMove(
-		MarkPolicyActionXXREG0BitSize,
-		MarkPolicyActionXXREG0BitStart,
-		MarkPolicyActionXXREG0BitStart,
-		NXM_NX_XXREG0,
-		NXM_NX_CT_LABEL,
-	)
 	movePolicyAct := openflow13.NewNXActionRegMove(
 		AllFlowSpaceXXREG0BitSize,
 		AllFlowSpaceXXREG0BitStart,
@@ -1437,6 +1610,20 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 		NXM_NX_CT_LABEL,
 		0,
 	)
+	setSourceWorkActionAct := openflow13.NewNXActionRegMove(
+		WorkPolicyActionXXREG0BitSize,
+		WorkPolicyActionXXREG0Bit,
+		SourceWorkPolicyActionXXREG0Bit,
+		NXM_NX_XXREG0,
+		NXM_NX_CT_LABEL,
+	)
+	setTargetWorkActionAct := openflow13.NewNXActionRegMove(
+		WorkPolicyActionXXREG0BitSize,
+		WorkPolicyActionXXREG0Bit,
+		TargetWorkPolicyActionXXREG0Bit,
+		NXM_NX_XXREG0,
+		NXM_NX_CT_LABEL,
+	)
 	// mark 0x3(micro segmentation) to ct label[124..125]
 	markMSAct := openflow13.NewNXActionRegLoad(
 		openflow13.NewNXRange(EncodingSchemeXXREG0BitStart, EncodingSchemeXXREG0BitEnd).ToOfsBits(),
@@ -1478,21 +1665,28 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 			lo.T2(TFTPPort, uint8(PROTOCOL_UDP)),
 		}
 		ethertypes = [...]uint16{protocol.IPv4_MSG, protocol.IPv6_MSG}
-		directions = [...]lo.Tuple2[uint32, *openflow13.NXActionRegLoad]{
-			lo.T2(
-				p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToLocalSuffix],
-				maskEgressTreatedAct,
-			),
-			lo.T2(
-				p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToClsSuffix],
-				maskIngressTreatedAct,
-			),
+		directions = [...]ctCommitDirection{
+			{
+				inputPort:        p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToLocalSuffix],
+				treatedAct:       maskEgressTreatedAct,
+				replyTreatedAct:  maskIngressTreatedAct,
+				originWorkAction: setSourceWorkActionAct,
+				replyWorkAction:  setTargetWorkActionAct,
+			},
+			{
+				inputPort:        p.datapathManager.BridgeChainPortMap[p.localBrName][PolicyToClsSuffix],
+				treatedAct:       maskIngressTreatedAct,
+				replyTreatedAct:  maskEgressTreatedAct,
+				originWorkAction: setTargetWorkActionAct,
+				replyWorkAction:  setSourceWorkActionAct,
+			},
 		}
 	)
 
 	// match
 	originFlowMatch := ofctrl.FlowMatch{
 		Priority: MID_MATCH_FLOW_PRIORITY + FLOW_MATCH_OFFSET,
+		CtStates: ctNoRplTrkState(),
 		// fix: ER-1499
 		// should commit ct when commit ct flag has been set
 		Regs: []*ofctrl.NXRegister{
@@ -1503,46 +1697,55 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 			},
 		},
 	}
+	rplRematchFlowMatch := ofctrl.FlowMatch{
+		Priority: MID_MATCH_FLOW_PRIORITY + FLOW_MATCH_OFFSET,
+		CtStates: ctRplTrkState(),
+		Regs: []*ofctrl.NXRegister{
+			{
+				RegID: constants.OVSReg4,
+				Data:  0,
+				Range: openflow13.NewNXRange(0, 15),
+			},
+			{
+				RegID: constants.OVSReg5,
+				Data:  OriginShouldCommitCTReg5NXRange.ToUint32Mask(),
+				Range: OriginShouldCommitCTReg5NXRange,
+			},
+		},
+		// only re-commit +rpl traffic when current packet action is allow.
+		// reg4[0..15]=0 means no deny/fallback action was set by policy matching.
+	}
 	replyFlowMatch := ofctrl.FlowMatch{
-		Priority:    MID_MATCH_FLOW_PRIORITY + FLOW_MATCH_OFFSET,
-		CtStates:    ctRplTrkState(),
+		Priority: MID_MATCH_FLOW_PRIORITY + FLOW_MATCH_OFFSET,
+		CtStates: ctRplTrkState(),
+		Regs: []*ofctrl.NXRegister{
+			{
+				RegID: constants.OVSReg5,
+				Data:  0,
+				Range: OriginShouldCommitCTReg5NXRange,
+			},
+		},
 		CTLabel:     &NoReplyMatchCTLabel,
 		CTLabelMask: &NoReplyMatchCTLabelMask,
-	}
-
-	var setDstPort = func(match *ofctrl.FlowMatch, dstPort uint16, ipProto uint8) {
-		switch ipProto {
-		case PROTOCOL_TCP:
-			match.IpProto = ipProto
-			match.TcpDstPort = dstPort
-			match.TcpDstPortMask = PortMaskMatchFullBit
-			match.UdpDstPort = 0
-			match.UdpDstPortMask = 0
-		case PROTOCOL_UDP:
-			match.IpProto = ipProto
-			match.UdpDstPort = dstPort
-			match.UdpDstPortMask = PortMaskMatchFullBit
-			match.TcpDstPort = 0
-			match.TcpDstPortMask = 0
-		}
 	}
 
 	for _, algProtocol := range algProtocols {
 		dstPort := algProtocol.A
 		ipProto := algProtocol.B
-		setDstPort(&originFlowMatch, dstPort, ipProto)
+		setCtFlowMatchDstPort(&originFlowMatch, dstPort, ipProto)
+		setCtFlowMatchDstPort(&replyFlowMatch, dstPort, ipProto)
 		for _, ethertype := range ethertypes {
 			originFlowMatch.Ethertype = ethertype
 			for _, direction := range directions {
-				originFlowMatch.InputPort = direction.A
-				treatedAct := direction.B
+				originFlowMatch.InputPort = direction.inputPort
 				originFlow, _ := p.ctCommitTable.NewFlow(originFlowMatch)
 				originAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
-					moveFinalActionAct, moveMarkActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+					moveFinalActionAct, movePolicyAct, moveRoundNumAct, // policy numbers
+					direction.originWorkAction,         // src/dst action
 					markOriginSourceAct, markInportAct, // inport and origin source bridge
 					resetReplySourceAct, resetReplyInportAct, // reset origin source and inport
-					markMSAct,  // micro segmentation
-					treatedAct, // ER-1177 mask the flow processed with policies in egress.
+					markMSAct,            // micro segmentation
+					direction.treatedAct, // ER-1177 mask the flow processed with policies in egress.
 				)
 				originAction.SetAlg(dstPort)
 				_ = originFlow.SetConntrack(originAction)
@@ -1551,7 +1754,6 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 				}
 			}
 		}
-		setDstPort(&replyFlowMatch, dstPort, ipProto)
 		algRplAction, _ := ofctrl.NewConntrackActionWithZoneField(true, false, &ctDropTable, policyCTZoneReg, policyCTZoneRange,
 			markReplySourceAct, markReplyInportAct, // inport and reply source bridge
 			markMSAct, // micro segmentation
@@ -1565,6 +1767,21 @@ func (p *PolicyBridge) initALGFlow(_ *ofctrl.OFSwitch) error {
 				return fmt.Errorf("failed to install alg reply flow, err: %v", err)
 			}
 		}
+	}
+	if err := p.initCtCommitTableALGRplRematchFlow(
+		rplRematchFlowMatch,
+		algProtocols[:],
+		ethertypes[:],
+		directions[:],
+		ctDropTable,
+		moveFinalActionAct,
+		movePolicyAct,
+		moveRoundNumAct,
+		markReplySourceAct,
+		markReplyInportAct,
+		markMSAct,
+	); err != nil {
+		return fmt.Errorf("failed to init alg ct rpl rematch flow: %w", err)
 	}
 	return nil
 }
@@ -2333,18 +2550,6 @@ func (p *PolicyBridge) AddMicroSegmentRule(ctx context.Context, seqID uint32, ru
 			if err := ruleFlow.LoadField("nxm_nx_xxreg0", 0x1, WorkPolicyActionNXRange); err != nil {
 				log.Error(err, "Failed to load field")
 				return nil, err
-			}
-			switch direction {
-			case POLICY_DIRECTION_OUT:
-				if err := ruleFlow.LoadField("nxm_nx_xxreg0", 0x1, SourceWorkPolicyActionNXRange); err != nil {
-					log.Error(err, "Failed to load field")
-					return nil, err
-				}
-			case POLICY_DIRECTION_IN:
-				if err := ruleFlow.LoadField("nxm_nx_xxreg0", 0x1, TargetWorkPolicyActionNXRange); err != nil {
-					log.Error(err, "Failed to load field")
-					return nil, err
-				}
 			}
 		default:
 			err := fmt.Errorf("unknown action")


### PR DESCRIPTION
fix ER-1688. 主要修复：
1. 将 ct 4 5 标志位的设定调整到 ct commit 阶段
2. 增加 rpl 的策略匹配和 ct 提交
3. 调整已有（包含 alg） ct commit 条目匹配条件，确保不会错误匹配