### PR TITLE
fix(er-1748): avoid round number drift on replay

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -589,6 +590,17 @@ func (dp *DpManager) InitializeDatapath(ctx context.Context) {
 		}
 		bridgeSet.Insert(strings.TrimSpace(item))
 	}
+
+	roundInfos, err := getDatapathRoundInfosAsPrevious(lo.Keys(dp.Config.ManagedVDSMap), dp.OvsdbDriverMap)
+	if err != nil {
+		klog.Fatalf("Failed to get datapath current round infos, err = %s", err)
+	}
+	currentRoundDatapathVersion := version.GetVersionInfo().GitVersion
+	for vdsID := range roundInfos {
+		roundInfos[vdsID].currentRoundDatapathVersion = currentRoundDatapathVersion
+	}
+	assignNewRoundInfos(roundInfos)
+
 	var wg sync.WaitGroup
 	for vdsID, ovsbrName := range dp.Config.ManagedVDSMap {
 		wg.Add(1)
@@ -610,7 +622,7 @@ func (dp *DpManager) InitializeDatapath(ctx context.Context) {
 
 		go func(vdsID, ovsbrName string) {
 			defer wg.Done()
-			InitializeVDS(ctx, dp, vdsID, ovsbrName)
+			InitializeVDS(ctx, dp, vdsID, ovsbrName, roundInfos[vdsID])
 		}(vdsID, ovsbrName)
 	}
 	wg.Wait()
@@ -649,6 +661,118 @@ func (dp *DpManager) InitializeDatapath(ctx context.Context) {
 					}
 				}
 			}()
+		}
+	}
+}
+
+func getDatapathRoundInfosAsPrevious(
+	vdses []string,
+	ovsdbDriverMap map[string]map[string]*ovsdbDriver.OvsDriver,
+) (map[string]*RoundInfo, error) {
+	roundInfos := make(map[string]*RoundInfo, len(vdses))
+	for _, vdsID := range vdses {
+		ovsdbDriver := ovsdbDriverMap[vdsID][LOCAL_BRIDGE_KEYWORD]
+		externalIDs, err := ovsdbDriver.GetExternalIds()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to get ovsdb externalids with vdsID %s, error: %v",
+				vdsID, err,
+			)
+		}
+		previousRoundNum := uint64(0)
+		previousRoundDatapathVersion := externalIDs[datapathCurrentDatapathVersion]
+
+		roundNumRaw, ok := externalIDs[datapathCurrentRound]
+		if ok {
+			previousRoundNum, err = strconv.ParseUint(roundNumRaw, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to parse round num %s with vdsID %s, error: %v",
+					roundNumRaw, vdsID, err,
+				)
+			}
+			// do not check previousRoundNum here, it may be invalid.
+			if previousRoundDatapathVersion == "" {
+				previousRoundDatapathVersion = datapathDatapathVersionUnknown
+			}
+		}
+		roundInfos[vdsID] = &RoundInfo{
+			previousRoundNum:             previousRoundNum,
+			previousRoundDatapathVersion: previousRoundDatapathVersion,
+		}
+	}
+	return roundInfos, nil
+}
+
+// Assign new round numbers to roundInfos with previous round numbers.
+func assignNewRoundInfos(roundInfos map[string]*RoundInfo) {
+	type AssignState uint8
+	const (
+		AssignStateClear    AssignState = iota // not assigned
+		AssignStateDirty                       // assigned by previous everoute-agent
+		AssignStateAssigned                    // assigned by current everoute-agent
+	)
+
+	// [1, MaxRoundNum] are assign-able round numbers
+	// assignStates[0] is reserved for invalid index
+	var assignStates [MaxRoundNum + 1]AssignState
+	for i := range assignStates {
+		assignStates[i] = AssignStateClear
+	}
+	// mark dirty round numbers
+	for _, roundInfo := range roundInfos {
+		if roundInfo.previousRoundNum > 0 && roundInfo.previousRoundNum <= MaxRoundNum {
+			assignStates[roundInfo.previousRoundNum] = AssignStateDirty
+		}
+	}
+
+	findNextRoundNumber := func(
+		assignStates [MaxRoundNum + 1]AssignState,
+		n uint64,
+		state AssignState,
+	) uint64 {
+		for i := n + 1; i <= MaxRoundNum; i++ { // [n+1:MaxRoundNum]
+			if assignStates[i] == state {
+				return i
+			}
+		}
+		for i := uint64(1); i < n; i++ { // [1:n-1]
+			if assignStates[i] == state {
+				return i
+			}
+		}
+		return 0 // not found
+	}
+
+	vdses := lo.Keys(roundInfos)
+	sort.Strings(vdses)
+
+	for _, vdsID := range vdses {
+		roundInfo := roundInfos[vdsID]
+		prn := roundInfo.previousRoundNum
+		if prn > MaxRoundNum {
+			prn = 0
+		}
+		if i := findNextRoundNumber(assignStates, prn, AssignStateClear); i != 0 {
+			// find a clear round number
+			assignStates[i] = AssignStateAssigned
+			roundInfo.currentRoundNum = i
+		} else if i := findNextRoundNumber(assignStates, prn, AssignStateDirty); i != 0 {
+			// find a dirty round number
+			assignStates[i] = AssignStateAssigned
+			roundInfo.currentRoundNum = i
+		} else {
+			// use next round number if all other round numbers are assigned
+			crn := prn + 1
+			if crn > MaxRoundNum {
+				crn = 1 // loop back to 1
+			}
+			roundInfo.currentRoundNum = crn
+			// start a new assignment round to reduce round number conflicts.
+			for i := 1; i <= MaxRoundNum; i++ {
+				assignStates[i] = AssignStateDirty
+			}
+			assignStates[crn] = AssignStateAssigned
 		}
 	}
 }
@@ -755,11 +879,12 @@ func (dp *DpManager) GetBridgeIndexesWithFlowID(flowID uint64) []uint32 {
 		return bridgeIndexes
 	}
 
+	roundNumber := dp.FlowIDAlloctorForRule.GetRoundNumberByFlowID(flowID)
 	for vdsID, flow := range rule.RuleFlowMap {
 		if flow.FlowID == flowID {
 			ovsbrname := dp.Config.ManagedVDSMap[vdsID]
 			bridge := dp.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD]
-			if bridge != nil {
+			if bridge != nil && roundNumber == bridge.GetRoundInfo().currentRoundNum {
 				index, err := bridge.GetIndex()
 				if err != nil {
 					klog.Errorf("failed to get index of bridge %s, error: %v", ovsbrname, err)
@@ -1053,12 +1178,10 @@ func policyBrCookieAllocator(roundNum uint64) cookie.Allocator {
 	return cookie.NewAllocator(roundNum, cookie.SetFlowIDRange(cookie.InitFlowID, 1<<CookieAutoAllocBitWidthForPolicyBr-1))
 }
 
-func InitializeVDS(ctx context.Context, datapathManager *DpManager, vdsID string, ovsbrName string) {
+func InitializeVDS(ctx context.Context,
+	datapathManager *DpManager, vdsID string, ovsbrName string, roundInfo *RoundInfo,
+) {
 	log := ctrl.LoggerFrom(ctx)
-	roundInfo, err := getRoundInfo(datapathManager.OvsdbDriverMap[vdsID][LOCAL_BRIDGE_KEYWORD])
-	if err != nil {
-		klog.Fatalf("Failed to get Roundinfo from ovsdb: %v", err)
-	}
 
 	cookieAllocator := cookie.NewAllocator(roundInfo.currentRoundNum, cookie.SetDefaultFlowIDRange())
 	for brKeyword := range datapathManager.BridgeChainMap[vdsID] {
@@ -1104,68 +1227,69 @@ func InitializeVDS(ctx context.Context, datapathManager *DpManager, vdsID string
 		klog.Fatalf("Failed to reset patch port mcast-snooping-flood-reports config for vds %s, err: %v", vdsID, err)
 	}
 
-	// check no-forward configuration
-	go func(vdsID string) {
-		cmdStr := fmt.Sprintf("ovs-ofctl show %s | grep -B 1 NO_FWD | grep addr | awk -F '[()]' '{print $1\" \"$2}'",
-			datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
-		out, err := ExecteCommandWithOutput(cmdStr)
-		if err != nil {
-			klog.Fatalf("fail to list ofport info for vds %s, err = %s", vdsID, err)
-		}
-
-		// key:   ifaceID
-		// value: ofPort
-		vnics := map[string]int{}
-		for _, item := range strings.Split(out, "\n") {
-			item = strings.TrimSpace(item)
-			ofPort, _ := strconv.Atoi(strings.Split(item, " ")[0])
-			if ofPort <= 0 {
-				continue
-			}
-			ifaceName := strings.Split(item, " ")[1]
-
-			out, _ = ExecteCommandWithOutput(
-				fmt.Sprintf("ovs-vsctl --bare get int %s external_ids:iface-id", ifaceName))
-			ifaceID := strings.ReplaceAll(out, "\n", "")
-			ifaceID = strings.ReplaceAll(ifaceID, " ", "")
-			ifaceID = strings.ReplaceAll(ifaceID, "\"", "")
-			if ifaceID != "" {
-				vnics[ifaceID] = ofPort
-			}
-		}
-
-		klog.Infof("find no-forward vnics %+v for bridge %s", vnics,
-			datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
-
-		checkCnt := 1
-		for checkCnt < 60 {
-			klog.Infof("check(#%d) no-forward vnics %+v for bridge %s", checkCnt, vnics,
-				datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
-			if len(vnics) == 0 {
-				return
-			}
-			for ifaceID, ofPort := range vnics {
-				if _, ok := datapathManager.VNicToRules[ifaceID]; ok {
-					klog.Infof("find no-forward for bridge:%s ofPort %d ifaceID:%s",
-						datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID)
-					delete(vnics, ifaceID)
-				}
-			}
-			time.Sleep(time.Second)
-			checkCnt++
-		}
-
-		for ifaceID, ofPort := range vnics {
-			klog.Infof("set forward for bridge:%s ofPort:%d ifaceID:%s",
-				datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID)
-			if err := SetPortForward(datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, true); err != nil {
-				klog.Fatalf("failed to set forward for bridge:%s ofPort:%d ifaceID:%s err:%s",
-					datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID, err)
-			}
-		}
-	}(vdsID)
-
+	go reconcileNoForwardPorts(datapathManager, vdsID)
 	go DeletePreviousRoundFlow(datapathManager, vdsID, roundInfo)
+}
+
+// check no-forward configuration
+func reconcileNoForwardPorts(datapathManager *DpManager, vdsID string) {
+	cmdStr := fmt.Sprintf("ovs-ofctl show %s | grep -B 1 NO_FWD | grep addr | awk -F '[()]' '{print $1\" \"$2}'",
+		datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
+	out, err := ExecteCommandWithOutput(cmdStr)
+	if err != nil {
+		klog.Fatalf("fail to list ofport info for vds %s, err = %s", vdsID, err)
+	}
+
+	// key:   ifaceID
+	// value: ofPort
+	vnics := map[string]int{}
+	for _, item := range strings.Split(out, "\n") {
+		item = strings.TrimSpace(item)
+		ofPort, _ := strconv.Atoi(strings.Split(item, " ")[0])
+		if ofPort <= 0 {
+			continue
+		}
+		ifaceName := strings.Split(item, " ")[1]
+
+		out, _ = ExecteCommandWithOutput(
+			fmt.Sprintf("ovs-vsctl --bare get int %s external_ids:iface-id", ifaceName))
+		ifaceID := strings.ReplaceAll(out, "\n", "")
+		ifaceID = strings.ReplaceAll(ifaceID, " ", "")
+		ifaceID = strings.ReplaceAll(ifaceID, "\"", "")
+		if ifaceID != "" {
+			vnics[ifaceID] = ofPort
+		}
+	}
+
+	klog.Infof("find no-forward vnics %+v for bridge %s", vnics,
+		datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
+
+	checkCnt := 1
+	for checkCnt < 60 {
+		klog.Infof("check(#%d) no-forward vnics %+v for bridge %s", checkCnt, vnics,
+			datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName())
+		if len(vnics) == 0 {
+			return
+		}
+		for ifaceID, ofPort := range vnics {
+			if _, ok := datapathManager.VNicToRules[ifaceID]; ok {
+				klog.Infof("find no-forward for bridge:%s ofPort %d ifaceID:%s",
+					datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID)
+				delete(vnics, ifaceID)
+			}
+		}
+		time.Sleep(time.Second)
+		checkCnt++
+	}
+
+	for ifaceID, ofPort := range vnics {
+		klog.Infof("set forward for bridge:%s ofPort:%d ifaceID:%s",
+			datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID)
+		if err := SetPortForward(datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, true); err != nil {
+			klog.Fatalf("failed to set forward for bridge:%s ofPort:%d ifaceID:%s err:%s",
+				datapathManager.BridgeChainMap[vdsID][LOCAL_BRIDGE_KEYWORD].GetName(), ofPort, ifaceID, err)
+		}
+	}
 }
 
 // Delete flow with previousRoundNum cookie, and then persistent currentRoundNum to ovsdb. We need to wait for long
@@ -1185,9 +1309,15 @@ func DeletePreviousRoundFlow(datapathManager *DpManager, vdsID string, roundInfo
 		roundInfo.currentRoundDatapathVersion,
 	)
 
-	for brKeyword := range datapathManager.BridgeChainMap[vdsID] {
-		datapathManager.BridgeChainMap[vdsID][brKeyword].getOfSwitch().DeleteFlowByRoundInfo(roundInfo.previousRoundNum)
-		datapathManager.BridgeChainMap[vdsID][brKeyword].PostDeletePreviousRoundFlow(roundInfo)
+	if roundInfo.previousRoundNum > 0 && roundInfo.previousRoundNum <= MaxRoundNum {
+		for brKeyword := range datapathManager.BridgeChainMap[vdsID] {
+			b := datapathManager.BridgeChainMap[vdsID][brKeyword]
+			if b == nil { // never happen
+				continue
+			}
+			b.getOfSwitch().DeleteFlowByRoundInfo(roundInfo.previousRoundNum)
+			b.PostDeletePreviousRoundFlow(roundInfo)
+		}
 	}
 
 	err := persistentRoundInfo(*roundInfo, datapathManager.OvsdbDriverMap[vdsID][LOCAL_BRIDGE_KEYWORD])
@@ -1223,10 +1353,7 @@ func (dp *DpManager) replayVDSFlow(ctx context.Context, vdsID, bridgeName, bridg
 	}
 
 	// replay basic connectivity flow
-	roundInfo, err := getRoundInfo(dp.OvsdbDriverMap[vdsID][LOCAL_BRIDGE_KEYWORD])
-	if err != nil {
-		return fmt.Errorf("failed to get Roundinfo from ovsdb: %v", err)
-	}
+	roundInfo := dp.BridgeChainMap[vdsID][POLICY_BRIDGE_KEYWORD].GetRoundInfo()
 
 	var cookieAllocator cookie.Allocator
 	if bridgeKeyword == POLICY_BRIDGE_KEYWORD {
@@ -2156,40 +2283,6 @@ func DeepCopyMap(theMap interface{}) interface{} {
 		dstMap.SetMapIndex(key, srcMap.MapIndex(key))
 	}
 	return dstMap.Interface()
-}
-
-func getRoundInfo(ovsdbDriver *ovsdbDriver.OvsDriver) (*RoundInfo, error) {
-	externalIDs, err := ovsdbDriver.GetExternalIds()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ovsdb externalids: %v", err)
-	}
-
-	previousRoundNum := uint64(0)
-	previousRoundDatapathVersion := externalIDs[datapathCurrentDatapathVersion]
-	currentRoundNum := uint64(1)
-	currentRoundDatapathVersion := version.GetVersionInfo().GitVersion
-
-	roundNumRaw, ok := externalIDs[datapathCurrentRound]
-	if ok {
-		previousRoundNum, err = strconv.ParseUint(roundNumRaw, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid round num %s: %w", roundNumRaw, err)
-		}
-		// Flipping current round num with minimum round num value while it equals with the maximum round num
-		if previousRoundNum < MaxRoundNum {
-			currentRoundNum = previousRoundNum + 1
-		}
-		if previousRoundDatapathVersion == "" {
-			previousRoundDatapathVersion = datapathDatapathVersionUnknown
-		}
-	}
-
-	return &RoundInfo{
-		previousRoundNum:             previousRoundNum,
-		previousRoundDatapathVersion: previousRoundDatapathVersion,
-		currentRoundNum:              currentRoundNum,
-		currentRoundDatapathVersion:  currentRoundDatapathVersion,
-	}, nil
 }
 
 func persistentRoundInfo(roundInfo RoundInfo, ovsdbDriver *ovsdbDriver.OvsDriver) error {

--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -968,7 +968,7 @@ func testFlowReplay(t *testing.T) {
 }
 
 func testRoundNumFlip(t *testing.T) {
-	roundInfo := RoundInfo{
+	roundInfo := &RoundInfo{
 		currentRoundNum:             MaxRoundNum,
 		previousRoundNum:            MaxRoundNum - 1,
 		currentRoundDatapathVersion: "test-version",
@@ -976,16 +976,156 @@ func testRoundNumFlip(t *testing.T) {
 
 	t.Run("persistentRoundInfo into local bridge", func(t *testing.T) {
 		Eventually(func() error {
-			return persistentRoundInfo(roundInfo, datapathManager.OvsdbDriverMap["ovsbr0"][LOCAL_BRIDGE_KEYWORD])
+			return persistentRoundInfo(*roundInfo, datapathManager.OvsdbDriverMap["ovsbr0"][LOCAL_BRIDGE_KEYWORD])
 		}, timeout, interval).Should(Succeed())
 	})
 
-	t.Run("validate ER agent Round num flip", func(t *testing.T) {
+	t.Run("validate datapath current round infos and assign round infos", func(t *testing.T) {
 		Eventually(func() bool {
-			round, _ := getRoundInfo(datapathManager.OvsdbDriverMap["ovsbr0"][LOCAL_BRIDGE_KEYWORD])
-			return round.currentRoundNum == 1 &&
-				round.previousRoundDatapathVersion == roundInfo.currentRoundDatapathVersion
+			roundInfos, err := getDatapathRoundInfosAsPrevious(
+				[]string{"ovsbr0"},
+				datapathManager.OvsdbDriverMap,
+			)
+			if err != nil {
+				return false
+			}
+			round, ok := roundInfos["ovsbr0"]
+			if !ok {
+				return false
+			}
+			assignNewRoundInfos(roundInfos)
+			return round.previousRoundNum == MaxRoundNum &&
+				round.previousRoundDatapathVersion == roundInfo.currentRoundDatapathVersion &&
+				roundInfos["ovsbr0"].currentRoundNum == 1
 		}, timeout, interval).Should(BeTrue())
+	})
+}
+
+func TestAssignRoundInfos(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("assign clear rounds with stable order", func(t *testing.T) {
+		roundInfos := map[string]*RoundInfo{
+			"vds-b": {previousRoundNum: 2},
+			"vds-a": {previousRoundNum: 1},
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		Expect(roundInfos["vds-a"].currentRoundNum).Should(Equal(uint64(3)))
+		Expect(roundInfos["vds-b"].currentRoundNum).Should(Equal(uint64(4)))
+	})
+
+	t.Run("wrap from max round to one", func(t *testing.T) {
+		roundInfos := map[string]*RoundInfo{
+			"vds-a": {previousRoundNum: MaxRoundNum},
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		Expect(roundInfos["vds-a"].currentRoundNum).Should(Equal(uint64(1)))
+	})
+
+	t.Run("ignore invalid previous round when assigning", func(t *testing.T) {
+		roundInfos := map[string]*RoundInfo{
+			"vds-a": {previousRoundNum: MaxRoundNum + 3},
+			"vds-b": {previousRoundNum: 0},
+			"vds-c": {previousRoundNum: MaxRoundNum + 1},
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		Expect(roundInfos["vds-a"].currentRoundNum).Should(Equal(uint64(1)))
+		Expect(roundInfos["vds-b"].currentRoundNum).Should(Equal(uint64(2)))
+		Expect(roundInfos["vds-c"].currentRoundNum).Should(Equal(uint64(3)))
+	})
+
+	t.Run("assign unique round numbers when vds count equals max round num", func(t *testing.T) {
+		roundInfos := make(map[string]*RoundInfo, MaxRoundNum)
+		for i := 1; i <= MaxRoundNum; i++ {
+			vdsID := fmt.Sprintf("vds-%02d", i)
+			roundInfos[vdsID] = &RoundInfo{previousRoundNum: uint64(i)}
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		assignedRounds := sets.New[uint64]()
+		for vdsID, roundInfo := range roundInfos {
+			crn := roundInfo.currentRoundNum
+			prn := roundInfo.previousRoundNum
+			Expect(crn).Should(BeNumerically(">=", 1), "vds %s", vdsID)
+			Expect(crn).Should(BeNumerically("<=", MaxRoundNum), "vds %s", vdsID)
+			Expect(crn).ShouldNot(Equal(prn), "vds %s should not reuse previous round num", vdsID)
+			Expect(assignedRounds.Has(crn)).Should(BeFalse(), "round num %d duplicated for vds %s", crn, vdsID)
+			assignedRounds.Insert(crn)
+		}
+		Expect(assignedRounds.Len()).Should(Equal(MaxRoundNum))
+	})
+
+	t.Run("loop back to one when all round numbers are assigned", func(t *testing.T) {
+		roundInfos := make(map[string]*RoundInfo, MaxRoundNum+1)
+		for i := 1; i <= MaxRoundNum+1; i++ {
+			vdsID := fmt.Sprintf("vds-%02d", i)
+			roundInfos[vdsID] = &RoundInfo{previousRoundNum: MaxRoundNum}
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		assignedRounds := sets.New[uint64]()
+		for i := 1; i <= MaxRoundNum+1; i++ {
+			vdsID := fmt.Sprintf("vds-%02d", i)
+			crn := roundInfos[vdsID].currentRoundNum
+			prn := roundInfos[vdsID].previousRoundNum
+			Expect(crn).Should(BeNumerically(">=", 1), "vds %s", vdsID)
+			Expect(crn).Should(BeNumerically("<=", MaxRoundNum), "vds %s", vdsID)
+			Expect(crn).ShouldNot(Equal(prn), "vds %s should not reuse previous round num", vdsID)
+			assignedRounds.Insert(crn)
+		}
+		Expect(assignedRounds.Len()).Should(Equal(MaxRoundNum - 1))
+		Expect(roundInfos[fmt.Sprintf("vds-%02d", MaxRoundNum)].currentRoundNum).Should(Equal(uint64(1)))
+		Expect(roundInfos[fmt.Sprintf("vds-%02d", MaxRoundNum+1)].currentRoundNum).Should(Equal(uint64(2)))
+	})
+
+	t.Run("start next assignment round after all usable rounds are exhausted", func(t *testing.T) {
+		roundInfos := make(map[string]*RoundInfo, MaxRoundNum+2)
+		for i := 1; i <= MaxRoundNum+2; i++ {
+			vdsID := fmt.Sprintf("vds-%02d", i)
+			roundInfos[vdsID] = &RoundInfo{previousRoundNum: MaxRoundNum}
+		}
+
+		assignNewRoundInfos(roundInfos)
+
+		Expect(roundInfos[fmt.Sprintf("vds-%02d", MaxRoundNum)].currentRoundNum).Should(Equal(uint64(1)))
+		Expect(roundInfos[fmt.Sprintf("vds-%02d", MaxRoundNum+1)].currentRoundNum).Should(Equal(uint64(2)))
+		Expect(roundInfos[fmt.Sprintf("vds-%02d", MaxRoundNum+2)].currentRoundNum).Should(Equal(uint64(3)))
+	})
+}
+
+func TestGetDatapathCurrentRoundInfos(t *testing.T) {
+	RegisterTestingT(t)
+
+	t.Run("return unknown previous datapath version when round exists without version", func(t *testing.T) {
+		driver := datapathManager.OvsdbDriverMap["ovsbr0"][LOCAL_BRIDGE_KEYWORD]
+		externalIDs, err := driver.GetExternalIds()
+		Expect(err).ShouldNot(HaveOccurred())
+		originExternalIDs := make(map[string]string, len(externalIDs))
+		for k, v := range externalIDs {
+			originExternalIDs[k] = v
+		}
+		defer func() {
+			Expect(driver.SetExternalIds(originExternalIDs)).Should(Succeed())
+		}()
+		externalIDs[datapathCurrentRound] = "7"
+		delete(externalIDs, datapathCurrentDatapathVersion)
+		Expect(driver.SetExternalIds(externalIDs)).Should(Succeed())
+
+		roundInfos, err := getDatapathRoundInfosAsPrevious(
+			[]string{"ovsbr0"},
+			datapathManager.OvsdbDriverMap,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(roundInfos["ovsbr0"].previousRoundNum).Should(Equal(uint64(7)))
+		Expect(roundInfos["ovsbr0"].previousRoundDatapathVersion).Should(Equal(datapathDatapathVersionUnknown))
 	})
 }
 

--- a/pkg/agent/datapath/uplinkBridgeOverlay_test.go
+++ b/pkg/agent/datapath/uplinkBridgeOverlay_test.go
@@ -112,10 +112,20 @@ func setupUplinkBridge() error {
 		datapathManager.WaitForBridgeConnected()
 	}
 
-	roundInfo, err := getRoundInfo(driver)
+	roundInfos, err := getDatapathRoundInfosAsPrevious(
+		[]string{"testuplink"},
+		map[string]map[string]*ovsdbDriver.OvsDriver{
+			"testuplink": {
+				LOCAL_BRIDGE_KEYWORD: driver,
+			},
+		},
+	)
 	if err != nil {
 		return err
 	}
+	assignNewRoundInfos(roundInfos)
+	roundInfo := roundInfos["testuplink"]
+	br.SetRoundInfo(roundInfo)
 	cookieAllocator := cookie.NewAllocator(roundInfo.currentRoundNum)
 	br.getOfSwitch().CookieAllocator = cookieAllocator
 	return nil


### PR DESCRIPTION
http://jira.smartx.com/browse/ER-1748

在每次启动时，先收集所有的 VDS 的 round number，然后统一分配新的 round number，以尽可能地避免 round number 出现冲突。

1. 为每个 VDS 优先分配一个当前和曾经（指 everoute-agent 重启之前）都没有分配的 round number。
2. 如果所有 round number 都已经分配或曾经分配过，那么避开当前已经分配的 round number。
3. 如果所有 round number 都已经分配，即超过了 15 个 VDS，重新启动下一轮的分配。

在 RPC 接口 GetBridgeIndexesWithFlowID 中，额外校验 round number 是否正确。

将函数 `InitializeVDS` 内的 `go func(vdsId)` 移出函数 `InitializeVDS`，因为太长了。

自测，所有的 vds 的 round number 自动避开。

<img width="683" height="214" alt="image" src="https://github.com/user-attachments/assets/3627c914-9b78-44d9-b353-cb99b54eefb5" />
<img width="693" height="216" alt="image" src="https://github.com/user-attachments/assets/5a0a0559-8181-4cb0-a613-7fcaee5bd6e6" />

conntrack 中记录了不同的 round number

<img width="1029" height="62" alt="image" src="https://github.com/user-attachments/assets/19732a37-0d52-42cd-9a13-72eb177cf8e8" />
