### PR TITLE
ci: use commit sha for tower e2e package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,8 +259,8 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: |
-            BRANCH="${{ github.head_ref || github.ref_name }}"
-            $COUSU build -m "ms=${BRANCH}" -p "${{ steps.version.outputs.version }}" -f
+            COMMIT_ID="${{ github.event.pull_request.head.sha || github.sha }}"
+            $COUSU build -m "ms=${COMMIT_ID}" -p "${{ steps.version.outputs.version }}" -f
 
       - name: wait for build completion
         uses: nick-fields/retry@v2


### PR DESCRIPTION
## Summary

- Build the Tower E2E package from the exact commit under test instead of the pull request branch name.

## Problem

Fork pull request branches only exist in the contributor repository. The CI job passed ms=<branch> to Cousu, and Cousu can fail to resolve that branch from the upstream repository when building the Tower E2E package.

## Fix

Use github.event.pull_request.head.sha for pull_request events, with github.sha as the fallback for non-PR events. This makes the Tower E2E package build target the exact commit under test and avoids depending on branch visibility.

## Testing

- git diff --check -- .github/workflows/ci.yaml
- yq parsed the updated build-tower-e2e-package step successfully