### PR TITLE
fix(er-1712): skip ovs bridge local interface endpoint

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -1494,6 +1494,12 @@ func (dp *DpManager) skipLocalEndpoint(endpoint *Endpoint) bool {
 	if strings.HasSuffix(endpoint.InterfaceName, LocalToNatSuffix) {
 		return true
 	}
+
+	// skip ovs bridge local interface
+	if endpoint.InterfaceName == endpoint.BridgeName {
+		return true
+	}
+
 	// skip cni local gateway
 	if dp.Info.LocalGwName == endpoint.InterfaceName {
 		return true

--- a/pkg/agent/datapath/skip_local_endpoint_test.go
+++ b/pkg/agent/datapath/skip_local_endpoint_test.go
@@ -1,0 +1,65 @@
+package datapath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipLocalEndpoint(t *testing.T) {
+	dp := &DpManager{
+		Info: &DpManagerInfo{
+			BridgeName:  "cni-br",
+			LocalGwName: "local-gw",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		endpoint *Endpoint
+		want     bool
+	}{
+		{
+			name: "ovs bridge local interface",
+			endpoint: &Endpoint{
+				InterfaceName: "ovsbr0",
+				BridgeName:    "ovsbr0",
+				PortNo:        0xfffe,
+			},
+			want: true,
+		},
+		{
+			name: "ordinary endpoint",
+			endpoint: &Endpoint{
+				InterfaceName: "tap0",
+				BridgeName:    "ovsbr0",
+				PortNo:        10,
+			},
+			want: false,
+		},
+		{
+			name: "cni bridge default interface",
+			endpoint: &Endpoint{
+				InterfaceName: "cni-br",
+				BridgeName:    "ovsbr0",
+				PortNo:        1,
+			},
+			want: true,
+		},
+		{
+			name: "cni local gateway",
+			endpoint: &Endpoint{
+				InterfaceName: "local-gw",
+				BridgeName:    "ovsbr0",
+				PortNo:        2,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, dp.skipLocalEndpoint(tt.endpoint))
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
Avoid installing OpenFlow 1.1+ flows that match `in_port=0xfffe` for the OVS bridge local interface. OVS reports the bridge's same-name internal interface with ofport `65534`, but that value is not a valid OpenFlow 1.1+ physical in_port match.

## Changes
- Skip local endpoint processing when an OVS interface name equals its bridge name.
- Add unit coverage for bridge local interface filtering and existing local endpoint skip cases.

## Tests
- `make docker-generate`
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute-ofpp-fix:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/agent/datapath -run TestSkipLocalEndpoint -count=1`
- Built and pushed `registry.smtx.io/everoute/debug:7230945` from the original detached worktree commit.
- Deployed to `172.21.152.102`; `eradm update --allow-pull` completed and no recent `65534`, `0xfffe`, `in_port=65534/0xfffe`, `OFPP`, or OpenFlow flow failure logs were found in `/var/log/everoute/everoute-agent.log`.
