### PR TITLE
feat: reorganize erctl runtime commands

### DIFF
--- a/pkg/erctl/cmd/memory.go
+++ b/pkg/erctl/cmd/memory.go
@@ -9,8 +9,13 @@ import (
 	"github.com/everoute/everoute/pkg/erctl"
 )
 
+var gomemlimitCmd = &cobra.Command{
+	Use:   "gomemlimit",
+	Short: "Manage Go runtime memory limit on agent",
+}
+
 var getGOMemLimitCmd = &cobra.Command{
-	Use:   "get-gomemlimit",
+	Use:   "get",
 	Short: "Get current Go runtime memory limit from agent",
 	Args:  cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
@@ -27,7 +32,7 @@ var getGOMemLimitCmd = &cobra.Command{
 }
 
 var setGOMemLimitCmd = &cobra.Command{
-	Use:   "set-gomemlimit [limit]",
+	Use:   "set [limit]",
 	Short: "Set Go runtime memory limit on agent (must be > 0)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
@@ -51,6 +56,7 @@ var setGOMemLimitCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(getGOMemLimitCmd)
-	rootCmd.AddCommand(setGOMemLimitCmd)
+	gomemlimitCmd.AddCommand(getGOMemLimitCmd)
+	gomemlimitCmd.AddCommand(setGOMemLimitCmd)
+	rootCmd.AddCommand(gomemlimitCmd)
 }

--- a/pkg/erctl/cmd/pprof.go
+++ b/pkg/erctl/cmd/pprof.go
@@ -8,28 +8,17 @@ import (
 	"github.com/everoute/everoute/pkg/erctl"
 )
 
-var setPprofCmd = &cobra.Command{
-	Use:   "set-pprof [enable|disable]",
-	Short: "Enable or disable agent pprof HTTP handlers",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		if err := erctl.ConnectClient(); err != nil {
-			return err
-		}
+var pprofCmd = &cobra.Command{
+	Use:   "pprof",
+	Short: "Manage agent pprof HTTP handlers",
+}
 
-		var (
-			enabled bool
-			url     string
-			err     error
-		)
-		switch args[0] {
-		case "enable":
-			enabled, url, err = erctl.EnablePprof()
-		case "disable":
-			enabled, url, err = erctl.DisablePprof()
-		default:
-			return fmt.Errorf("pprof state must be enable or disable")
-		}
+var enablePprofCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable agent pprof HTTP handlers",
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		enabled, url, err := setPprofEnabled(true)
 		if err != nil {
 			return err
 		}
@@ -38,8 +27,22 @@ var setPprofCmd = &cobra.Command{
 	},
 }
 
-var getPprofCmd = &cobra.Command{
-	Use:   "get-pprof",
+var disablePprofCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable agent pprof HTTP handlers",
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		enabled, url, err := setPprofEnabled(false)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("pprof enabled: %t, url: %s\n", enabled, url)
+		return nil
+	},
+}
+
+var pprofStatusCmd = &cobra.Command{
+	Use:   "status",
 	Short: "Get agent pprof HTTP handler status",
 	Args:  cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
@@ -55,7 +58,19 @@ var getPprofCmd = &cobra.Command{
 	},
 }
 
+func setPprofEnabled(enabled bool) (bool, string, error) {
+	if err := erctl.ConnectClient(); err != nil {
+		return false, "", err
+	}
+	if enabled {
+		return erctl.EnablePprof()
+	}
+	return erctl.DisablePprof()
+}
+
 func init() {
-	rootCmd.AddCommand(setPprofCmd)
-	rootCmd.AddCommand(getPprofCmd)
+	pprofCmd.AddCommand(enablePprofCmd)
+	pprofCmd.AddCommand(disablePprofCmd)
+	pprofCmd.AddCommand(pprofStatusCmd)
+	rootCmd.AddCommand(pprofCmd)
 }


### PR DESCRIPTION
## Purpose

Reorganize the erctl runtime tuning/debug commands so the resource comes before the action.

## Changes

- Replace root-level `get-gomemlimit` / `set-gomemlimit` with `gomemlimit get` / `gomemlimit set`.
- Replace root-level `get-pprof` / `set-pprof enable|disable` with `pprof status` / `pprof enable` / `pprof disable`.
- Do not keep compatibility aliases for the old command names.

## Tests

- `make erctl`
- `make docker-generate` (no generated diff)
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute-erctl-runtime-cmds:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/erctl/cmd -count=1`
- `make image-debug` pushed `registry.smtx.io/everoute/debug:ed6cd66`
- Verified packaged erctl in `registry.smtx.io/everoute/debug:ed6cd66` exposes `pprof enable|disable|status` and `gomemlimit get|set`.
- On `172.21.152.103`, ran `/tmp/erctl-ed6cd66` against the live agent and verified:
  - `pprof --help` and `gomemlimit --help` expose the new subcommands.
  - old `get-pprof` returns unknown command.
  - `gomemlimit get` and `gomemlimit set <current>` work.
  - `pprof status`, `pprof enable`, `pprof status`, `pprof disable`, `pprof status` work; final state restored to disabled.

## Notes

A full replacement of the `everoute-agent` container on `172.21.152.103` with the debug image was attempted and then rolled back. The test host's plugin template passes `--policy-static-memory-limit-bytes`, which is not supported by the current `origin/main` agent binary, so the image cannot be used as a drop-in replacement on that host. The plugin template was restored and `eradm update --allow-pull` completed successfully afterward.
