### PR TITLE
ci: run ut in parallel with checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
         run: echo "::error::Please run \"make generate\" or \"make docker-generate\" before commit."
 
   pr-check:
-    needs: [static-check, generate-check]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -94,6 +93,7 @@ jobs:
 
   build-k8s-e2e-image:
     runs-on: [self-hosted, build]
+    needs: [static-check, generate-check, pr-check]
     steps:
       - uses: actions/checkout@v2
 
@@ -106,7 +106,7 @@ jobs:
           push: true
 
   run-k8s-e2e:
-    needs: [build-k8s-e2e-image, static-check, generate-check, pr-check]
+    needs: [build-k8s-e2e-image]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Remove the dependency that made pr-check wait for static-check and generate-check.
- Allow unit test jobs to start in parallel with the check jobs.
- Move the k8s e2e check gate to build-k8s-e2e-image so run-k8s-e2e only depends on the image job.

## Problem
Before this change, pr-check had needs: [static-check, generate-check]. That serialized unit tests behind the static and generation checks, increasing CI feedback time even though those jobs do not produce artifacts needed by UT.

The k8s e2e path also repeated the same check dependencies on run-k8s-e2e. That made the dependency graph more verbose than necessary for that path.

## Behavior After Change
The UT matrix starts as an independent job alongside static-check and generate-check.

build-k8s-e2e-image now waits for static-check, generate-check, and pr-check. run-k8s-e2e only waits for build-k8s-e2e-image, while still being transitively gated by the same checks.

## Validation
- git diff --check