### PR TITLE
feat: add dpi health-check log compression with 1s probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ bin: controller agent cni erctl
 images: image image-generate
 
 image-debug:
-	docker buildx build -f build/images/release/Dockerfile -t registry.smtx.io/everoute/debug:$(COMMIT_ID) . --push
+	docker buildx build -f build/images/release-nocni/Dockerfile -t registry.smtx.io/everoute/debug:$(COMMIT_ID) . --push
 
 image:
 	docker buildx build -f build/images/release/Dockerfile -t everoute/release . --load

--- a/pkg/common/log/msg_compressor.go
+++ b/pkg/common/log/msg_compressor.go
@@ -1,0 +1,82 @@
+package log
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type MsgRecoverySummary struct {
+	Since      time.Time
+	Elapsed    time.Duration
+	Suppressed int
+}
+
+// MsgCompressor compresses repeated logs for one message stream.
+// It does not log directly; caller decides how to print returned messages.
+type MsgCompressor struct {
+	mu            sync.Mutex
+	now           func() time.Time
+	summaryPeriod time.Duration
+	since         time.Time
+	lastLogTime   time.Time
+	suppressed    int
+}
+
+func NewMsgCompressor(summaryPeriod time.Duration) *MsgCompressor {
+	return &MsgCompressor{
+		now:           time.Now,
+		summaryPeriod: summaryPeriod,
+	}
+}
+
+// NextMessage records one occurrence and returns text to print.
+// Empty string means this occurrence is suppressed.
+func (c *MsgCompressor) NextMessage(format string, args ...interface{}) string {
+	msg := fmt.Sprintf(format, args...)
+	now := c.now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.since.IsZero() {
+		c.since = now
+		c.lastLogTime = now
+		return msg
+	}
+
+	elapsed := now.Sub(c.since)
+	if now.Sub(c.lastLogTime) >= c.summaryPeriod {
+		out := fmt.Sprintf(
+			"still failing for %s (suppressed %d repeated logs), latest error: %s",
+			elapsed.Round(time.Second), c.suppressed, msg,
+		)
+		c.lastLogTime = now
+		c.suppressed = 0
+		return out
+	}
+
+	c.suppressed++
+	return ""
+}
+
+func (c *MsgCompressor) Recover() (MsgRecoverySummary, bool) {
+	now := c.now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.since.IsZero() {
+		return MsgRecoverySummary{}, false
+	}
+
+	s := MsgRecoverySummary{
+		Since:      c.since,
+		Elapsed:    now.Sub(c.since).Round(time.Second),
+		Suppressed: c.suppressed,
+	}
+	c.since = time.Time{}
+	c.lastLogTime = time.Time{}
+	c.suppressed = 0
+	return s, true
+}

--- a/pkg/common/log/msg_compressor_test.go
+++ b/pkg/common/log/msg_compressor_test.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMsgCompressorThrottleAndRecover(t *testing.T) {
+	c := NewMsgCompressor(10 * time.Second)
+
+	base := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	now := base
+	c.now = func() time.Time { return now }
+
+	msg := c.NextMessage("dial failed")
+	if msg == "" {
+		t.Fatalf("first message should be logged")
+	}
+
+	now = base.Add(5 * time.Second)
+	msg = c.NextMessage("dial failed")
+	if msg != "" {
+		t.Fatalf("message should be suppressed before summary period")
+	}
+
+	now = base.Add(11 * time.Second)
+	msg = c.NextMessage("dial failed")
+	if msg == "" {
+		t.Fatalf("summary message should be logged")
+	}
+
+	now = base.Add(12 * time.Second)
+	s, ok := c.Recover()
+	if !ok {
+		t.Fatalf("expected recovery summary")
+	}
+	if s.Elapsed != 12*time.Second {
+		t.Fatalf("unexpected elapsed, got %s", s.Elapsed)
+	}
+	if s.Suppressed != 0 {
+		t.Fatalf("unexpected suppressed, got %d", s.Suppressed)
+	}
+}

--- a/pkg/constants/tr/constants.go
+++ b/pkg/constants/tr/constants.go
@@ -18,8 +18,8 @@ const (
 
 	DpActionMaxRetryTimes = 5
 
-	DPIHealthyCheckTimeout = 3 * time.Second
-	DPIHealthyCheckPeriod  = 3 * time.Second
+	DPIHealthyCheckTimeout = 1 * time.Second
+	DPIHealthyCheckPeriod  = 1 * time.Second
 )
 
 var (

--- a/pkg/constants/tr/constants.go
+++ b/pkg/constants/tr/constants.go
@@ -18,8 +18,9 @@ const (
 
 	DpActionMaxRetryTimes = 5
 
-	DPIHealthyCheckTimeout = 1 * time.Second
-	DPIHealthyCheckPeriod  = 1 * time.Second
+	DPIHealthyCheckTimeout      = 1 * time.Second
+	DPIHealthyCheckPeriod       = 1 * time.Second
+	DPIHealthyLogCompressPeriod = 30 * time.Second
 )
 
 var (

--- a/pkg/trafficredirect/dpihealthy/healthy_check.go
+++ b/pkg/trafficredirect/dpihealthy/healthy_check.go
@@ -27,6 +27,9 @@ type ProcessHealthyCheck struct {
 func (p *ProcessHealthyCheck) Do(_ context.Context) {
 	curS := HealthyCheck()
 	if curS != p.lastStatus {
+		if p.lastStatus == types.DPIUnknown && curS != types.DPIUnknown {
+			LogHealthyRecovered(curS)
+		}
 		klog.Infof("Begin to update DPI status from %s to %s", p.lastStatus, curS)
 		p.process(curS)
 		klog.Infof("Success update DPI status from %s to %s", p.lastStatus, curS)

--- a/pkg/trafficredirect/dpihealthy/rpc_request.go
+++ b/pkg/trafficredirect/dpihealthy/rpc_request.go
@@ -2,10 +2,16 @@ package dpihealthy
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
 	"k8s.io/klog/v2"
 
+	commonlog "github.com/everoute/everoute/pkg/common/log"
 	"github.com/everoute/everoute/pkg/constants/tr"
 	"github.com/everoute/everoute/pkg/types"
 )
@@ -16,6 +22,19 @@ const (
 	DPIModuleName     = "DPI"
 	EverouteRequestID = 2
 )
+
+const (
+	errKeyDial           = "dial"
+	errKeyEncodeRequest  = "encode-request"
+	errKeySendRequest    = "send-request"
+	errKeyReadResponse   = "read-response"
+	errKeyParseResponse  = "parse-response"
+	errKeyExecuteFailure = "execute-failure"
+	errKeyUnknownStatus  = "unknown-status"
+	errKeyMissingModule  = "missing-module"
+)
+
+var healthyCheckErrLogger = &healthyLogger{compressors: make(map[string]*commonlog.MsgCompressor)}
 
 type Request struct {
 	JSONRPC string `json:"jsonrpc"`
@@ -37,8 +56,7 @@ type Response struct {
 func HealthyCheck() types.DPIStatus {
 	conn, err := net.DialTimeout("unix", SocketPath, tr.DPIHealthyCheckTimeout)
 	if err != nil {
-		klog.Errorf("Can't connect dpi healthy check unix socket(%s): %s", SocketPath, err)
-		return types.DPIUnknown
+		return logUnknown(errKeyDial, "can't connect dpi healthy check unix socket(%s): %s", SocketPath, err)
 	}
 	defer conn.Close()
 
@@ -49,33 +67,28 @@ func HealthyCheck() types.DPIStatus {
 	}
 	reqBytes, err := json.Marshal(req)
 	if err != nil {
-		klog.Errorf("Failed to encode request %v to json: %s", req, err)
-		return types.DPIUnknown
+		return logUnknown(errKeyEncodeRequest, "failed to encode request %v to json: %s", req, err)
 	}
 
 	_, err = conn.Write(reqBytes)
 	if err != nil {
-		klog.Errorf("Failed to send request: %s", err)
-		return types.DPIUnknown
+		return logUnknown(errKeySendRequest, "failed to send request: %s", err)
 	}
 
 	buf := make([]byte, 4096)
 	n, err := conn.Read(buf)
 	if err != nil {
-		klog.Errorf("Failed to get response: %s", err)
-		return types.DPIUnknown
+		return logUnknown(errKeyReadResponse, "failed to get response: %s", err)
 	}
 
 	var resp Response
 	err = json.Unmarshal(buf[:n], &resp)
 	if err != nil {
-		klog.Errorf("Failed to parse response: %s", err)
-		return types.DPIUnknown
+		return logUnknown(errKeyParseResponse, "failed to parse response: %s", err)
 	}
 
 	if resp.Result.Ec != "E_OK" || resp.Result.Error != "" {
-		klog.Errorf("Request execute failed, ec: %s, err: %s", resp.Result.Ec, resp.Result.Error)
-		return types.DPIUnknown
+		return logUnknown(errKeyExecuteFailure, "request execute failed, ec: %s, err: %s", resp.Result.Ec, resp.Result.Error)
 	}
 
 	for k, v := range resp.Result.Data {
@@ -84,11 +97,79 @@ func HealthyCheck() types.DPIStatus {
 				klog.V(4).Infof("DPI healthy check response status is %s", v)
 				return types.DPIStatus(v)
 			}
-			klog.Infof("DPI healthy check response status is unknown status %s", v)
-			return types.DPIUnknown
+			return logUnknown(errKeyUnknownStatus, "DPI healthy check response status is unknown status %s", v)
 		}
 	}
 
-	klog.Errorf("DPI Healthy check response status doesn't has %s module", DPIModuleName)
+	return logUnknown(errKeyMissingModule, "DPI healthy check response status doesn't has %s module", DPIModuleName)
+}
+
+func LogHealthyRecovered(status types.DPIStatus) {
+	healthyCheckErrLogger.recover(status)
+}
+
+func logUnknown(key, format string, args ...interface{}) types.DPIStatus {
+	healthyCheckErrLogger.logErrorf(key, format, args...)
 	return types.DPIUnknown
+}
+
+type healthyLogger struct {
+	mu          sync.Mutex
+	compressors map[string]*commonlog.MsgCompressor
+}
+
+func (l *healthyLogger) logErrorf(key, format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	c, ok := l.compressors[key]
+	if !ok {
+		c = commonlog.NewMsgCompressor(tr.DPIHealthyLogCompressPeriod)
+		l.compressors[key] = c
+	}
+
+	if msg := c.NextMessage(format, args...); msg != "" {
+		klog.Errorf("%s", msg)
+	}
+}
+
+func (l *healthyLogger) recover(status types.DPIStatus) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	keys := make([]string, 0, len(l.compressors))
+	for k := range l.compressors {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	type item struct {
+		key   string
+		count int
+	}
+	items := make([]item, 0, len(keys))
+	var earliest time.Time
+	for _, k := range keys {
+		summary, ok := l.compressors[k].Recover()
+		if !ok {
+			continue
+		}
+		if earliest.IsZero() || summary.Since.Before(earliest) {
+			earliest = summary.Since
+		}
+		items = append(items, item{key: k, count: summary.Suppressed})
+	}
+
+	if len(items) == 0 {
+		return
+	}
+
+	parts := make([]string, 0, len(items))
+	for _, it := range items {
+		parts = append(parts, fmt.Sprintf("%s=%d", it.key, it.count))
+	}
+	klog.Infof(
+		"DPI healthy check recover from unknown to %s after %s (suppressed by category: %s)",
+		status, time.Since(earliest).Round(time.Second), strings.Join(parts, ", "),
+	)
 }


### PR DESCRIPTION
## Purpose
Reduce DPI health-check log flooding while keeping 1s probe cadence and clear recovery visibility.

## Changes
- Keep DPI probe period at `1s` in `pkg/trafficredirect/dpihealthy/healthy_check.go`.
- Refactor compression utility to a generic message-level compressor:
  - replace `error_compressor` with `msg_compressor` under `pkg/common/log/`.
  - utility no longer writes logs directly; caller controls `klog` output.
- Move per-category state ownership to caller (`dpihealthy`):
  - `rpc_request.go` now keeps `key -> MsgCompressor` map in `healthyLogger`.
  - categories include `dial`, `read-response`, `parse-response`, `execute-failure`, etc.
- Logging behavior updates:
  - first failure logs immediately.
  - continuous failure logs summary every configurable period (`tr.DPIHealthyLogCompressPeriod`, default `30s`).
  - recovery logs only on status transition `unknown -> healthy/dead`.
  - recovery message includes per-category suppressed counts.
- Code organization updates:
  - helper/function placement follows package coding conventions (business flow first, internal helpers later).

## Tests
### Unit tests
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/common/log ./pkg/trafficredirect/dpihealthy -count=1`

### Build and deployment validation on SMTX OS node
- Build and push image:
  - `make image-debug`
  - image used: `registry.smtx.io/everoute/debug:fdcf072`
- Node: `172.21.152.103` (`smartx`)
- Update template:
  - `/etc/everoute/plugin/template/everoute-agent/plugin.yaml`
  - replace image under container `name: agent`
- Apply:
  - `sudo bash -lc 'shopt -s expand_aliases; source /etc/everoute/profile; eval "eradm update --allow-pull"'`
- Verify:
  - `admin update ... session ... done` observed

### Runtime log behavior validation
- Log file: `/var/log/everoute/everoute-agent.log`
- Failure injection:
  - `systemctl stop vm-security-controller`
- Recovery injection:
  - `systemctl start vm-security-controller`
- Observed logs (from real run):
  - first failure immediately:
    - `can't connect dpi healthy check unix socket ...`
  - compressed summaries every 30s:
    - `still failing for 30s (suppressed 29 repeated logs) ...`
    - `still failing for 1m0s (suppressed 29 repeated logs) ...`
    - `still failing for 1m30s (suppressed 29 repeated logs) ...`
  - recovery once on state transition:
    - `DPI healthy check recover from unknown to alive ... (suppressed by category: dial=4)`

## Commits
- `fix(er-1666): set dpi health check period to 1s`
- `feat: add keyed error log compression with prolonged unhealthy reporting`
