### PR TITLE
fix(ER-1701): replace ovs-dpctl with ovs-appctl

### DIFF
--- a/pkg/erctl/flowclient.go
+++ b/pkg/erctl/flowclient.go
@@ -85,7 +85,7 @@ func GetFlows(dp bool, names ...string) (map[string][]string, error) {
 		ans[name] = flows
 	}
 	if dp {
-		b, err := exec.Command("/bin/sh", "-c", "ovs-dpctl dump-flows").CombinedOutput()
+		b, err := exec.Command("ovs-appctl", "dpctl/dump-flows").CombinedOutput()
 		if err != nil {
 			laste = fmt.Errorf("%s,%s", laste.Error(), err.Error())
 		} else {


### PR DESCRIPTION
## Summary

- Replace `ovs-dpctl dump-flows` in `erctl get flow --dp` with `ovs-appctl dpctl/dump-flows`.
- Let datapath flow dump requests be handled by the running `ovs-vswitchd`.

## Why

When `ovs-dpctl` and the running `ovs-vswitchd` come from different OVS versions, opening the kernel datapath directly can trigger incompatible feature negotiation. Using `ovs-appctl` keeps the request on the daemon side and avoids that mismatch.

## Tests

- `go test ./pkg/erctl`