### PR TITLE
ci: add tower e2e for unmanaged vds endpoints

### DIFF
--- a/tests/e2e/cases/security_test.go
+++ b/tests/e2e/cases/security_test.go
@@ -31,9 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
 	"github.com/everoute/everoute/pkg/constants"
+	policyctrl "github.com/everoute/everoute/pkg/controller/policy"
 	"github.com/everoute/everoute/pkg/labels"
 	"github.com/everoute/everoute/tests/e2e/framework"
 	"github.com/everoute/everoute/tests/e2e/framework/config"
@@ -808,6 +811,78 @@ var _ = Describe("SecurityPolicy", func() {
 		})
 	})
 
+	Context("environment with endpoints from unmanaged vds [Feature:Tower]", func() {
+		var vm1, vm2, vm3 *model.Endpoint
+		var vm1Endpoint, vm2Endpoint, vm3Endpoint securityv1alpha1.Endpoint
+		var clientSelector, peerSelector *labels.Selector
+		var policy *securityv1alpha1.SecurityPolicy
+
+		BeforeEach(func() {
+			if e2eEnv.EndpointManager().Name() != "tower" {
+				Skip("only tower e2e supports vds")
+			}
+			if e2eEnv.EndpointManager().UnmanagedVDSID() == "" {
+				Skip("tower e2e unmanaged vds id isn't configured")
+			}
+
+			clientSelector = newSelector(map[string][]string{"vds-scope": {"client"}})
+			peerSelector = newSelector(map[string][]string{"vds-scope": {"peer"}})
+			vm1 = &model.Endpoint{
+				Name:   "managed-vds-client",
+				VID:    0,
+				Labels: map[string][]string{"vds-scope": {"client"}},
+			}
+			vm2 = &model.Endpoint{
+				Name:   "managed-vds-peer",
+				VID:    0,
+				Labels: map[string][]string{"vds-scope": {"peer"}},
+			}
+			vm3 = &model.Endpoint{
+				Name:   "unmanaged-vds-peer",
+				VID:    0,
+				VDSID:  e2eEnv.EndpointManager().UnmanagedVDSID(),
+				Labels: map[string][]string{"vds-scope": {"peer"}},
+			}
+
+			Expect(e2eEnv.EndpointManager().SetupMany(ctx, vm1, vm2, vm3)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			if policy != nil {
+				Expect(e2eEnv.CleanObjects(ctx, policy)).Should(Succeed())
+			}
+		})
+
+		It("should exclude endpoints outside managed vds from policy groupmembers", func() {
+			vm1Endpoint = waitEndpointByVMID(vm1, false)
+			vm2Endpoint = waitEndpointByVMID(vm2, false)
+			vm3Endpoint = waitEndpointByVMID(vm3, true)
+			Expect(vm1Endpoint.Spec.VDSID).ShouldNot(BeEmpty())
+			Expect(vm2Endpoint.Spec.VDSID).Should(Equal(vm1Endpoint.Spec.VDSID))
+			Expect(vm3Endpoint.Spec.VDSID).Should(Equal(e2eEnv.EndpointManager().UnmanagedVDSID()))
+
+			// The unmanaged-vds-id configured for this case must be reachable from the managed
+			// VDS before policy is installed, so policy behavior can be distinguished from
+			// underlying network isolation.
+			assertReachable([]*model.Endpoint{vm1}, []*model.Endpoint{vm2, vm3}, "ICMP", true)
+
+			policy = newPolicy("tower-unmanaged-vds-egress", constants.Tier2, securityv1alpha1.DefaultRuleDrop, clientSelector)
+			addEngressRule(policy, "ICMP", 0, peerSelector)
+			Expect(e2eEnv.SetupObjects(ctx, policy)).Should(Succeed())
+
+			namespace := e2eEnv.Namespace()
+			appliedPeer := policyctrl.AppliedAsSecurityPeer(namespace, policy.Spec.AppliedTo[0])
+			appliedGroup := policyctrl.PeerAsEndpointGroup(namespace, appliedPeer)
+			egressPeer := securityv1alpha1.SecurityPolicyPeer{EndpointSelector: peerSelector}
+			peerGroup := policyctrl.PeerAsEndpointGroup(namespace, egressPeer)
+			assertGroupMembers(appliedGroup.Name, vm1Endpoint)
+			assertGroupMembers(peerGroup.Name, vm2Endpoint)
+
+			assertReachable([]*model.Endpoint{vm1}, []*model.Endpoint{vm2}, "ICMP", true)
+			assertReachable([]*model.Endpoint{vm1}, []*model.Endpoint{vm3}, "ICMP", false)
+		})
+	})
+
 	Context("environment with endpoints has multiple labels with same key [Feature:ExtendLabels]", func() {
 		var groupA, groupB *labels.Selector
 		var endpointA, endpointB, endpointC *model.Endpoint
@@ -1332,6 +1407,59 @@ func getPolicyPeer(policyPeers ...interface{}) []securityv1alpha1.SecurityPolicy
 	}
 
 	return peerList
+}
+
+func waitEndpointByVMID(endpoint *model.Endpoint, notManaged bool) securityv1alpha1.Endpoint {
+	var matchedEndpoint securityv1alpha1.Endpoint
+	Eventually(func() bool {
+		if endpoint.Status == nil || endpoint.Status.LocalID == "" {
+			return false
+		}
+
+		endpointList := securityv1alpha1.EndpointList{}
+		err := e2eEnv.KubeClient().List(ctx, &endpointList, client.InNamespace(e2eEnv.Namespace()))
+		Expect(err).Should(Succeed())
+		for _, item := range endpointList.Items {
+			if item.Spec.VMID != endpoint.Status.LocalID {
+				continue
+			}
+			matchedEndpoint = item
+			return item.Status.NotManaged == notManaged
+		}
+		return false
+	}, e2eEnv.Timeout(), e2eEnv.Interval()).Should(BeTrue())
+	return matchedEndpoint
+}
+
+func assertGroupMembers(groupName string, endpoints ...securityv1alpha1.Endpoint) {
+	Eventually(func() error {
+		groupMembers := groupv1alpha1.GroupMembers{}
+		err := e2eEnv.KubeClient().Get(ctx, types.NamespacedName{Name: groupName}, &groupMembers)
+		if err != nil {
+			return err
+		}
+		if len(groupMembers.GroupMembers) != len(endpoints) {
+			return fmt.Errorf("unexpected groupmembers %v", groupMembers.GroupMembers)
+		}
+		want := map[string]string{}
+		for _, endpoint := range endpoints {
+			want[endpoint.Spec.Reference.ExternalIDValue] = endpoint.Spec.VDSID
+		}
+		for _, member := range groupMembers.GroupMembers {
+			vdsID, ok := want[member.EndpointReference.ExternalIDValue]
+			if !ok {
+				return fmt.Errorf("unexpected groupmember %v", member)
+			}
+			if member.VDSID != vdsID {
+				return fmt.Errorf("unexpected groupmember vds %s, want %s", member.VDSID, vdsID)
+			}
+			delete(want, member.EndpointReference.ExternalIDValue)
+		}
+		if len(want) != 0 {
+			return fmt.Errorf("missing groupmembers %v", want)
+		}
+		return nil
+	}, e2eEnv.Timeout(), e2eEnv.Interval()).Should(Succeed())
 }
 
 func assertFlowMatches(securityModel *SecurityModel) {

--- a/tests/e2e/framework/config/config.go
+++ b/tests/e2e/framework/config/config.go
@@ -87,6 +87,8 @@ type EndpointConfig struct {
 	VMTemplateID *string `yaml:"vm-template-id,omitempty"`
 	// create vm in the specify vds, only valid when provider is tower
 	VdsID *string `yaml:"vds-id,omitempty"`
+	// create vm outside current Everoute managed vds, only valid when provider is tower
+	UnmanagedVDSID *string `yaml:"unmanaged-vds-id,omitempty"`
 	// prefix for vm name, only valid when provider is tower, default "everoute-e2e-ci-"
 	VMNamePrefix *string `yaml:"vm-name-prefix,omitempty"`
 }

--- a/tests/e2e/framework/endpoint/manager.go
+++ b/tests/e2e/framework/endpoint/manager.go
@@ -54,10 +54,12 @@ const (
 
 type Manager struct {
 	model.EndpointProvider
+	unmanagedVDSID string
 }
 
 func NewManager(pool ipam.Pool, namespace string, kubeClient client.Client, nodeManager *node.Manager, config *config.EndpointConfig) *Manager {
 	var provider model.EndpointProvider
+	var unmanagedVDSID string
 
 	switch {
 	case config.Provider == nil, *config.Provider == "netns":
@@ -70,6 +72,9 @@ func NewManager(pool ipam.Pool, namespace string, kubeClient client.Client, node
 			vmNamePrefix = *config.VMNamePrefix
 		}
 		provider = tower.NewProvider(pool, nodeManager, config.TowerClient, *config.VMTemplateID, *config.VdsID, vmNamePrefix)
+		if config.UnmanagedVDSID != nil {
+			unmanagedVDSID = *config.UnmanagedVDSID
+		}
 
 	case *config.Provider == "pod":
 		provider = pod.NewProvider(config.KubeConfig, kubeClient, nodeManager, namespace)
@@ -77,7 +82,11 @@ func NewManager(pool ipam.Pool, namespace string, kubeClient client.Client, node
 		panic("unknown provider " + *config.Provider)
 	}
 
-	return &Manager{EndpointProvider: provider}
+	return &Manager{EndpointProvider: provider, unmanagedVDSID: unmanagedVDSID}
+}
+
+func (m *Manager) UnmanagedVDSID() string {
+	return m.unmanagedVDSID
 }
 
 func (m *Manager) SetupMany(ctx context.Context, endpoints ...*model.Endpoint) error {

--- a/tests/e2e/framework/endpoint/tower/provider.go
+++ b/tests/e2e/framework/endpoint/tower/provider.go
@@ -142,7 +142,12 @@ func (m *provider) Create(ctx context.Context, endpoint *model.Endpoint) (*model
 		return nil, err
 	}
 
-	vm, err := m.newFromTemplate(endpoint.Name, endpoint.Status.Host, endpoint.VID, description)
+	vdsID := endpoint.VDSID
+	if vdsID == "" {
+		vdsID = m.vdsID
+	}
+
+	vm, err := m.newFromTemplate(endpoint.Name, endpoint.Status.Host, vdsID, endpoint.VID, description)
 	if err != nil {
 		return nil, fmt.Errorf("create %s from template %s: %s", endpoint.Name, m.vmTemplateID, err)
 	}
@@ -278,14 +283,14 @@ func (m *provider) RunCommand(ctx context.Context, name string, cmd string, arg 
 	return execContext(ctx, client, domain, cmd, nil, arg...)
 }
 
-func (m *provider) newFromTemplate(name string, agent string, vlanID int, describe string) (*VM, error) {
+func (m *provider) newFromTemplate(name string, agent string, vdsID string, vlanID int, describe string) (*VM, error) {
 	var err error
 	var vlanUUID string
 
 	if err = m.cacheVMTemplate(); err != nil {
 		return nil, err
 	}
-	if vlanUUID, err = m.mutationQueryVlan(context.TODO(), vlanID); err != nil {
+	if vlanUUID, err = m.mutationQueryVlan(context.TODO(), vdsID, vlanID); err != nil {
 		return nil, err
 	}
 
@@ -397,7 +402,7 @@ func (m *provider) mutationVMLabels(vmID string, labels map[string][]string) err
 }
 
 // mutationQueryVlan find vlan by id. If not found, it will be create.
-func (m *provider) mutationQueryVlan(ctx context.Context, vlanID int) (string, error) {
+func (m *provider) mutationQueryVlan(ctx context.Context, vdsID string, vlanID int) (string, error) {
 	m.mutationVdsLock.Lock()
 	defer m.mutationVdsLock.Unlock()
 
@@ -412,7 +417,7 @@ func (m *provider) mutationQueryVlan(ctx context.Context, vlanID int) (string, e
 				// filter out invalid vlan
 				continue
 			}
-			if vlan.Vds.ID == m.vdsID && vlan.VlanID == vlanID {
+			if vlan.Vds.ID == vdsID && vlan.VlanID == vlanID {
 				vlanUUID = vlan.ID
 				break
 			}
@@ -425,7 +430,7 @@ func (m *provider) mutationQueryVlan(ctx context.Context, vlanID int) (string, e
 		vlan, err := adaptMutationCreateVlan(m.towerClient, &VlanCreateInput{
 			Name:   fmt.Sprintf("vlan%d", vlanID),
 			Type:   NetworkTypeVM,
-			Vds:    &ConnectInput{Connect: &UniqueInput{ID: &m.vdsID}},
+			Vds:    &ConnectInput{Connect: &UniqueInput{ID: &vdsID}},
 			VlanID: vlanID,
 		})
 		if err != nil {

--- a/tests/e2e/framework/model/endpoint.go
+++ b/tests/e2e/framework/model/endpoint.go
@@ -36,6 +36,8 @@ type Endpoint struct {
 	// Virtual network identifier, update VID not supported.
 	// VID must between 0-4095 when network is vlan.
 	VID int
+	// VDSID overrides the default VDS used by the endpoint provider.
+	VDSID string
 	// Expose tcp port. TODO: support tcp-ports
 	TCPPort int
 	// Expose udp port. TODO: support udp-ports


### PR DESCRIPTION
## Summary
- Add tower e2e coverage for endpoints on unmanaged VDS.
- Allow tower e2e endpoints to override the default VDS with `endpoint.unmanaged-vds-id` from `kube-system/everoute-e2e-framework-config`.
- Start tower e2e package build immediately after PR creation by removing its dependency on static/generate checks.

## Test Scenario
- Create three tower VM endpoints with `VID=0`.
- `vm1` and `vm2` use the managed VDS; `vm3` uses `unmanaged-vds-id`.
- Verify baseline ICMP connectivity from `vm1` to both peers before policy creation.
- Create a SecurityPolicy with `vm1` as AppliedTo and egress ICMP allow to the peer selector.
- Verify generated GroupMembers include only managed endpoints, excluding the unmanaged VDS endpoint.
- Verify post-policy connectivity: `vm1 -> vm2` succeeds and `vm1 -> vm3` fails.

## Tests
- `docker run --rm -iu 0:0 -e USER=root -w /workspace -v /root/workspace/everoute:/workspace -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./tests/e2e/framework/... ./tests/e2e/cases/. -run TestE2e -count=0`
