### PR TITLE
feat: filter group members by managed endpoint scope

### DIFF
--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -266,6 +266,7 @@ func startManager(ctx context.Context, mgr manager.Manager, datapathManager *dat
 			Client:                   mgr.GetClient(),
 			Scheme:                   mgr.GetScheme(),
 			DatapathManager:          datapathManager,
+			ManagedVDSes:             datapathManager.Config.MSVdsSet.Clone(),
 			ReadyToProcessGlobalRule: opts.readyToProcessGlobalRule,
 		}).SetupWithManager(mgr); err != nil {
 			klog.Fatalf("unable to create policy controller: %s", err.Error())

--- a/cmd/everoute-controller/main.go
+++ b/cmd/everoute-controller/main.go
@@ -154,6 +154,14 @@ func main() {
 		}).SetupWithManager(mgr); err != nil {
 			klog.Fatalf("unable to create endpoint controller: %s", err.Error())
 		}
+
+		if err = (&endpointctrl.NotManagedReconciler{
+			Client:             mgr.GetClient(),
+			ConfigMapNamespace: towerPluginOptions.Namespace,
+			ConfigMapName:      msconst.ComputeClustersConfigMapName,
+		}).SetupWithManager(mgr); err != nil {
+			klog.Fatalf("unable to create endpoint notManaged controller: %s", err.Error())
+		}
 	}
 
 	// group controller sync & manager group members.

--- a/deploy/chart/templates/crds/group.everoute.io_groupmembers.yaml
+++ b/deploy/chart/templates/crds/group.everoute.io_groupmembers.yaml
@@ -84,6 +84,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object

--- a/deploy/chart/templates/crds/group.everoute.io_groupmemberspatches.yaml
+++ b/deploy/chart/templates/crds/group.everoute.io_groupmemberspatches.yaml
@@ -72,6 +72,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -153,6 +155,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -209,6 +213,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object

--- a/deploy/chart/templates/crds/security.everoute.io_endpoints.yaml
+++ b/deploy/chart/templates/crds/security.everoute.io_endpoints.yaml
@@ -123,6 +123,9 @@ spec:
                 - static
                 - static-ip
                 type: string
+              vdsID:
+                description: VDSID is the VDS ID that the endpoint belongs to.
+                type: string
               vid:
                 description: VID describe the endpoint in which VLAN
                 format: int32
@@ -151,6 +154,10 @@ spec:
               macAddress:
                 description: MacAddress of an endpoint.
                 type: string
+              notManaged:
+                description: NotManaged indicates this endpoint is outside the current
+                  Everoute managed scope.
+                type: boolean
             type: object
         required:
         - spec

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -500,6 +500,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -601,6 +603,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -682,6 +686,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -738,6 +744,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -1067,6 +1075,9 @@ spec:
                 - static
                 - static-ip
                 type: string
+              vdsID:
+                description: VDSID is the VDS ID that the endpoint belongs to.
+                type: string
               vid:
                 description: VID describe the endpoint in which VLAN
                 format: int32
@@ -1095,6 +1106,10 @@ spec:
               macAddress:
                 description: MacAddress of an endpoint.
                 type: string
+              notManaged:
+                description: NotManaged indicates this endpoint is outside the current
+                  Everoute managed scope.
+                type: boolean
             type: object
         required:
         - spec

--- a/deploy/microsegment/chart/templates/crds/group.everoute.io_groupmembers.yaml
+++ b/deploy/microsegment/chart/templates/crds/group.everoute.io_groupmembers.yaml
@@ -84,6 +84,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object

--- a/deploy/microsegment/chart/templates/crds/group.everoute.io_groupmemberspatches.yaml
+++ b/deploy/microsegment/chart/templates/crds/group.everoute.io_groupmemberspatches.yaml
@@ -72,6 +72,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -153,6 +155,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object
@@ -209,6 +213,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                vdsID:
+                  type: string
               required:
               - endpointReference
               type: object

--- a/deploy/microsegment/chart/templates/crds/security.everoute.io_endpoints.yaml
+++ b/deploy/microsegment/chart/templates/crds/security.everoute.io_endpoints.yaml
@@ -123,6 +123,9 @@ spec:
                 - static
                 - static-ip
                 type: string
+              vdsID:
+                description: VDSID is the VDS ID that the endpoint belongs to.
+                type: string
               vid:
                 description: VID describe the endpoint in which VLAN
                 format: int32
@@ -151,6 +154,10 @@ spec:
               macAddress:
                 description: MacAddress of an endpoint.
                 type: string
+              notManaged:
+                description: NotManaged indicates this endpoint is outside the current
+                  Everoute managed scope.
+                type: boolean
             type: object
         required:
         - spec

--- a/docs/content/en/docs/reference/apidocs.html
+++ b/docs/content/en/docs/reference/apidocs.html
@@ -98,6 +98,17 @@ string
 </tr>
 <tr>
 <td>
+<code>vdsID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>VDSID is the VDS ID that the endpoint belongs to.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>extendLabels</code><br/>
 <em>
 map[string][]string
@@ -662,6 +673,17 @@ string
 </tr>
 <tr>
 <td>
+<code>vdsID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>VDSID is the VDS ID that the endpoint belongs to.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>extendLabels</code><br/>
 <em>
 map[string][]string
@@ -789,6 +811,17 @@ string
 </td>
 <td>
 <p>Agents where this endpoint is currently located</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>notManaged</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>NotManaged indicates this endpoint is outside the current Everoute managed scope.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/agent/controller/policy/cache/group.go
+++ b/pkg/agent/controller/policy/cache/group.go
@@ -102,11 +102,19 @@ func GroupMembersToIPBlocks(ctx context.Context, members []groupv1alpha1.GroupMe
 			if _, ok := res[ipNetStr]; !ok {
 				res[ipNetStr] = NewIPBlockItem()
 				res[ipNetStr].AgentRef.Insert(member.EndpointAgent...)
+				if member.VDSID != "" {
+					res[ipNetStr].VDSRef.Insert(member.VDSID)
+				}
 			} else {
 				if res[ipNetStr].AgentRef.Len() == 0 || len(member.EndpointAgent) == 0 {
 					res[ipNetStr].AgentRef = sets.New[string]()
 				} else {
 					res[ipNetStr].AgentRef.Insert(member.EndpointAgent...)
+				}
+				if res[ipNetStr].VDSRef.Len() == 0 || member.VDSID == "" {
+					res[ipNetStr].VDSRef = sets.New[string]()
+				} else {
+					res[ipNetStr].VDSRef.Insert(member.VDSID)
 				}
 			}
 			res[ipNetStr].Ports = AppendIPBlockPorts(res[ipNetStr].Ports, member.Ports)

--- a/pkg/agent/controller/policy/cache/helper.go
+++ b/pkg/agent/controller/policy/cache/helper.go
@@ -120,6 +120,11 @@ func AppendIPBlocks(ori map[string]*IPBlockItem, add map[string]*IPBlockItem) ma
 			} else {
 				res[ip].AgentRef.Insert(v.AgentRef.UnsortedList()...)
 			}
+			if res[ip].VDSRef.Len() == 0 || v.VDSRef.Len() == 0 {
+				res[ip].VDSRef = sets.New[string]()
+			} else {
+				res[ip].VDSRef.Insert(v.VDSRef.UnsortedList()...)
+			}
 			res[ip].Ports = AppendIPBlockPorts(res[ip].Ports, v.Ports)
 		}
 	}

--- a/pkg/agent/controller/policy/cache/helper_test.go
+++ b/pkg/agent/controller/policy/cache/helper_test.go
@@ -107,6 +107,34 @@ func TestGetIPCidr(t *testing.T) {
 	}
 }
 
+func TestGroupMembersToIPBlocksWithVDSRef(t *testing.T) {
+	members := []groupv1alpha1.GroupMember{
+		{
+			IPs:   []types.IPAddress{"10.10.0.1"},
+			VDSID: "vds-1",
+		},
+		{
+			IPs:   []types.IPAddress{"10.10.0.1"},
+			VDSID: "vds-2",
+		},
+		{
+			IPs:   []types.IPAddress{"10.10.0.2"},
+			VDSID: "vds-1",
+		},
+		{
+			IPs: []types.IPAddress{"10.10.0.2"},
+		},
+	}
+
+	expect := makeIPMap(
+		"10.10.0.1/32", &IPBlockItem{VDSRef: sets.New("vds-1", "vds-2")},
+		"10.10.0.2/32", &IPBlockItem{},
+	)
+	if got := GroupMembersToIPBlocks(context.Background(), members); !equalIPMap(got, expect) {
+		t.Fatalf("expect %v, got %v", expect, got)
+	}
+}
+
 func TestAssembleStaticIPAndGroup(t *testing.T) {
 	gCache := NewGroupCache()
 	gCache.members["group-1"] = []groupv1alpha1.GroupMember{
@@ -117,6 +145,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 			},
 			IPs:           []types.IPAddress{"10.10.0.1", "10.10.0.2"},
 			EndpointAgent: []string{"agent1"},
+			VDSID:         "vds-1",
 			Ports: []securityv1alpha1.NamedPort{
 				{
 					Name:     "ssh",
@@ -145,6 +174,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 		{
 			IPs:           []types.IPAddress{"10.10.0.4"},
 			EndpointAgent: []string{"agent2"},
+			VDSID:         "vds-4",
 		},
 		{
 			IPs: []types.IPAddress{"10.10.0.5"},
@@ -162,6 +192,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 		{
 			IPs:           []types.IPAddress{"10.10.0.1"},
 			EndpointAgent: []string{"agent3", "agent2"},
+			VDSID:         "vds-2",
 			Ports: []securityv1alpha1.NamedPort{
 				{
 					Name:     "http",
@@ -173,6 +204,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 		{
 			IPs:           []types.IPAddress{"10.10.0.3"},
 			EndpointAgent: []string{"agent2"},
+			VDSID:         "vds-3",
 			Ports: []securityv1alpha1.NamedPort{
 				{
 					Name:     "http",
@@ -254,6 +286,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 			expErr: false,
 			exp: makeIPMap("10.10.0.1/32", &IPBlockItem{
 				AgentRef: sets.New("agent1", "agent2", "agent3"),
+				VDSRef:   sets.New("vds-1", "vds-2"),
 				Ports: []securityv1alpha1.NamedPort{
 					{
 						Name:     "ssh",
@@ -272,6 +305,7 @@ func TestAssembleStaticIPAndGroup(t *testing.T) {
 				},
 			}, "10.10.0.2/32", &IPBlockItem{
 				AgentRef: sets.New("agent1"),
+				VDSRef:   sets.New("vds-1"),
 				Ports: []securityv1alpha1.NamedPort{
 					{
 						Name:     "ssh",
@@ -355,6 +389,14 @@ func equalIPMap(i1, i2 map[string]*IPBlockItem) bool {
 		}
 		if len(v.AgentRef) != 0 {
 			if !v.AgentRef.Equal(v2.AgentRef) {
+				return false
+			}
+		}
+		if len(v.VDSRef) != len(v2.VDSRef) {
+			return false
+		}
+		if len(v.VDSRef) != 0 {
+			if !v.VDSRef.Equal(v2.VDSRef) {
 				return false
 			}
 		}

--- a/pkg/agent/controller/policy/cache/rule.go
+++ b/pkg/agent/controller/policy/cache/rule.go
@@ -135,7 +135,10 @@ type IPBlockItem struct {
 	// AgentRef means this ip has appeared in these agents.
 	// if sets is empty, this ip will apply to all agents.
 	AgentRef sets.Set[string]
-	Ports    []securityv1alpha1.NamedPort
+	// VDSRef means this ip belongs to these VDSes.
+	// if sets is empty, this ip will apply to all VDSes.
+	VDSRef sets.Set[string]
+	Ports  []securityv1alpha1.NamedPort
 }
 
 func (item *IPBlockItem) DeepCopy() interface{} {
@@ -145,6 +148,7 @@ func (item *IPBlockItem) DeepCopy() interface{} {
 	}
 	return &IPBlockItem{
 		AgentRef: sets.New(item.AgentRef.UnsortedList()...),
+		VDSRef:   sets.New(item.VDSRef.UnsortedList()...),
 		Ports:    item.Ports,
 	}
 }
@@ -152,6 +156,7 @@ func (item *IPBlockItem) DeepCopy() interface{} {
 func NewIPBlockItem() *IPBlockItem {
 	item := &IPBlockItem{}
 	item.AgentRef = sets.New[string]()
+	item.VDSRef = sets.New[string]()
 	return item
 }
 
@@ -238,11 +243,11 @@ func (rule *CompleteRule) Clone() *CompleteRule {
 }
 
 // ListRules return a list of security.everoute.io/v1alpha1 PolicyRule
-func (rule *CompleteRule) ListRules(ctx context.Context, groupCache *GroupCache) []PolicyRule {
+func (rule *CompleteRule) ListRules(ctx context.Context, groupCache *GroupCache, managedVDSes sets.Set[string]) []PolicyRule {
 	rule.lock.RLock()
 	defer rule.lock.RUnlock()
 	policyRuleList := rule.GenerateRuleList(ctx, rule.assemblySrcIPBlocks(ctx, groupCache),
-		rule.assemblyDstIPBlocks(ctx, groupCache), rule.Ports)
+		rule.assemblyDstIPBlocks(ctx, groupCache), rule.Ports, managedVDSes)
 	policyRuleList = append(policyRuleList, rule.GenerateFullIsolationRule(groupCache, nil)...)
 
 	return policyRuleList
@@ -286,7 +291,7 @@ func (rule *CompleteRule) GenerateFullIsolationRule(groupCache *GroupCache, gm *
 }
 
 func (rule *CompleteRule) GenerateRuleList(ctx context.Context, srcIPBlocks map[string]*IPBlockItem,
-	dstIPBlocks map[string]*IPBlockItem, ports []RulePort) []PolicyRule {
+	dstIPBlocks map[string]*IPBlockItem, ports []RulePort, managedVDSes sets.Set[string]) []PolicyRule {
 	log := ctrl.LoggerFrom(ctx)
 	var policyRuleList []PolicyRule
 
@@ -320,14 +325,14 @@ func (rule *CompleteRule) GenerateRuleList(ctx context.Context, srcIPBlocks map[
 				for _, dstPort := range dstPorts {
 					if rule.SymmetricMode {
 						// SymmetricMode will ignore rule direction, create both ingress and egress
-						if rule.hasLocalRule(dstIPBlock) {
+						if rule.hasLocalRule(dstIPBlock, managedVDSes) {
 							policyRuleList = append(policyRuleList, rule.generateRule(srcIP, dstIP, RuleDirectionIn, dstPort, "", "")...)
 						}
-						if rule.hasLocalRule(srcIPBlock) {
+						if rule.hasLocalRule(srcIPBlock, managedVDSes) {
 							policyRuleList = append(policyRuleList, rule.generateRule(srcIP, dstIP, RuleDirectionOut, dstPort, "", "")...)
 						}
-					} else if (rule.Direction == RuleDirectionIn && rule.hasLocalRule(dstIPBlock)) ||
-						(rule.Direction == RuleDirectionOut && rule.hasLocalRule(srcIPBlock)) {
+					} else if (rule.Direction == RuleDirectionIn && rule.hasLocalRule(dstIPBlock, managedVDSes)) ||
+						(rule.Direction == RuleDirectionOut && rule.hasLocalRule(srcIPBlock, managedVDSes)) {
 						policyRuleList = append(policyRuleList, rule.generateRule(srcIP, dstIP, rule.Direction, dstPort, "", "")...)
 					}
 				}
@@ -354,16 +359,19 @@ func (rule *CompleteRule) assemblyDstIPBlocks(ctx context.Context, groupCache *G
 	return ipBlocks
 }
 
-func (rule *CompleteRule) hasLocalRule(ipBlock *IPBlockItem) bool {
+func (rule *CompleteRule) hasLocalRule(ipBlock *IPBlockItem, managedVDSes sets.Set[string]) bool {
 	// apply to all target
 	if ipBlock == nil {
 		return true
 	}
 	// apply to src/dst has current agent
-	if ipBlock.AgentRef.Len() == 0 || ipBlock.AgentRef.Has(utils.CurrentAgentName()) {
-		return true
+	if ipBlock.AgentRef.Len() > 0 {
+		return ipBlock.AgentRef.Has(utils.CurrentAgentName())
 	}
-	return false
+	if ipBlock.VDSRef.Len() > 0 {
+		return ipBlock.VDSRef.HasAny(managedVDSes.UnsortedList()...)
+	}
+	return true
 }
 
 func (rule *CompleteRule) generateRule(srcIPBlock, dstIPBlock string, direction RuleDirection, port RulePort, srcVNicRef, dstVNicRef string) []PolicyRule {

--- a/pkg/agent/controller/policy/cache/rule_test.go
+++ b/pkg/agent/controller/policy/cache/rule_test.go
@@ -6,9 +6,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
 	"github.com/everoute/everoute/pkg/constants"
+	"github.com/everoute/everoute/pkg/utils"
 )
 
 func TestResolveDstPort(t *testing.T) {
@@ -137,6 +139,73 @@ func TestResolveDstPort(t *testing.T) {
 				t.Errorf("test %s failed, expect is %#v, but the res is %#v", item.name, item.expect, res)
 			}
 		}
+	}
+}
+
+func TestCompleteRuleHasLocalRule(t *testing.T) {
+	rule := &CompleteRule{}
+	currentAgent := utils.CurrentAgentName()
+	otherAgent := currentAgent + "-other"
+	managedVDSes := sets.New("vds-1")
+
+	tests := []struct {
+		name     string
+		ipBlock  *IPBlockItem
+		expected bool
+	}{
+		{
+			name:     "nil ipBlock should apply to all",
+			ipBlock:  nil,
+			expected: true,
+		},
+		{
+			name: "current agent should apply",
+			ipBlock: &IPBlockItem{
+				AgentRef: sets.New(currentAgent),
+				VDSRef:   sets.New[string](),
+			},
+			expected: true,
+		},
+		{
+			name: "agent ref should take precedence over managed vds",
+			ipBlock: &IPBlockItem{
+				AgentRef: sets.New(otherAgent),
+				VDSRef:   sets.New("vds-1"),
+			},
+			expected: false,
+		},
+		{
+			name: "managed vds should apply when agent ref is empty",
+			ipBlock: &IPBlockItem{
+				AgentRef: sets.New[string](),
+				VDSRef:   sets.New("vds-1"),
+			},
+			expected: true,
+		},
+		{
+			name: "unmanaged vds should not apply when agent ref is empty",
+			ipBlock: &IPBlockItem{
+				AgentRef: sets.New[string](),
+				VDSRef:   sets.New("vds-2"),
+			},
+			expected: false,
+		},
+		{
+			name: "empty agent and vds refs should apply to all",
+			ipBlock: &IPBlockItem{
+				AgentRef: sets.New[string](),
+				VDSRef:   sets.New[string](),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rule.hasLocalRule(tt.ipBlock, managedVDSes); got != tt.expected {
+				t.Fatalf("expect %t, got %t", tt.expected, got)
+			}
+		})
 	}
 }
 

--- a/pkg/agent/controller/policy/policy_controller.go
+++ b/pkg/agent/controller/policy/policy_controller.go
@@ -73,6 +73,7 @@ type Reconciler struct {
 	groupCache *policycache.GroupCache
 
 	DatapathManager *datapath.DpManager
+	ManagedVDSes    sets.Set[string]
 
 	sysProcessedPolicyLock sync.RWMutex
 	sysProcessedPolicy     sets.Set[k8stypes.NamespacedName]
@@ -186,6 +187,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.groupCache == nil {
 		r.groupCache = policycache.NewGroupCache()
 	}
+	if r.ManagedVDSes == nil {
+		r.ManagedVDSes = sets.New[string]()
+	}
 
 	r.sysProcessedPolicy = make(sets.Set[k8stypes.NamespacedName])
 
@@ -243,10 +247,10 @@ func (r *Reconciler) ruleUpdateByGroup(ctx context.Context, gm *groupv1alpha1.Gr
 		var oldRuleList, newRuleList []policycache.PolicyRule
 		rule := rules[i].(*policycache.CompleteRule)
 
-		oldRuleList = append(oldRuleList, rule.ListRules(ctx, r.groupCache)...)
+		oldRuleList = append(oldRuleList, rule.ListRules(ctx, r.groupCache, r.ManagedVDSes)...)
 		srcIPs := r.getRuleIPBlocksForUpdateGroupMembers(ctx, rule.SrcIPs, rule.SrcGroups, gm)
 		dstIPs := r.getRuleIPBlocksForUpdateGroupMembers(ctx, rule.DstIPs, rule.DstGroups, gm)
-		newRuleList = append(newRuleList, rule.GenerateRuleList(ctx, srcIPs, dstIPs, rule.Ports)...)
+		newRuleList = append(newRuleList, rule.GenerateRuleList(ctx, srcIPs, dstIPs, rule.Ports, r.ManagedVDSes)...)
 		newRuleList = append(newRuleList, rule.GenerateFullIsolationRule(nil, gm)...)
 		if err := r.syncPolicyRulesUntilSuccess(ctx, []string{rule.Policy}, oldRuleList, newRuleList); err != nil {
 			return err
@@ -275,7 +279,7 @@ func (r *Reconciler) cleanPolicyDependents(ctx context.Context, policy k8stypes.
 	// retrieve policy completeRules from cache
 	completeRules, _ := r.ruleCache.ByIndex(policycache.PolicyIndex, policy.Namespace+"/"+policy.Name)
 	for _, completeRule := range completeRules {
-		oldRuleList = append(oldRuleList, completeRule.(*policycache.CompleteRule).ListRules(ctx, r.groupCache)...)
+		oldRuleList = append(oldRuleList, completeRule.(*policycache.CompleteRule).ListRules(ctx, r.groupCache, r.ManagedVDSes)...)
 		// start a force full synchronization of policyrule
 		// remove policy completeRules from cache
 		_ = r.ruleCache.Delete(completeRule)
@@ -290,7 +294,7 @@ func (r *Reconciler) processPolicyUpdate(ctx context.Context, policy *securityv1
 
 	completeRules, _ := r.ruleCache.ByIndex(policycache.PolicyIndex, policy.Namespace+"/"+policy.Name)
 	for _, completeRule := range completeRules {
-		oldRuleList = append(oldRuleList, completeRule.(*policycache.CompleteRule).ListRules(ctx, r.groupCache)...)
+		oldRuleList = append(oldRuleList, completeRule.(*policycache.CompleteRule).ListRules(ctx, r.groupCache, r.ManagedVDSes)...)
 	}
 
 	newRuleList, err := r.calculateExpectedPolicyRules(ctx, policy)
@@ -329,7 +333,7 @@ func (r *Reconciler) calculateExpectedPolicyRules(ctx context.Context, policy *s
 
 	for _, completeRule := range completeRules {
 		_ = r.ruleCache.Add(completeRule)
-		policyRuleList = append(policyRuleList, completeRule.ListRules(ctx, r.groupCache)...)
+		policyRuleList = append(policyRuleList, completeRule.ListRules(ctx, r.groupCache, r.ManagedVDSes)...)
 	}
 
 	return policyRuleList, nil

--- a/pkg/agent/controller/policy/policy_controller_test.go
+++ b/pkg/agent/controller/policy/policy_controller_test.go
@@ -2450,6 +2450,7 @@ func endpointToMember(ep *securityv1alpha1.Endpoint) *groupv1alpha1.GroupMember 
 		},
 		IPs:           ep.Status.IPs,
 		EndpointAgent: ep.Status.Agents,
+		VDSID:         ep.Spec.VDSID,
 		Ports:         ep.Spec.Ports,
 	}
 }
@@ -2585,7 +2586,7 @@ func getRuleByPolicy(policy *securityv1alpha1.SecurityPolicy) []cache.PolicyRule
 		if err != nil {
 			return nil
 		}
-		policyRuleList = append(policyRuleList, rule.GenerateRuleList(ctx, srcIPs, dstIPs, rule.Ports)...)
+		policyRuleList = append(policyRuleList, rule.GenerateRuleList(ctx, srcIPs, dstIPs, rule.Ports, pCtrl.ManagedVDSes)...)
 		policyRuleList = append(policyRuleList, rule.GenerateFullIsolationRule(pCtrl.GetGroupCache(), nil)...)
 	}
 	return policyRuleList

--- a/pkg/apis/group/v1alpha1/types.go
+++ b/pkg/apis/group/v1alpha1/types.go
@@ -52,6 +52,7 @@ type GroupMember struct {
 	// EndpointAgent means where this groupMember may appear.
 	// if this field is empty, this group member will apply to all agents.
 	EndpointAgent []string             `json:"endpointAgent,omitempty"`
+	VDSID         string               `json:"vdsID,omitempty"`
 	IPs           []types.IPAddress    `json:"ips,omitempty"`
 	Ports         []v1alpha1.NamedPort `json:"ports,omitempty"`
 }
@@ -64,6 +65,9 @@ func (g *GroupMember) Equal(a *GroupMember) bool {
 		return false
 	}
 	if !sets.New[string](g.EndpointAgent...).Equal(sets.New[string](a.EndpointAgent...)) {
+		return false
+	}
+	if g.VDSID != a.VDSID {
 		return false
 	}
 

--- a/pkg/apis/group/v1alpha1/types_test.go
+++ b/pkg/apis/group/v1alpha1/types_test.go
@@ -21,6 +21,7 @@ func TestGroupMemberEqual(t *testing.T) {
 					ExternalIDName:  "test",
 					ExternalIDValue: "value-a",
 				},
+				VDSID:         "vds-1",
 				EndpointAgent: []string{"agent1", "agent2"},
 				IPs:           []types.IPAddress{"192.168.1.1", "10.10.10.1"},
 				Ports: []v1alpha1.NamedPort{
@@ -40,6 +41,7 @@ func TestGroupMemberEqual(t *testing.T) {
 					ExternalIDName:  "test",
 					ExternalIDValue: "value-a",
 				},
+				VDSID:         "vds-1",
 				EndpointAgent: []string{"agent2", "agent1"},
 				IPs:           []types.IPAddress{"10.10.10.1", "192.168.1.1"},
 				Ports: []v1alpha1.NamedPort{
@@ -55,6 +57,24 @@ func TestGroupMemberEqual(t *testing.T) {
 				},
 			},
 			exp: true,
+		},
+		{
+			name: "vds id doesn't equal",
+			aGM: &GroupMember{
+				EndpointReference: EndpointReference{
+					ExternalIDName:  "test",
+					ExternalIDValue: "value-a",
+				},
+				VDSID: "vds-1",
+			},
+			bGM: &GroupMember{
+				EndpointReference: EndpointReference{
+					ExternalIDName:  "test",
+					ExternalIDValue: "value-a",
+				},
+				VDSID: "vds-2",
+			},
+			exp: false,
 		},
 		{
 			name: "ip num doesn't equal",

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -339,6 +339,8 @@ type EndpointSpec struct {
 	// VID describe the endpoint in which VLAN
 	VID  uint32 `json:"vid"`
 	VMID string `json:"vmID,omitempty"`
+	// VDSID is the VDS ID that the endpoint belongs to.
+	VDSID string `json:"vdsID,omitempty"`
 
 	// ExtendLabels contains extend labels of endpoint. Each key in the labels
 	// could have multiple values, but at least one should be specified.
@@ -382,6 +384,8 @@ type EndpointStatus struct {
 	MacAddress string `json:"macAddress,omitempty"`
 	// Agents where this endpoint is currently located
 	Agents []string `json:"agents,omitempty"`
+	// NotManaged indicates this endpoint is outside the current Everoute managed scope.
+	NotManaged bool `json:"notManaged,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -35,9 +35,11 @@ const (
 
 	DefaultMaxConcurrentReconciles = 4
 	DependentsCleanFinalizer       = "finalizer.everoute.io/dependentsclean"
-	OwnerGroupLabelKey             = "label.everoute.io/ownergroup"
-	OwnerPolicyLabelKey            = "label.everoute.io/ownerpolicy"
-	IsGlobalPolicyRuleLabel        = "label.everoute.io/isglobalpolicy"
+	LabelKeyPrefix                 = "label.everoute.io"
+	OwnerGroupLabelKey             = LabelKeyPrefix + "/ownergroup"
+	OwnerPolicyLabelKey            = LabelKeyPrefix + "/ownerpolicy"
+	IsGlobalPolicyRuleLabel        = LabelKeyPrefix + "/isglobalpolicy"
+	EndpointLabelKeyVDSID          = LabelKeyPrefix + "/vds-id"
 
 	// Tier0 used for isolation policy and forensic one side drop
 	Tier0 = "tier0"

--- a/pkg/controller/endpoint/endpoint_controller.go
+++ b/pkg/controller/endpoint/endpoint_controller.go
@@ -160,6 +160,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, err
 		}
 	}
+	expectStatus.NotManaged = endpoint.Status.NotManaged
 
 	// Skip if none change for this endpoint.
 	if EqualEndpointStatus(endpoint.Status, *expectStatus) {
@@ -777,8 +778,9 @@ func EqualEndpointStatus(s securityv1alpha1.EndpointStatus, e securityv1alpha1.E
 	macEqual := s.MacAddress == e.MacAddress
 	ipsEqual := utils.EqualIPs(s.IPs, e.IPs)
 	agentEqual := utils.EqualStringSlice(s.Agents, e.Agents)
+	notManagedEqual := s.NotManaged == e.NotManaged
 
-	return macEqual && ipsEqual && agentEqual
+	return macEqual && ipsEqual && agentEqual && notManagedEqual
 }
 
 // GetEndpointID return ID of an endpoint, it's unique in one cluster.

--- a/pkg/controller/endpoint/notmanaged_controller.go
+++ b/pkg/controller/endpoint/notmanaged_controller.go
@@ -1,0 +1,371 @@
+/*
+Copyright 2021 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
+	msconst "github.com/everoute/everoute/pkg/constants/ms"
+	ersource "github.com/everoute/everoute/pkg/source"
+)
+
+type NotManagedReconciler struct {
+	client.Client
+
+	ConfigMapNamespace string
+	ConfigMapName      string
+	EndpointQueue      chan event.GenericEvent
+
+	configMapCacheLock sync.Mutex
+	configMapPrepared  bool
+	managedVDSes       sets.Set[string]
+}
+
+func (r *NotManagedReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if mgr == nil {
+		return fmt.Errorf("can't setup with nil manager")
+	}
+	if r.ConfigMapNamespace == "" {
+		return fmt.Errorf("can't setup with empty ConfigMapNamespace")
+	}
+	if r.ConfigMapName == "" {
+		return fmt.Errorf("can't setup with empty ConfigMapName")
+	}
+	if r.EndpointQueue == nil {
+		r.EndpointQueue = make(chan event.GenericEvent, 1024)
+	}
+	if r.managedVDSes == nil {
+		r.managedVDSes = sets.New[string]()
+	}
+
+	c, err := controller.New("endpoint-notmanaged-controller", mgr, controller.Options{
+		MaxConcurrentReconciles: constants.DefaultMaxConcurrentReconciles,
+		Reconciler:              r,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = c.Watch(ersource.Kind(mgr.GetCache(), &securityv1alpha1.Endpoint{}), &handler.EnqueueRequestForObject{}, endpointVDSIDChangedPredicate()); err != nil {
+		return err
+	}
+
+	if err = c.Watch(&source.Channel{Source: r.EndpointQueue}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	configMapController, err := controller.New("endpoint-notmanaged-configmap-controller", mgr, controller.Options{
+		MaxConcurrentReconciles: constants.DefaultMaxConcurrentReconciles,
+		Reconciler:              reconcile.Func(r.ReconcileConfigMap),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = configMapController.Watch(&ersource.WithSyncCache{
+		Name:       "endpoint-notmanaged-configmap",
+		Source:     ersource.Kind(mgr.GetCache(), &corev1.ConfigMap{}),
+		SyncCaches: []ersource.SyncCache{mgr.GetCache()},
+	}, &handler.EnqueueRequestForObject{}, r.configMapPredicate()); err != nil {
+		return err
+	}
+	klog.Infof("Setup endpoint notManaged controller with association ConfigMap %s/%s", r.ConfigMapNamespace, r.ConfigMapName)
+	return nil
+}
+
+func endpointVDSIDChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldEndpoint, oldOK := e.ObjectOld.(*securityv1alpha1.Endpoint)
+			newEndpoint, newOK := e.ObjectNew.(*securityv1alpha1.Endpoint)
+			if !(oldOK && newOK) {
+				return false
+			}
+			return oldEndpoint.Spec.VDSID != newEndpoint.Spec.VDSID
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return true
+		},
+	}
+}
+
+func (r *NotManagedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(6).Infof("Reconciling endpoint notManaged status for %s/%s", req.Namespace, req.Name)
+	endpoint := securityv1alpha1.Endpoint{}
+	if err := r.Get(ctx, req.NamespacedName, &endpoint); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	prepared, managedVDSes, err := r.currentAssociation(ctx)
+	if err != nil {
+		klog.Errorf("Failed to load association ConfigMap for endpoint %s/%s: %s", endpoint.Namespace, endpoint.Name, err)
+		return ctrl.Result{}, err
+	}
+	if !prepared {
+		klog.V(4).Infof("Skip endpoint %s/%s notManaged reconciliation because association ConfigMap isn't prepared", endpoint.Namespace, endpoint.Name)
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.reconcileEndpoint(ctx, &endpoint, managedVDSes); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *NotManagedReconciler) ReconcileConfigMap(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(6).Infof("Reconciling endpoint notManaged association ConfigMap %s/%s", req.Namespace, req.Name)
+	if req.Namespace != r.ConfigMapNamespace || req.Name != r.ConfigMapName {
+		klog.V(6).Infof("Skip unexpected association ConfigMap request %s/%s", req.Namespace, req.Name)
+		return ctrl.Result{}, nil
+	}
+
+	configMap := corev1.ConfigMap{}
+	if err := r.Get(ctx, req.NamespacedName, &configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.updateConfigMapCache(false, sets.New[string]())
+			klog.V(4).Infof("Association ConfigMap %s/%s was deleted, mark notManaged association as not prepared", req.Namespace, req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	prepared, managedVDSes, err := managedVDSesFromConfigMap(&configMap)
+	if err != nil {
+		r.updateConfigMapCache(false, sets.New[string]())
+		klog.Errorf("parse association ConfigMap %s/%s: %s", configMap.Namespace, configMap.Name, err)
+		return ctrl.Result{}, nil
+	}
+	if !prepared {
+		r.updateConfigMapCache(false, sets.New[string]())
+		klog.V(4).Infof("Association ConfigMap %s/%s isn't prepared, skip endpoint enqueue", configMap.Namespace, configMap.Name)
+		return ctrl.Result{}, nil
+	}
+
+	oldPrepared, changedVDSes := r.updateConfigMapCache(true, managedVDSes)
+	if !oldPrepared {
+		klog.Infof("Association ConfigMap %s/%s prepared, enqueue all endpoints for notManaged reconciliation", configMap.Namespace, configMap.Name)
+		r.enqueueAllEndpoints(ctx)
+		return ctrl.Result{}, nil
+	}
+	if changedVDSes.Len() == 0 {
+		klog.V(4).Infof("Association ConfigMap %s/%s has no managed VDS change, skip endpoint enqueue", configMap.Namespace, configMap.Name)
+		return ctrl.Result{}, nil
+	}
+
+	klog.Infof("Association ConfigMap %s/%s changed managed VDSes %v, enqueue related endpoints for notManaged reconciliation",
+		configMap.Namespace, configMap.Name, changedVDSes.UnsortedList())
+	r.enqueueEndpointsByVDSes(ctx, changedVDSes)
+	return ctrl.Result{}, nil
+}
+
+func (r *NotManagedReconciler) reconcileEndpoint(ctx context.Context, endpoint *securityv1alpha1.Endpoint, managedVDSes sets.Set[string]) error {
+	expectNotManaged := endpoint.Spec.VDSID != "" && !managedVDSes.Has(endpoint.Spec.VDSID)
+	if endpoint.Status.NotManaged == expectNotManaged {
+		return nil
+	}
+
+	endpoint.Status.NotManaged = expectNotManaged
+	if err := r.Status().Update(ctx, endpoint); err != nil {
+		return fmt.Errorf("update endpoint %s/%s notManaged status: %w", endpoint.Namespace, endpoint.Name, err)
+	}
+	klog.Infof("Updated endpoint %s/%s notManaged status to %v", endpoint.Namespace, endpoint.Name, expectNotManaged)
+	return nil
+}
+
+func (r *NotManagedReconciler) currentAssociation(ctx context.Context) (bool, sets.Set[string], error) {
+	configMap := corev1.ConfigMap{}
+	err := r.Get(ctx, k8stypes.NamespacedName{
+		Namespace: r.ConfigMapNamespace,
+		Name:      r.ConfigMapName,
+	}, &configMap)
+	if apierrors.IsNotFound(err) {
+		return false, sets.New[string](), nil
+	}
+	if err != nil {
+		return false, nil, err
+	}
+	return managedVDSesFromConfigMap(&configMap)
+}
+
+func (r *NotManagedReconciler) configMapPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			configMap, ok := e.Object.(*corev1.ConfigMap)
+			if !ok || !r.isAssociationConfigMap(configMap) {
+				return false
+			}
+
+			newPrepared, _, err := managedVDSesFromConfigMap(configMap)
+			if err != nil {
+				klog.Errorf("parse association ConfigMap %s/%s: %s", configMap.Namespace, configMap.Name, err)
+				return true
+			}
+			klog.V(6).Infof("Association ConfigMap %s/%s create predicate prepared=%v", configMap.Namespace, configMap.Name, newPrepared)
+			return newPrepared
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldConfigMap, oldOK := e.ObjectOld.(*corev1.ConfigMap)
+			newConfigMap, newOK := e.ObjectNew.(*corev1.ConfigMap)
+			if !(oldOK && newOK) || !r.isAssociationConfigMap(newConfigMap) {
+				return false
+			}
+
+			oldPrepared, oldManagedVDSes, err := managedVDSesFromConfigMap(oldConfigMap)
+			if err != nil {
+				klog.V(4).Infof("parse old association ConfigMap %s/%s: %s", oldConfigMap.Namespace, oldConfigMap.Name, err)
+				oldPrepared = false
+				oldManagedVDSes = sets.New[string]()
+			}
+			newPrepared, newManagedVDSes, err := managedVDSesFromConfigMap(newConfigMap)
+			if err != nil {
+				klog.Errorf("parse association ConfigMap %s/%s: %s", newConfigMap.Namespace, newConfigMap.Name, err)
+				return true
+			}
+			if oldPrepared != newPrepared {
+				klog.V(4).Infof("Association ConfigMap %s/%s update predicate accepted because prepared state changed from %v to %v",
+					newConfigMap.Namespace, newConfigMap.Name, oldPrepared, newPrepared)
+				return true
+			}
+			if !newPrepared {
+				klog.V(6).Infof("Association ConfigMap %s/%s update predicate skipped because new object isn't prepared", newConfigMap.Namespace, newConfigMap.Name)
+				return false
+			}
+			changedVDSes := oldManagedVDSes.Difference(newManagedVDSes).Union(newManagedVDSes.Difference(oldManagedVDSes))
+			klog.V(4).Infof("Association ConfigMap %s/%s update predicate changed VDSes %v", newConfigMap.Namespace, newConfigMap.Name, changedVDSes.UnsortedList())
+			return changedVDSes.Len() > 0
+		},
+		// Reconcile association ConfigMap delete events to clear the local prepared cache.
+		DeleteFunc: r.predicateConfigMapDelete,
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func (r *NotManagedReconciler) predicateConfigMapDelete(e event.DeleteEvent) bool {
+	configMap, ok := e.Object.(*corev1.ConfigMap)
+	if !ok {
+		return false
+	}
+	return r.isAssociationConfigMap(configMap)
+}
+
+func (r *NotManagedReconciler) isAssociationConfigMap(configMap *corev1.ConfigMap) bool {
+	return configMap.Namespace == r.ConfigMapNamespace && configMap.Name == r.ConfigMapName
+}
+
+func (r *NotManagedReconciler) updateConfigMapCache(prepared bool, managedVDSes sets.Set[string]) (oldPrepared bool, changedVDSes sets.Set[string]) {
+	r.configMapCacheLock.Lock()
+	defer r.configMapCacheLock.Unlock()
+
+	oldPrepared = r.configMapPrepared
+	oldManagedVDSes := r.managedVDSes
+	r.configMapPrepared = prepared
+	r.managedVDSes = sets.New(managedVDSes.UnsortedList()...)
+	if oldManagedVDSes == nil {
+		oldManagedVDSes = sets.New[string]()
+	}
+	changedVDSes = oldManagedVDSes.Difference(managedVDSes).Union(managedVDSes.Difference(oldManagedVDSes))
+	return oldPrepared, changedVDSes
+}
+
+func (r *NotManagedReconciler) enqueueAllEndpoints(ctx context.Context) {
+	endpoints := securityv1alpha1.EndpointList{}
+	if err := r.List(ctx, &endpoints); err != nil {
+		klog.Errorf("list endpoints for notManaged reconciliation: %s", err)
+		return
+	}
+	klog.V(4).Infof("Enqueue %d endpoints for notManaged reconciliation", len(endpoints.Items))
+	for i := range endpoints.Items {
+		r.enqueueEndpoint(ctx, &endpoints.Items[i])
+	}
+}
+
+func (r *NotManagedReconciler) enqueueEndpointsByVDSes(ctx context.Context, vdsIDs sets.Set[string]) {
+	requirement, err := k8slabels.NewRequirement(constants.EndpointLabelKeyVDSID, selection.In, vdsIDs.UnsortedList())
+	if err != nil {
+		klog.Errorf("build endpoint vds label selector: %s", err)
+		r.enqueueAllEndpoints(ctx)
+		return
+	}
+
+	endpoints := securityv1alpha1.EndpointList{}
+	if err := r.List(ctx, &endpoints, client.MatchingLabelsSelector{Selector: k8slabels.NewSelector().Add(*requirement)}); err != nil {
+		klog.Errorf("list endpoints by vds labels %v: %s", vdsIDs.UnsortedList(), err)
+		r.enqueueAllEndpoints(ctx)
+		return
+	}
+	klog.V(4).Infof("Enqueue %d endpoints in changed VDSes %v for notManaged reconciliation", len(endpoints.Items), vdsIDs.UnsortedList())
+	for i := range endpoints.Items {
+		r.enqueueEndpoint(ctx, &endpoints.Items[i])
+	}
+}
+
+func (r *NotManagedReconciler) enqueueEndpoint(ctx context.Context, endpoint *securityv1alpha1.Endpoint) {
+	select {
+	case r.EndpointQueue <- ersource.NewResourceEvent(endpoint.Name, endpoint.Namespace):
+		klog.V(4).Infof("Enqueued endpoint %s/%s for notManaged reconciliation", endpoint.Namespace, endpoint.Name)
+	case <-ctx.Done():
+		klog.V(4).Infof("Skip enqueue endpoint %s/%s because context is done", endpoint.Namespace, endpoint.Name)
+	}
+}
+
+func managedVDSesFromConfigMap(configMap *corev1.ConfigMap) (bool, sets.Set[string], error) {
+	annotations := configMap.GetAnnotations()
+	if annotations[msconst.AssociationSyncCompletedAnnotation] != "true" ||
+		annotations[msconst.AssociationFormatVersionAnnotation] != msconst.AssociationFormatVersionV2 {
+		return false, sets.New[string](), nil
+	}
+
+	managedVDSes := sets.New[string]()
+	for clusterID, rawVDSIDs := range configMap.Data {
+		var vdsIDs []string
+		if err := json.Unmarshal([]byte(rawVDSIDs), &vdsIDs); err != nil {
+			return false, nil, fmt.Errorf("unmarshal vdses for cluster %s: %w", clusterID, err)
+		}
+		for _, vdsID := range vdsIDs {
+			if vdsID != "" {
+				managedVDSes.Insert(vdsID)
+			}
+		}
+	}
+	return true, managedVDSes, nil
+}

--- a/pkg/controller/endpoint/notmanaged_controller_test.go
+++ b/pkg/controller/endpoint/notmanaged_controller_test.go
@@ -1,0 +1,479 @@
+/*
+Copyright 2021 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	clientsetscheme "github.com/everoute/everoute/pkg/client/clientset_generated/clientset/scheme"
+	"github.com/everoute/everoute/pkg/constants"
+	msconst "github.com/everoute/everoute/pkg/constants/ms"
+)
+
+var _ = Describe("notManaged controller", func() {
+	ctx := context.Background()
+	namespace := "tower-space"
+
+	type testEndpoint struct {
+		name           string
+		vdsID          string
+		notManaged     bool
+		wantNotManaged bool
+	}
+
+	newEndpoint := func(ep testEndpoint) *securityv1alpha1.Endpoint {
+		labels := map[string]string{}
+		if ep.vdsID != "" {
+			labels[constants.EndpointLabelKeyVDSID] = ep.vdsID
+		}
+		return &securityv1alpha1.Endpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ep.name,
+				Namespace: "default",
+				Labels:    labels,
+			},
+			Spec:   securityv1alpha1.EndpointSpec{VDSID: ep.vdsID},
+			Status: securityv1alpha1.EndpointStatus{NotManaged: ep.notManaged},
+		}
+	}
+
+	reconcileQueuedEndpoints := func(reconciler *NotManagedReconciler) {
+		for len(reconciler.EndpointQueue) > 0 {
+			genericEvent := <-reconciler.EndpointQueue
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+				Namespace: genericEvent.Object.GetNamespace(),
+				Name:      genericEvent.Object.GetName(),
+			}})
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+	}
+
+	expectEndpointNotManaged := func(k8sClient client.Client, ep testEndpoint) {
+		got := securityv1alpha1.Endpoint{}
+		Expect(k8sClient.Get(ctx, k8stypes.NamespacedName{Name: ep.name, Namespace: "default"}, &got)).Should(Succeed())
+		Expect(got.Status.NotManaged).Should(Equal(ep.wantNotManaged), "endpoint %s", ep.name)
+	}
+
+	testScheme := func() *runtime.Scheme {
+		scheme := runtime.NewScheme()
+		Expect(clientsetscheme.AddToScheme(scheme)).Should(Succeed())
+		Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+		return scheme
+	}
+
+	It("reconciles all endpoints when association configmap becomes prepared", func() {
+		endpoints := []testEndpoint{
+			{name: "prepared-no-vds", wantNotManaged: false},
+			{name: "prepared-managed-vds", vdsID: "vds-1", notManaged: true, wantNotManaged: false},
+			{name: "prepared-unmanaged-vds", vdsID: "vds-2", wantNotManaged: true},
+		}
+
+		objects := []client.Object{
+			preparedAssociationConfigMap(namespace, map[string]string{"cluster-1": `["vds-1"]`}),
+		}
+		for _, ep := range endpoints {
+			objects = append(objects, newEndpoint(ep))
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithStatusSubresource(&securityv1alpha1.Endpoint{}).
+			WithObjects(objects...).
+			Build()
+		reconciler := newTestNotManagedReconciler(k8sClient, namespace)
+
+		_, err := reconciler.ReconcileConfigMap(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      msconst.ComputeClustersConfigMapName,
+			Namespace: namespace,
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(reconciler.EndpointQueue).Should(HaveLen(len(endpoints)))
+
+		reconcileQueuedEndpoints(reconciler)
+		for _, ep := range endpoints {
+			expectEndpointNotManaged(k8sClient, ep)
+		}
+	})
+
+	It("reconciles endpoints in changed vdses when association configmap changes", func() {
+		endpoints := []testEndpoint{
+			{name: "changed-managed-vds", vdsID: "vds-1", wantNotManaged: false},
+			{name: "changed-new-managed-vds", vdsID: "vds-2", notManaged: true, wantNotManaged: false},
+			{name: "changed-no-vds", wantNotManaged: false},
+		}
+
+		configMap := preparedAssociationConfigMap(namespace, map[string]string{"cluster-1": `["vds-1","vds-2"]`})
+		objects := []client.Object{configMap}
+		for _, ep := range endpoints {
+			objects = append(objects, newEndpoint(ep))
+		}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithStatusSubresource(&securityv1alpha1.Endpoint{}).
+			WithObjects(objects...).
+			Build()
+		reconciler := newTestNotManagedReconciler(k8sClient, namespace)
+		reconciler.updateConfigMapCache(true, sets.New("vds-1"))
+
+		_, err := reconciler.ReconcileConfigMap(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+			Name:      msconst.ComputeClustersConfigMapName,
+			Namespace: namespace,
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(reconciler.EndpointQueue).Should(HaveLen(1))
+
+		reconcileQueuedEndpoints(reconciler)
+		for _, ep := range endpoints {
+			expectEndpointNotManaged(k8sClient, ep)
+		}
+	})
+})
+
+func TestManagedVDSesFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name         string
+		configMap    *corev1.ConfigMap
+		wantPrepared bool
+		wantVDSes    sets.Set[string]
+		wantErr      bool
+	}{
+		{
+			name: "not prepared",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: msconst.ComputeClustersConfigMapName},
+				Data:       map[string]string{"cluster-1": `["vds-1"]`},
+			},
+			wantPrepared: false,
+			wantVDSes:    sets.New[string](),
+		},
+		{
+			name: "prepared v2",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: msconst.ComputeClustersConfigMapName,
+					Annotations: map[string]string{
+						msconst.AssociationSyncCompletedAnnotation: "true",
+						msconst.AssociationFormatVersionAnnotation: msconst.AssociationFormatVersionV2,
+					},
+				},
+				Data: map[string]string{
+					"cluster-1": `["vds-1","vds-2"]`,
+					"cluster-2": `["vds-2","vds-3"]`,
+				},
+			},
+			wantPrepared: true,
+			wantVDSes:    sets.New("vds-1", "vds-2", "vds-3"),
+		},
+		{
+			name: "invalid vds list",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: msconst.ComputeClustersConfigMapName,
+					Annotations: map[string]string{
+						msconst.AssociationSyncCompletedAnnotation: "true",
+						msconst.AssociationFormatVersionAnnotation: msconst.AssociationFormatVersionV2,
+					},
+				},
+				Data: map[string]string{"cluster-1": `invalid`},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPrepared, gotVDSes, err := managedVDSesFromConfigMap(tt.configMap)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPrepared != tt.wantPrepared {
+				t.Fatalf("unexpected prepared, got %v want %v", gotPrepared, tt.wantPrepared)
+			}
+			if !gotVDSes.Equal(tt.wantVDSes) {
+				t.Fatalf("unexpected managed vdses, got %v want %v", gotVDSes, tt.wantVDSes)
+			}
+		})
+	}
+}
+
+func TestNotManagedReconcileEndpoint(t *testing.T) {
+	ctx := context.Background()
+	associationConfigMap := preparedAssociationConfigMap("tower-space", map[string]string{"cluster-1": `["vds-1"]`})
+	tests := []struct {
+		name           string
+		endpoint       *securityv1alpha1.Endpoint
+		wantNotManaged bool
+	}{
+		{
+			name: "endpoint without vds is managed",
+			endpoint: &securityv1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "ep-1", Namespace: "default"},
+			},
+			wantNotManaged: false,
+		},
+		{
+			name: "endpoint in managed vds is managed",
+			endpoint: &securityv1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "ep-2", Namespace: "default"},
+				Spec:       securityv1alpha1.EndpointSpec{VDSID: "vds-1"},
+				Status:     securityv1alpha1.EndpointStatus{NotManaged: true},
+			},
+			wantNotManaged: false,
+		},
+		{
+			name: "endpoint outside managed vds is notManaged",
+			endpoint: &securityv1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "ep-3", Namespace: "default"},
+				Spec:       securityv1alpha1.EndpointSpec{VDSID: "vds-2"},
+			},
+			wantNotManaged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme(t)).
+				WithStatusSubresource(&securityv1alpha1.Endpoint{}).
+				WithObjects(tt.endpoint.DeepCopy(), associationConfigMap.DeepCopy()).
+				Build()
+			reconciler := newTestNotManagedReconciler(k8sClient, "tower-space")
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+				Name:      tt.endpoint.Name,
+				Namespace: tt.endpoint.Namespace,
+			}})
+			if err != nil {
+				t.Fatalf("reconcile endpoint: %v", err)
+			}
+
+			got := securityv1alpha1.Endpoint{}
+			if err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: tt.endpoint.Name, Namespace: tt.endpoint.Namespace}, &got); err != nil {
+				t.Fatalf("get endpoint: %v", err)
+			}
+			if got.Status.NotManaged != tt.wantNotManaged {
+				t.Fatalf("unexpected notManaged, got %v want %v", got.Status.NotManaged, tt.wantNotManaged)
+			}
+		})
+	}
+}
+
+func TestNotManagedReconcileEndpointSkipBeforeAssociationPrepared(t *testing.T) {
+	ctx := context.Background()
+	endpoint := &securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "ep", Namespace: "default"},
+		Spec:       securityv1alpha1.EndpointSpec{VDSID: "vds-2"},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&securityv1alpha1.Endpoint{}).
+		WithObjects(endpoint).
+		Build()
+	reconciler := newTestNotManagedReconciler(k8sClient, "tower-space")
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+		Name:      endpoint.Name,
+		Namespace: endpoint.Namespace,
+	}})
+	if err != nil {
+		t.Fatalf("reconcile endpoint: %v", err)
+	}
+
+	got := securityv1alpha1.Endpoint{}
+	if err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: endpoint.Name, Namespace: endpoint.Namespace}, &got); err != nil {
+		t.Fatalf("get endpoint: %v", err)
+	}
+	if got.Status.NotManaged {
+		t.Fatalf("endpoint should not be marked notManaged before association configmap prepared")
+	}
+}
+
+func TestNotManagedReconcileConfigMapEnqueuesEndpoints(t *testing.T) {
+	ctx := context.Background()
+	managedEndpoint := &securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "managed", Namespace: "default"},
+		Spec:       securityv1alpha1.EndpointSpec{VDSID: "vds-1"},
+		Status:     securityv1alpha1.EndpointStatus{NotManaged: true},
+	}
+	notManagedEndpoint := &securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-managed", Namespace: "default"},
+		Spec:       securityv1alpha1.EndpointSpec{VDSID: "vds-2"},
+	}
+	associationConfigMap := preparedAssociationConfigMap("tower-space", map[string]string{"cluster-1": `["vds-1"]`})
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(&securityv1alpha1.Endpoint{}).
+		WithObjects(managedEndpoint, notManagedEndpoint, associationConfigMap).
+		Build()
+	reconciler := newTestNotManagedReconciler(k8sClient, "tower-space")
+
+	_, err := reconciler.ReconcileConfigMap(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+		Name:      msconst.ComputeClustersConfigMapName,
+		Namespace: "tower-space",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile configmap: %v", err)
+	}
+
+	if len(reconciler.EndpointQueue) != 2 {
+		t.Fatalf("unexpected endpoint queue length, got %d want 2", len(reconciler.EndpointQueue))
+	}
+	gotRequests := sets.New[string]()
+	for len(reconciler.EndpointQueue) > 0 {
+		event := <-reconciler.EndpointQueue
+		gotRequests.Insert(event.Object.GetNamespace() + "/" + event.Object.GetName())
+	}
+	wantRequests := sets.New("default/managed", "default/not-managed")
+	if !gotRequests.Equal(wantRequests) {
+		t.Fatalf("unexpected endpoint requests, got %v want %v", gotRequests.UnsortedList(), wantRequests.UnsortedList())
+	}
+}
+
+func TestNotManagedReconcileConfigMapEnqueuesChangedVDSEndpoints(t *testing.T) {
+	ctx := context.Background()
+	changedEndpoint := &securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "changed",
+			Namespace: "default",
+			Labels:    map[string]string{constants.EndpointLabelKeyVDSID: "vds-2"},
+		},
+		Spec: securityv1alpha1.EndpointSpec{VDSID: "vds-2"},
+	}
+	unchangedEndpoint := &securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unchanged",
+			Namespace: "default",
+			Labels:    map[string]string{constants.EndpointLabelKeyVDSID: "vds-1"},
+		},
+		Spec: securityv1alpha1.EndpointSpec{VDSID: "vds-1"},
+	}
+	associationConfigMap := preparedAssociationConfigMap("tower-space", map[string]string{"cluster-1": `["vds-1","vds-2"]`})
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithObjects(changedEndpoint, unchangedEndpoint, associationConfigMap).
+		Build()
+	reconciler := newTestNotManagedReconciler(k8sClient, "tower-space")
+	reconciler.updateConfigMapCache(true, sets.New("vds-1"))
+
+	_, err := reconciler.ReconcileConfigMap(ctx, ctrl.Request{NamespacedName: k8stypes.NamespacedName{
+		Name:      msconst.ComputeClustersConfigMapName,
+		Namespace: "tower-space",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile configmap: %v", err)
+	}
+
+	if len(reconciler.EndpointQueue) != 1 {
+		t.Fatalf("unexpected endpoint queue length, got %d want 1", len(reconciler.EndpointQueue))
+	}
+	event := <-reconciler.EndpointQueue
+	if event.Object.GetNamespace() != changedEndpoint.Namespace || event.Object.GetName() != changedEndpoint.Name {
+		t.Fatalf("unexpected queued endpoint %s/%s", event.Object.GetNamespace(), event.Object.GetName())
+	}
+}
+
+func TestNotManagedConfigMapUpdatePredicate(t *testing.T) {
+	reconciler := newTestNotManagedReconciler(nil, "tower-space")
+	oldConfigMap := preparedAssociationConfigMap("tower-space", map[string]string{"cluster-1": `["vds-1"]`})
+	newConfigMap := preparedAssociationConfigMap("tower-space", map[string]string{"cluster-1": `["vds-1","vds-2"]`})
+
+	p := reconciler.configMapPredicate()
+	if !p.Update(event.UpdateEvent{ObjectOld: oldConfigMap, ObjectNew: newConfigMap}) {
+		t.Fatalf("vds set change should pass configmap update predicate")
+	}
+
+	if p.Update(event.UpdateEvent{ObjectOld: oldConfigMap, ObjectNew: oldConfigMap.DeepCopy()}) {
+		t.Fatalf("same vds set should not pass configmap update predicate")
+	}
+}
+
+func TestEndpointVDSIDChangedPredicate(t *testing.T) {
+	p := endpointVDSIDChangedPredicate()
+	oldEndpoint := &securityv1alpha1.Endpoint{Spec: securityv1alpha1.EndpointSpec{VDSID: "vds-1"}}
+	sameEndpoint := &securityv1alpha1.Endpoint{Spec: securityv1alpha1.EndpointSpec{VDSID: "vds-1"}}
+	changedEndpoint := &securityv1alpha1.Endpoint{Spec: securityv1alpha1.EndpointSpec{VDSID: "vds-2"}}
+
+	if !p.Create(event.CreateEvent{Object: oldEndpoint}) {
+		t.Fatalf("create event should be enqueued")
+	}
+	if p.Delete(event.DeleteEvent{Object: oldEndpoint}) {
+		t.Fatalf("delete event should not be enqueued")
+	}
+	if !p.Generic(event.GenericEvent{Object: oldEndpoint}) {
+		t.Fatalf("generic event should be enqueued")
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: oldEndpoint, ObjectNew: sameEndpoint}) {
+		t.Fatalf("same vdsID update should not be enqueued")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: oldEndpoint, ObjectNew: changedEndpoint}) {
+		t.Fatalf("changed vdsID update should be enqueued")
+	}
+}
+
+func preparedAssociationConfigMap(namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      msconst.ComputeClustersConfigMapName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				msconst.AssociationSyncCompletedAnnotation: "true",
+				msconst.AssociationFormatVersionAnnotation: msconst.AssociationFormatVersionV2,
+			},
+		},
+		Data: data,
+	}
+}
+
+func newTestNotManagedReconciler(k8sClient client.Client, namespace string) *NotManagedReconciler {
+	return &NotManagedReconciler{
+		Client:             k8sClient,
+		ConfigMapNamespace: namespace,
+		ConfigMapName:      msconst.ComputeClustersConfigMapName,
+		EndpointQueue:      make(chan event.GenericEvent, 10),
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientsetscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add everoute scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return scheme
+}

--- a/pkg/controller/group/group_controller.go
+++ b/pkg/controller/group/group_controller.go
@@ -156,8 +156,10 @@ func (r *Reconciler) updateEndpoint(_ context.Context, e event.UpdateEvent, q wo
 
 	if k8slabels.Equals(newEndpoint.Labels, oldEndpoint.Labels) &&
 		labels.Equals(newEndpoint.Spec.ExtendLabels, oldEndpoint.Spec.ExtendLabels) &&
+		newEndpoint.Spec.VDSID == oldEndpoint.Spec.VDSID &&
 		utils.EqualIPs(newEndpoint.Status.IPs, oldEndpoint.Status.IPs) &&
-		utils.EqualStringSlice(newEndpoint.Status.Agents, oldEndpoint.Status.Agents) {
+		utils.EqualStringSlice(newEndpoint.Status.Agents, oldEndpoint.Status.Agents) &&
+		newEndpoint.Status.NotManaged == oldEndpoint.Status.NotManaged {
 		return
 	}
 
@@ -559,6 +561,9 @@ func (r *Reconciler) fetchCurrGroupMembers(ctx context.Context, group *groupv1al
 	// conversion endpoint list to member list
 	memberList := make([]groupv1alpha1.GroupMember, 0, len(matchedEndpoints))
 	for _, ep := range matchedEndpoints {
+		if ep.Status.NotManaged {
+			continue
+		}
 		if isAllEpsGroup && len(ep.Spec.Ports) == 0 {
 			// for AllEndpointsGroup skip endpoint has no named port
 			continue
@@ -570,6 +575,7 @@ func (r *Reconciler) fetchCurrGroupMembers(ctx context.Context, group *groupv1al
 				ExternalIDValue: ep.Spec.Reference.ExternalIDValue,
 			},
 			EndpointAgent: ep.Status.Agents,
+			VDSID:         ep.Spec.VDSID,
 			IPs:           ep.Status.IPs,
 			Ports:         ep.Spec.Ports,
 		}

--- a/pkg/controller/group/group_controller_test.go
+++ b/pkg/controller/group/group_controller_test.go
@@ -104,6 +104,24 @@ var _ = Describe("GroupController", func() {
 					assertHasGroupMembers(epGroup, groupv1alpha1.GroupMembers{GroupMembers: []groupv1alpha1.GroupMember{endpointToGroupMember(ep)}})
 				})
 			})
+			When("create a notManaged endpoint in the group", func() {
+				var ep *securityv1alpha1.Endpoint
+				var epStatus securityv1alpha1.EndpointStatus
+				var namespace = metav1.NamespaceDefault
+
+				BeforeEach(func() {
+					ep, epStatus = newTestEndpoint(namespace, "192.168.1.1", "agent1", map[string]string{"label.key": "label.value"}, nil)
+					epStatus.NotManaged = true
+
+					By(fmt.Sprintf("create notManaged endpoint %s with labels %v", ep.Name, ep.Labels))
+					Expect(k8sClient.Create(ctx, ep)).Should(Succeed())
+					ep.Status = epStatus
+					Expect(k8sClient.Status().Update(ctx, ep)).Should(Succeed())
+				})
+				It("should not add the endpoint to groupmembers", func() {
+					assertHasGroupMembers(epGroup, groupv1alpha1.GroupMembers{GroupMembers: []groupv1alpha1.GroupMember{}})
+				})
+			})
 		})
 		Context("an endpoint in the group", func() {
 			var ep *securityv1alpha1.Endpoint
@@ -149,6 +167,19 @@ var _ = Describe("GroupController", func() {
 
 					By(fmt.Sprintf("update endpoint %s agents to %v", ep.Name, ep.Status.Agents))
 					Expect(k8sClient.Status().Update(ctx, ep)).Should(Succeed())
+				})
+				It("should update groupmembers contains the endpoint", func() {
+					assertHasGroupMembers(epGroup, groupv1alpha1.GroupMembers{GroupMembers: []groupv1alpha1.GroupMember{endpointToGroupMember(ep)}})
+				})
+			})
+			When("update the endpoint vdsID", func() {
+				BeforeEach(func() {
+					updateEndpoint := ep.DeepCopy()
+					updateEndpoint.Spec.VDSID = "vds-2"
+
+					By(fmt.Sprintf("update endpoint %s vdsID to %s", ep.Name, updateEndpoint.Spec.VDSID))
+					Expect(k8sClient.Patch(ctx, updateEndpoint, client.MergeFrom(ep))).Should(Succeed())
+					ep = updateEndpoint
 				})
 				It("should update groupmembers contains the endpoint", func() {
 					assertHasGroupMembers(epGroup, groupv1alpha1.GroupMembers{GroupMembers: []groupv1alpha1.GroupMember{endpointToGroupMember(ep)}})
@@ -448,6 +479,7 @@ func endpointToGroupMember(ep *securityv1alpha1.Endpoint) groupv1alpha1.GroupMem
 		},
 		IPs:           ep.Status.IPs,
 		EndpointAgent: ep.Status.Agents,
+		VDSID:         ep.Spec.VDSID,
 	}
 }
 
@@ -463,6 +495,7 @@ func newTestEndpoint(namespace, ip, agent string, labels map[string]string, exte
 			Labels:    labels,
 		},
 		Spec: securityv1alpha1.EndpointSpec{
+			VDSID:        "vds-test",
 			ExtendLabels: extendLabels,
 			Reference: securityv1alpha1.EndpointReference{
 				ExternalIDName:  id,

--- a/plugin/tower/pkg/controller/endpoint/controller.go
+++ b/plugin/tower/pkg/controller/endpoint/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
 	"github.com/everoute/everoute/pkg/client/clientset_generated/clientset"
 	crd "github.com/everoute/everoute/pkg/client/informers_generated/externalversions"
+	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/types"
 	"github.com/everoute/everoute/pkg/utils"
 	"github.com/everoute/everoute/plugin/tower/pkg/informer"
@@ -671,10 +672,19 @@ func (c *Controller) setEndpoint(ep *v1alpha1.Endpoint, vnic *schema.VMNic, labe
 	var epCopy = ep.DeepCopy()
 
 	ep.Name = vnic.ID
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if vnic.Vlan.VDS.ID == "" {
+		delete(labels, constants.EndpointLabelKeyVDSID)
+	} else {
+		labels[constants.EndpointLabelKeyVDSID] = vnic.Vlan.VDS.ID
+	}
 	ep.Labels = labels
 	ep.Namespace = c.namespace
 	ep.Spec.VID = uint32(vnic.Vlan.VlanID)
 	ep.Spec.VMID = vmID
+	ep.Spec.VDSID = vnic.Vlan.VDS.ID
 	ep.Spec.ExtendLabels = extendLabels
 	ep.Spec.Reference.ExternalIDName = ExternalIDName
 	ep.Spec.Reference.ExternalIDValue = vnic.InterfaceID

--- a/plugin/tower/pkg/controller/endpoint/controller_test.go
+++ b/plugin/tower/pkg/controller/endpoint/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/types"
 	controller "github.com/everoute/everoute/plugin/tower/pkg/controller/endpoint"
 	"github.com/everoute/everoute/plugin/tower/pkg/schema"
@@ -122,6 +123,19 @@ var _ = Describe("EndpointController", func() {
 				assertEndpointsNum(ctx, 2)
 				assertHasEndpoint(ctx, matchDynamic(vnicA, AggregateLabels(labelA, labelB), nil))
 				assertHasEndpoint(ctx, matchDynamic(vnicB, AggregateLabels(labelA, labelB), nil))
+			})
+
+			When("vnic belongs to vds", func() {
+				BeforeEach(func() {
+					vnicA.Vlan.VDS.ID = "vds-1"
+					vm.VMNics[0] = *vnicA
+					server.TrackerFactory().VM().CreateOrUpdate(vm)
+				})
+				It("should sync endpoint vds id and label", func() {
+					expectLabels := AggregateLabels(labelA, labelB)
+					expectLabels[constants.EndpointLabelKeyVDSID] = "vds-1"
+					assertHasEndpoint(ctx, matchDynamic(vnicA, expectLabels, nil))
+				})
 			})
 
 			When("add vnic to vm", func() {
@@ -464,6 +478,8 @@ func matchDynamic(vnic *schema.VMNic, labels map[string]string, extendLabels map
 		return endpoint.GetName() == vnic.GetID() &&
 			cmp.Equal(endpoint.GetLabels(), labels, cmpopts.EquateEmpty()) &&
 			cmp.Equal(endpoint.Spec.ExtendLabels, extendLabels, cmpopts.EquateEmpty(), cmpopts.SortSlices(lessFunc)) &&
+			endpoint.Spec.VID == uint32(vnic.Vlan.VlanID) &&
+			endpoint.Spec.VDSID == vnic.Vlan.VDS.ID &&
 			endpoint.Spec.Reference.ExternalIDName == controller.ExternalIDName &&
 			endpoint.Spec.Reference.ExternalIDValue == vnic.InterfaceID &&
 			endpoint.Spec.Type == v1alpha1.EndpointDynamic


### PR DESCRIPTION
## Purpose

Filter endpoint/group member handling by the Everoute-managed VDS scope so endpoints outside the current Everoute management boundary do not become effective policy targets.

## Changes

- Sync Everoute-managed VDS associations from Tower into the existing `associate-compute-clusters` ConfigMap using v2 format.
- Keep ConfigMap data compatible with existing sks-plugin usage by storing `clusterID -> JSON VDS ID list` in `data`.
- Use ConfigMap annotations for sync readiness and format version so upgraded controllers can distinguish unsynced Tower data from an intentionally empty association set.
- Add endpoint `spec.vdsID` and `status.notManaged`; a dedicated controller updates `notManaged` from endpoint VDS and the synced ConfigMap.
- Filter generated groupmembers by endpoint `notManaged`, and include endpoint `vdsID` in GroupMember/GroupMembersPatch APIs.
- Update agent policy rule generation: node/agent ownership takes precedence; if no node ownership exists, VDS ownership limits flow delivery to agents managing that VDS; if no VDS ownership exists, rules are delivered normally.

## Tests

- `docker run --rm -iu 0:0 -e USER=root -w /workspace -v /root/workspace/everoute:/workspace -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/apis/group/v1alpha1 ./pkg/controller/group ./pkg/agent/controller/policy/cache ./pkg/agent/controller/policy ./cmd/everoute-agent -count=1`
- Earlier deployment verification on controller VMs confirmed controller containers became healthy and `associate-compute-clusters` was updated with the expected v2 cluster-to-VDS association data and sync annotation.