### PR TITLE
feat: update endpoint agents when endpoint match ovs interface

### DIFF
--- a/pkg/controller/endpoint/endpoint_controller.go
+++ b/pkg/controller/endpoint/endpoint_controller.go
@@ -721,8 +721,8 @@ func (r *Reconciler) fetchEndpointStatusFromAgentInfo(endpoint securityv1alpha1.
 		// combine all ifaces status into endpoint status
 		agentSets := sets.NewString()
 		for _, item := range ifaces {
+			agentSets.Insert(item.(*iface).agentName)
 			if len(item.(*iface).ipMap) != 0 {
-				agentSets.Insert(item.(*iface).agentName)
 				for ip := range item.(*iface).ipMap {
 					if v, ok := ipMap[ip.String()]; ok && v == "" {
 						continue

--- a/pkg/controller/endpoint/endpoint_controller_test.go
+++ b/pkg/controller/endpoint/endpoint_controller_test.go
@@ -748,6 +748,12 @@ func testInterfaceIPUpdate(t *testing.T) {
 			t.Errorf("failed to process add agentinfo request")
 		}
 
+		endpointStatusA := getFakeEndpoint(r.Client, fakeEndpointA.Name).Status
+		expectAgents := []string{fakeAgentInfoA.Name, fakeAgentInfoC.Name}
+		if !utils.EqualStringSlice(endpointStatusA.Agents, expectAgents) {
+			t.Errorf("endpoint should update agents from all matched ifaces, get %v, want %v", endpointStatusA.Agents, expectAgents)
+		}
+
 		r.onAgentInfoUpdate(ctx, event.UpdateEvent{
 			ObjectOld: fakeAgentInfoC,
 			ObjectNew: updatedfakeAgentInfoC,


### PR DESCRIPTION
## Purpose

当没有学习到 IP 地址时，也应该更新 endpoint 所属节点。

endpoint 所属节点表示虚拟机网卡所在位置，与 IP 学习结果无关。否则从 Tower 同步过来的 IP 如果无法被学习到，endpoint 就不会有所属节点信息，这是不合理的。

## Changes

- Update endpoint status agent collection so all matched OVS interfaces contribute their agent, even when the interface has no learned IPs.
- Add unit test coverage for matched interfaces with empty `IPMap` still updating endpoint agents.

## Tests

```bash
docker run --rm -iu 0:0 \
  -w /go/src/github.com/everoute/everoute \
  -v /root/workspace/everoute:/go/src/github.com/everoute/everoute \
  -v /lib/modules:/lib/modules \
  --privileged \
  everoute/unit-test \
  go test ./pkg/controller/endpoint -count=1
```
