### PR TITLE
feat: sync everoute managed vds associations

### DIFF
--- a/pkg/constants/ms/constants.go
+++ b/pkg/constants/ms/constants.go
@@ -32,6 +32,10 @@ const (
 
 	ComputeClustersConfigMapName = "associate-compute-clusters"
 
+	AssociationSyncCompletedAnnotation = "everoute.io/association-sync-completed"
+	AssociationFormatVersionAnnotation = "everoute.io/association-format-version"
+	AssociationFormatVersionV2         = "2"
+
 	// used in shareIP
 	ALLInterfaceIDs = "ALL"
 )

--- a/plugin/tower/pkg/controller/computecluster/controller.go
+++ b/plugin/tower/pkg/controller/computecluster/controller.go
@@ -2,6 +2,9 @@ package computecluster
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
+	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,22 +104,14 @@ func (c *Controller) handleConfigMapUpdate(oldObj, newObj interface{}) {
 	if newCfg.Name != msconst.ComputeClustersConfigMapName || newCfg.Namespace != c.ConfigMapNamespace {
 		return
 	}
-	if len(oldCfg.Data) == 0 && len(newCfg.Data) == 0 {
-		return
-	}
-	if len(oldCfg.Data) == 0 || len(newCfg.Data) == 0 {
+	if !configMapDataEqual(oldCfg.Data, newCfg.Data) {
 		c.reconcileQueue.Add(c.EverouteClusterID)
 		return
 	}
-	oldELFs := make(sets.Set[string], len(oldCfg.Data))
-	newELFs := make(sets.Set[string], len(newCfg.Data))
-	for k := range oldCfg.Data {
-		oldELFs.Insert(k)
+	if !hasAssociationAnnotations(oldCfg.Annotations) && hasAssociationAnnotations(newCfg.Annotations) {
+		return
 	}
-	for k := range newCfg.Data {
-		newELFs.Insert(k)
-	}
-	if !oldELFs.Equal(newELFs) {
+	if !associationAnnotationValuesEqual(oldCfg.Annotations, newCfg.Annotations) {
 		c.reconcileQueue.Add(c.EverouteClusterID)
 	}
 }
@@ -141,7 +136,7 @@ func (c *Controller) handleClusterUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if newCluster.GetELFs().Equal(oldCluster.GetELFs()) {
+	if reflect.DeepEqual(oldCluster.GetAssociation(), newCluster.GetAssociation()) {
 		return
 	}
 	c.reconcileQueue.Add(c.EverouteClusterID)
@@ -170,19 +165,23 @@ func (c *Controller) create() error {
 		klog.Errorf("Failed to get networkCluster from cloudPlatform: %s", err)
 		return err
 	}
+	if !exists {
+		klog.Errorf("Can't found networkCluster %s, skip create configMap which store computeClusters", c.EverouteClusterID)
+		return nil
+	}
+
 	ConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.ConfigMapNamespace,
 			Name:      msconst.ComputeClustersConfigMapName,
 		},
 	}
-	if exists {
-		ConfigMap.Data = make(map[string]string)
-		cluster := obj.(*schema.EverouteCluster)
-		for i := range cluster.AgentELFClusters {
-			ConfigMap.Data[cluster.AgentELFClusters[i].LocalID] = ""
-		}
+	cluster := obj.(*schema.EverouteCluster)
+	ConfigMap.Data, err = associationData(cluster.GetAssociation())
+	if err != nil {
+		return err
 	}
+	ConfigMap.Annotations = associationAnnotations()
 	_, err = c.erCli.CoreV1().ConfigMaps(ConfigMap.Namespace).Create(c.ctx, &ConfigMap, metav1.CreateOptions{})
 	if err != nil {
 		klog.Errorf("Failed to create configMap with computeClusters %v, err: %s", ConfigMap.Data, err)
@@ -204,22 +203,21 @@ func (c *Controller) update(configMap *corev1.ConfigMap) error {
 	}
 
 	cluster := obj.(*schema.EverouteCluster)
-	newELFs := cluster.GetELFs()
-
-	oldELFs := sets.New[string]()
-	if configMap.Data != nil {
-		for k := range configMap.Data {
-			oldELFs.Insert(k)
-		}
+	newData, err := associationData(cluster.GetAssociation())
+	if err != nil {
+		return err
 	}
-
-	if oldELFs.Equal(newELFs) {
+	newAnnotations := associationAnnotations()
+	if reflect.DeepEqual(configMap.Data, newData) && hasAssociationAnnotations(configMap.Annotations) {
 		return nil
 	}
 
-	configMap.Data = make(map[string]string, newELFs.Len())
-	for _, elf := range newELFs.UnsortedList() {
-		configMap.Data[elf] = ""
+	configMap.Data = newData
+	if configMap.Annotations == nil {
+		configMap.Annotations = map[string]string{}
+	}
+	for key, value := range newAnnotations {
+		configMap.Annotations[key] = value
 	}
 
 	_, err = c.erCli.CoreV1().ConfigMaps(configMap.Namespace).Update(c.ctx, configMap, metav1.UpdateOptions{})
@@ -229,4 +227,42 @@ func (c *Controller) update(configMap *corev1.ConfigMap) error {
 	}
 	klog.Infof("Success to update configMap with computeClusters %v", configMap.Data)
 	return nil
+}
+
+func associationData(association map[string]sets.Set[string]) (map[string]string, error) {
+	data := make(map[string]string, len(association))
+	for clusterID, vdsSet := range association {
+		vdsIDs := vdsSet.UnsortedList()
+		sort.Strings(vdsIDs)
+		raw, err := json.Marshal(vdsIDs)
+		if err != nil {
+			return nil, err
+		}
+		data[clusterID] = string(raw)
+	}
+	return data, nil
+}
+
+func associationAnnotations() map[string]string {
+	return map[string]string{
+		msconst.AssociationSyncCompletedAnnotation: "true",
+		msconst.AssociationFormatVersionAnnotation: msconst.AssociationFormatVersionV2,
+	}
+}
+
+func hasAssociationAnnotations(annotations map[string]string) bool {
+	return annotations[msconst.AssociationSyncCompletedAnnotation] == "true" &&
+		annotations[msconst.AssociationFormatVersionAnnotation] == msconst.AssociationFormatVersionV2
+}
+
+func associationAnnotationValuesEqual(a, b map[string]string) bool {
+	return a[msconst.AssociationSyncCompletedAnnotation] == b[msconst.AssociationSyncCompletedAnnotation] &&
+		a[msconst.AssociationFormatVersionAnnotation] == b[msconst.AssociationFormatVersionAnnotation]
+}
+
+func configMapDataEqual(a, b map[string]string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
 }

--- a/plugin/tower/pkg/controller/computecluster/controller_test.go
+++ b/plugin/tower/pkg/controller/computecluster/controller_test.go
@@ -20,7 +20,7 @@ var _ = Describe("elf controller", func() {
 	})
 
 	Context("add elf ConfigMap", func() {
-		It("er cluster associate elf", func() {
+		It("er cluster associate elf without vds", func() {
 			erCluster := &schema.EverouteCluster{
 				ObjectMeta: schema.ObjectMeta{
 					ID: everouteCluster,
@@ -36,9 +36,9 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(res.Data).ShouldNot(BeNil())
-				g.Expect(len(res.Data)).Should(Equal(2))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf1", ""))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf2", ""))
+				g.Expect(len(res.Data)).Should(Equal(0))
+				g.Expect(res.Annotations).Should(HaveKeyWithValue(msconst.AssociationSyncCompletedAnnotation, "true"))
+				g.Expect(res.Annotations).Should(HaveKeyWithValue(msconst.AssociationFormatVersionAnnotation, msconst.AssociationFormatVersionV2))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -55,8 +55,11 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(len(res.Data)).Should(Equal(0))
+				g.Expect(res.Annotations).Should(HaveKeyWithValue(msconst.AssociationSyncCompletedAnnotation, "true"))
+				g.Expect(res.Annotations).Should(HaveKeyWithValue(msconst.AssociationFormatVersionAnnotation, msconst.AssociationFormatVersionV2))
 			}, timeout, interval).Should(Succeed())
 		})
+
 	})
 
 	Context("update elf ConfigMap", func() {
@@ -75,14 +78,12 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(res.Data).ShouldNot(BeNil())
-				g.Expect(len(res.Data)).Should(Equal(2))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf1", ""))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf2", ""))
+				g.Expect(len(res.Data)).Should(Equal(0))
 				g.Expect(controller.reconcileQueue.Len()).Should(Equal(0))
 			}, timeout, interval).Should(Succeed())
 		})
 
-		It("add associate elf cluster", func() {
+		It("add associate elf cluster doesn't change vds association", func() {
 			erCluster := &schema.EverouteCluster{
 				ObjectMeta: schema.ObjectMeta{
 					ID: everouteCluster,
@@ -99,14 +100,11 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(res.Data).ShouldNot(BeNil())
-				g.Expect(len(res.Data)).Should(Equal(3))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf1", ""))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf2", ""))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf", ""))
+				g.Expect(len(res.Data)).Should(Equal(0))
 			}, timeout, interval).Should(Succeed())
 		})
 
-		It("del assocaite elf cluster", func() {
+		It("del associate elf cluster doesn't change vds association", func() {
 			erCluster := &schema.EverouteCluster{
 				ObjectMeta: schema.ObjectMeta{
 					ID: everouteCluster,
@@ -120,8 +118,7 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(res.Data).ShouldNot(BeNil())
-				g.Expect(len(res.Data)).Should(Equal(1))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf2", ""))
+				g.Expect(len(res.Data)).Should(Equal(0))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -142,9 +139,7 @@ var _ = Describe("elf controller", func() {
 				res, err := erClient.CoreV1().ConfigMaps(towerSpace).Get(ctx, msconst.ComputeClustersConfigMapName, metav1.GetOptions{})
 				g.Expect(err).Should(BeNil())
 				g.Expect(res.Data).ShouldNot(BeNil())
-				g.Expect(len(res.Data)).Should(Equal(2))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf2", ""))
-				g.Expect(res.Data).Should(HaveKeyWithValue("elf1", ""))
+				g.Expect(len(res.Data)).Should(Equal(0))
 			}, timeout, interval).Should(Succeed())
 		})
 	})
@@ -407,14 +402,15 @@ func TestHandleClusterUpdate(t *testing.T) {
 		queueLen int
 	}{
 		{
-			name: "normal",
+			name: "vds association removed",
 			oldObj: &schema.EverouteCluster{
 				ObjectMeta: schema.ObjectMeta{
 					ID: everouteCluster,
 				},
-				AgentELFClusters: []schema.AgentELFCluster{
+				AgentELFVDSes: []schema.AgentELFVDS{
 					{
-						LocalID: "elf1",
+						ObjectMeta: schema.ObjectMeta{ID: "vds1"},
+						Cluster:    schema.ObjectReference{ID: "elf1"},
 					},
 				},
 			},
@@ -450,6 +446,42 @@ func TestHandleClusterUpdate(t *testing.T) {
 				},
 			},
 			queueLen: 0,
+		},
+		{
+			name: "vds association changed",
+			oldObj: &schema.EverouteCluster{
+				ObjectMeta: schema.ObjectMeta{
+					ID: everouteCluster,
+				},
+				AgentELFClusters: []schema.AgentELFCluster{
+					{
+						LocalID: "elf1",
+					},
+				},
+				AgentELFVDSes: []schema.AgentELFVDS{
+					{
+						ObjectMeta: schema.ObjectMeta{ID: "vds1"},
+						Cluster:    schema.ObjectReference{ID: "elf1"},
+					},
+				},
+			},
+			newObj: &schema.EverouteCluster{
+				ObjectMeta: schema.ObjectMeta{
+					ID: everouteCluster,
+				},
+				AgentELFClusters: []schema.AgentELFCluster{
+					{
+						LocalID: "elf1",
+					},
+				},
+				AgentELFVDSes: []schema.AgentELFVDS{
+					{
+						ObjectMeta: schema.ObjectMeta{ID: "vds2"},
+						Cluster:    schema.ObjectReference{ID: "elf1"},
+					},
+				},
+			},
+			queueLen: 1,
 		},
 		{
 			name: "unexpected everoute cluster",

--- a/plugin/tower/pkg/schema/types.go
+++ b/plugin/tower/pkg/schema/types.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 )
 
 type VM struct {
@@ -112,12 +113,14 @@ type EverouteCluster struct {
 	GlobalDefaultAction GlobalPolicyAction           `json:"global_default_action"`
 	GlobalWhitelist     EverouteClusterWhitelist     `json:"global_whitelist,omitempty"`
 	EnableLogging       bool                         `json:"enable_logging,omitempty"`
+	Status              EverouteClusterStatus        `json:"status,omitempty"`
 }
 
 type AgentELFVDS struct {
 	ObjectMeta
 
 	EverouteClusterRef ObjectReference `json:"everoute_cluster,omitempty"`
+	Cluster            ObjectReference `json:"cluster,omitempty"`
 }
 
 type AgentELFCluster struct {
@@ -136,6 +139,63 @@ func (e *EverouteCluster) GetELFs() sets.Set[string] {
 		res.Insert(e.AgentELFClusters[i].LocalID)
 	}
 	return res
+}
+
+func (e *EverouteCluster) GetAssociation() map[string]sets.Set[string] {
+	res := map[string]sets.Set[string]{}
+	if e == nil {
+		return res
+	}
+
+	for i := range e.AgentELFVDSes {
+		clusterID := e.AgentELFVDSes[i].Cluster.ID
+		vdsID := e.AgentELFVDSes[i].ID
+		if vdsID != "" {
+			if clusterID == "" {
+				klog.Warningf("skip agent_elf_vdses vds %s in everoute cluster %s due to empty cluster id", vdsID, e.ID)
+				continue
+			}
+			ensureVDSSet(res, clusterID).Insert(vdsID)
+		}
+	}
+
+	for i := range e.Status.Agents.ManageVDSes {
+		managedVDS := e.Status.Agents.ManageVDSes[i]
+		clusterID := managedVDS.VDS.Cluster.ID
+		vdsID := managedVDS.VDS.ID
+		if vdsID == "" {
+			vdsID = managedVDS.VDSID
+		}
+		if vdsID != "" {
+			if clusterID == "" {
+				klog.Warningf("skip status managed vds %s in everoute cluster %s due to empty cluster id", vdsID, e.ID)
+				continue
+			}
+			ensureVDSSet(res, clusterID).Insert(vdsID)
+		}
+	}
+
+	return res
+}
+
+func ensureVDSSet(m map[string]sets.Set[string], clusterID string) sets.Set[string] {
+	if _, ok := m[clusterID]; !ok {
+		m[clusterID] = sets.New[string]()
+	}
+	return m[clusterID]
+}
+
+type EverouteClusterStatus struct {
+	Agents EverouteClusterAgentStatus `json:"agents,omitempty"`
+}
+
+type EverouteClusterAgentStatus struct {
+	ManageVDSes []EverouteClusterManagedVDS `json:"manageVDSes,omitempty"`
+}
+
+type EverouteClusterManagedVDS struct {
+	VDSID string      `json:"vdsID,omitempty"`
+	VDS   AgentELFVDS `json:"vds,omitempty"`
 }
 
 type EverouteClusterWhitelist struct {

--- a/plugin/tower/pkg/schema/types_test.go
+++ b/plugin/tower/pkg/schema/types_test.go
@@ -1,0 +1,64 @@
+package schema
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestEverouteClusterGetAssociation(t *testing.T) {
+	cluster := &EverouteCluster{
+		AgentELFClusters: []AgentELFCluster{
+			{LocalID: "cluster-without-vds"},
+		},
+		AgentELFVDSes: []AgentELFVDS{
+			{
+				ObjectMeta: ObjectMeta{ID: "vds-2"},
+				Cluster:    ObjectReference{ID: "cluster-1"},
+			},
+			{
+				ObjectMeta: ObjectMeta{ID: "vds-1"},
+				Cluster:    ObjectReference{ID: "cluster-1"},
+			},
+			{
+				ObjectMeta: ObjectMeta{ID: "vds-without-cluster"},
+			},
+		},
+		Status: EverouteClusterStatus{
+			Agents: EverouteClusterAgentStatus{
+				ManageVDSes: []EverouteClusterManagedVDS{
+					{
+						VDSID: "vds-3",
+						VDS: AgentELFVDS{
+							Cluster: ObjectReference{ID: "cluster-1"},
+						},
+					},
+					{
+						VDS: AgentELFVDS{
+							ObjectMeta: ObjectMeta{ID: "vds-4"},
+							Cluster:    ObjectReference{ID: "cluster-2"},
+						},
+					},
+					{
+						VDSID: "vds-without-cluster",
+					},
+				},
+			},
+		},
+	}
+
+	got := cluster.GetAssociation()
+	want := map[string]sets.Set[string]{
+		"cluster-1": sets.New("vds-1", "vds-2", "vds-3"),
+		"cluster-2": sets.New("vds-4"),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("unexpected association length, got %d want %d: %v", len(got), len(want), got)
+	}
+	for clusterID, wantVDSes := range want {
+		if !got[clusterID].Equal(wantVDSes) {
+			t.Fatalf("unexpected vdses for cluster %s, got %v want %v", clusterID, got[clusterID], wantVDSes)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

Sync Everoute-managed VDS associations from Tower into the existing `associate-compute-clusters` ConfigMap so downstream controllers can determine whether endpoints belong to the current Everoute management scope.

## Design

This change reuses the existing `associate-compute-clusters` ConfigMap instead of introducing a separate ConfigMap. The main reason is compatibility with the existing `sks-plugin` consumer: it already depends on this ConfigMap to understand associated compute clusters, so v2 keeps the same ConfigMap name and keeps compute cluster IDs as `data` keys.

The v2 format stores VDS IDs as the ConfigMap value: `clusterID -> JSON encoded VDS ID list`. This preserves the old lookup shape for cluster-based consumers while adding the VDS association detail needed by newer controllers.

The ConfigMap is marked with annotations:

- `everoute.io/association-format-version: "2"`
- `everoute.io/association-sync-completed: "true"`

The sync-completed annotation is used for upgrade scenarios. During upgrade, consumers can distinguish "tower-plugin has not synced v2 association data yet" from "tower-plugin has synced successfully and the association result is empty".

## Changes

- Extend Tower `EverouteCluster` schema parsing for `agent_elf_vdses` and `status.agents.manageVDSes`.
- Generate ConfigMap data as `clusterID -> JSON encoded VDS ID list` and mark sync completion with v2 annotations.
- Reconcile ConfigMap updates based on association data and v2 annotations.
- Skip creating an empty association ConfigMap when the EverouteCluster cannot be found.
- Add unit coverage for VDS association merging and ConfigMap update behavior.

## Tests

- `go test ./plugin/tower/pkg/schema ./plugin/tower/pkg/controller/computecluster -count=1`
- Docker unit tests for schema, computecluster, and informer packages were run before submission.
- `make docker-test`
- `make docker-generate`
- Built and pushed `registry.smtx.io/everoute/debug:54bb831`.
- Deployed to controller VMs `172.21.253.31`, `172.21.253.32`, `172.21.253.33` with `eradm update --allow-pull`.
- Verified each controller VM runs `registry.smtx.io/everoute/debug:54bb831` and `curl -k https://127.0.0.1:9445/healthz` returns `ok`.
- Verified `associate-compute-clusters` was updated to v2 in `tower-space`:

```yaml
metadata:
  annotations:
    everoute.io/association-format-version: "2"
    everoute.io/association-sync-completed: "true"
data:
  cmj6xkuwvvxgf0806g5h25egw: '["cmj9labfy2ahd0806l7ytop0d"]'
```
