### PR TITLE
feat: add policy guard alert metrics

### DIFF
--- a/cmd/everoute-controller/main.go
+++ b/cmd/everoute-controller/main.go
@@ -132,6 +132,9 @@ func main() {
 
 	controllerMetric := metrics.NewControllerMetric()
 	controllerMetric.Init()
+	if err = mgr.Add(controllerMetric.GetControllerActive()); err != nil {
+		klog.Fatalf("unable to add controller active metric: %s", err.Error())
+	}
 
 	if !disableAutoTLS {
 		// set secret and webhook
@@ -166,8 +169,9 @@ func main() {
 
 	// group controller sync & manager group members.
 	if err = (&groupctrl.Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		EndpointGroupMetric: controllerMetric.GetEndpointGroupInfo(),
 	}).SetupWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create group controller: %s", err.Error())
 	}
@@ -234,6 +238,7 @@ func main() {
 	}
 
 	// register tower plugin
+	towerPluginOptions.EndpointGroupSecurityGroupMetric = controllerMetric.GetEndpointGroupSecurityGroup()
 	err = towerplugin.AddToManager(&towerPluginOptions, mgr)
 	if err != nil {
 		klog.Fatalf("unable register tower plugin: %s", err.Error())

--- a/pkg/agent/controller/policy/policy_controller.go
+++ b/pkg/agent/controller/policy/policy_controller.go
@@ -395,6 +395,7 @@ func (r *Reconciler) admitPolicyUpdate(ctx context.Context, policy *securityv1al
 	}
 
 	req := newAdmissionRequest(policyGuardResourcePolicy, policy.Namespace, policy.Name, operation)
+	req.TowerID = policyTowerID(policy)
 	if isPureCompleteRuleDelete(oldCompleteRules, newCompleteRules) {
 		r.resetGuard(req)
 		return admissionResult{Allowed: true}
@@ -457,6 +458,18 @@ func (r *Reconciler) admitGroupUpdate(ctx context.Context, gm *groupv1alpha1.Gro
 
 	req.Estimate = newEstimate
 	return r.ruleEstimateGuard.admit(ctx, req)
+}
+
+func policyTowerID(policy *securityv1alpha1.SecurityPolicy) string {
+	if policy == nil {
+		return ""
+	}
+	if policy.Spec.Logging != nil {
+		if towerID := policy.Spec.Logging.Tags[msconst.LoggingTagPolicyID]; towerID != "" {
+			return towerID
+		}
+	}
+	return fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)
 }
 
 func (r *Reconciler) cleanPolicyDependents(ctx context.Context, policy k8stypes.NamespacedName) error {

--- a/pkg/agent/controller/policy/policy_guard.go
+++ b/pkg/agent/controller/policy/policy_guard.go
@@ -84,6 +84,7 @@ type admissionRequest struct {
 	Resource  string
 	Namespace string
 	Name      string
+	TowerID   string
 	Operation string
 	Estimate  uint64
 }
@@ -386,8 +387,9 @@ func (g *RuleEstimateGuard) admit(ctx context.Context, req admissionRequest) adm
 		key := req.key(policyGuardReasonRuleEstimateExceeded)
 		g.rejectedByRuleLock.Lock()
 		g.rejectedByRule[key] = struct{}{}
-		g.metric.SetPolicyRuleEstimateRejectedObject(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, true)
-		g.metric.SetPolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, req.Estimate)
+		if g.metric != nil {
+			g.metric.SetPolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, req.TowerID, key.Operation, key.Reason, req.Estimate)
+		}
 		g.rejectedByRuleLock.Unlock()
 		log.Info("Reject policy reconcile by rule estimate", "resource", req.Resource, "namespace", req.Namespace,
 			"name", req.Name, "operation", req.Operation, "estimate", req.Estimate, "limit", ruleEstimateLimit)
@@ -442,9 +444,9 @@ func (g *RuleEstimateGuard) resetRejectedObject(req admissionRequest) {
 	defer g.rejectedByRuleLock.Unlock()
 	for key := range g.rejectedByRule {
 		if req.sameObject(key) {
-			// TODO: Consider deleting recovered object label values instead of setting them to 0.
-			g.metric.SetPolicyRuleEstimateRejectedObject(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, false)
-			g.metric.SetPolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, 0)
+			if g.metric != nil {
+				g.metric.DeletePolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason)
+			}
 			delete(g.rejectedByRule, key)
 		}
 	}
@@ -457,8 +459,9 @@ func (g *RuleEstimateGuard) resetAllRejectedObjects() {
 	g.rejectedByRuleLock.Lock()
 	defer g.rejectedByRuleLock.Unlock()
 	for key := range g.rejectedByRule {
-		g.metric.SetPolicyRuleEstimateRejectedObject(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, false)
-		g.metric.SetPolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason, 0)
+		if g.metric != nil {
+			g.metric.DeletePolicyRuleEstimateRejectedValue(key.Resource, key.Namespace, key.Name, key.Operation, key.Reason)
+		}
 		delete(g.rejectedByRule, key)
 	}
 }

--- a/pkg/agent/controller/policy/policy_guard_test.go
+++ b/pkg/agent/controller/policy/policy_guard_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	msconst "github.com/everoute/everoute/pkg/constants/ms"
 	"github.com/everoute/everoute/pkg/metrics"
 )
 
@@ -213,5 +216,27 @@ func TestNormalizeGuardType(t *testing.T) {
 
 	if _, err := normalizeGuardType("invalid"); err == nil {
 		t.Fatalf("expected invalid guard type to return error")
+	}
+}
+
+func TestPolicyTowerID(t *testing.T) {
+	policy := &securityv1alpha1.SecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "tower-space",
+			Name:      "policy-a",
+		},
+	}
+
+	if got := policyTowerID(policy); got != "tower-space/policy-a" {
+		t.Fatalf("expected ns/name tower id fallback, got %q", got)
+	}
+
+	policy.Spec.Logging = &securityv1alpha1.Logging{
+		Tags: map[string]string{
+			msconst.LoggingTagPolicyID: "tower-policy-id",
+		},
+	}
+	if got := policyTowerID(policy); got != "tower-policy-id" {
+		t.Fatalf("expected tower id from logging tags, got %q", got)
 	}
 }

--- a/pkg/controller/group/endpointgroup_metric.go
+++ b/pkg/controller/group/endpointgroup_metric.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2021 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	msconst "github.com/everoute/everoute/pkg/constants/ms"
+	"github.com/everoute/everoute/pkg/labels"
+	"github.com/everoute/everoute/pkg/metrics"
+)
+
+func (r *Reconciler) recordEndpointGroupInfo(ctx context.Context, group *groupv1alpha1.EndpointGroup) {
+	if r == nil || r.EndpointGroupMetric == nil || group == nil {
+		return
+	}
+	targetType := endpointGroupTargetType(&group.Spec)
+	r.EndpointGroupMetric.Set(group.Name, targetType, r.endpointGroupTargetDisplay(ctx, &group.Spec, targetType))
+}
+
+func endpointGroupTargetType(spec *groupv1alpha1.EndpointGroupSpec) string {
+	if spec == nil {
+		return metrics.EndpointGroupTargetTypeUnknown
+	}
+	if selectorHasPodClusterLabels(spec.EndpointSelector) {
+		return metrics.EndpointGroupTargetTypePod
+	}
+	if spec.Endpoint != nil {
+		return metrics.EndpointGroupTargetTypeVNIC
+	}
+	if spec.EndpointSelector != nil {
+		return metrics.EndpointGroupTargetTypeVMLabel
+	}
+	return metrics.EndpointGroupTargetTypeUnknown
+}
+
+func selectorHasPodClusterLabels(selector *labels.Selector) bool {
+	if selector == nil {
+		return false
+	}
+	_, hasKSCName := selector.LabelSelector.MatchLabels[msconst.SKSLabelKeyClusterName]
+	_, hasKSCNamespace := selector.LabelSelector.MatchLabels[msconst.SKSLabelKeyClusterNamespace]
+	return hasKSCName && hasKSCNamespace
+}
+
+func (r *Reconciler) endpointGroupTargetDisplay(ctx context.Context, spec *groupv1alpha1.EndpointGroupSpec, targetType string) string {
+	if spec == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 3)
+	switch targetType {
+	case metrics.EndpointGroupTargetTypeVNIC:
+		return r.vnicTargetDisplay(ctx, spec.Endpoint)
+	case metrics.EndpointGroupTargetTypeVMLabel:
+		return selectorDisplay(spec.EndpointSelector)
+	case metrics.EndpointGroupTargetTypePod:
+		parts = append(parts, "selector="+selectorDisplay(spec.EndpointSelector))
+	default:
+		parts = append(parts, "unknown")
+	}
+
+	if spec.Namespace != nil && *spec.Namespace != "" {
+		parts = append(parts, "spec.namespace="+*spec.Namespace)
+	}
+	if spec.NamespaceSelector != nil {
+		parts = append(parts, "namespaceSelector="+labelSelectorDisplay(spec.NamespaceSelector))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (r *Reconciler) vnicTargetDisplay(ctx context.Context, endpointRef *securityv1alpha1.NamespacedName) string {
+	if endpointRef == nil {
+		return ""
+	}
+	if r != nil && r.Client != nil {
+		endpoint := securityv1alpha1.Endpoint{}
+		err := r.Get(ctx, k8stypes.NamespacedName{Name: endpointRef.Name, Namespace: endpointRef.Namespace}, &endpoint)
+		if err != nil && !apierrors.IsNotFound(err) {
+			klog.Errorf("failed to get endpoint %s/%s for endpointgroup metric: %s", endpointRef.Namespace, endpointRef.Name, err)
+		}
+		if err == nil && endpoint.Spec.VMID != "" {
+			return endpoint.Spec.VMID
+		}
+	}
+	return endpointRef.Namespace + "/" + endpointRef.Name
+}
+
+func selectorDisplay(selector *labels.Selector) string {
+	if selector == nil {
+		return "<nil>"
+	}
+	if selector.MatchNothing {
+		return "matchNothing=true"
+	}
+
+	parts := labelSelectorParts(&selector.LabelSelector)
+	extendKeys := make([]string, 0, len(selector.ExtendMatchLabels))
+	for key := range selector.ExtendMatchLabels {
+		extendKeys = append(extendKeys, key)
+	}
+	sort.Strings(extendKeys)
+	for _, key := range extendKeys {
+		values := append([]string{}, selector.ExtendMatchLabels[key]...)
+		sort.Strings(values)
+		parts = append(parts, fmt.Sprintf("%s in (%s)", key, strings.Join(values, ",")))
+	}
+	if len(parts) == 0 {
+		return "<all>"
+	}
+	return strings.Join(parts, ",")
+}
+
+func labelSelectorDisplay(selector *metav1.LabelSelector) string {
+	if selector == nil {
+		return "<nil>"
+	}
+	parts := labelSelectorParts(selector)
+	if len(parts) == 0 {
+		return "<all>"
+	}
+	return strings.Join(parts, ",")
+}
+
+func labelSelectorParts(selector *metav1.LabelSelector) []string {
+	parts := make([]string, 0, len(selector.MatchLabels)+len(selector.MatchExpressions))
+	keys := make([]string, 0, len(selector.MatchLabels))
+	for key := range selector.MatchLabels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, selector.MatchLabels[key]))
+	}
+
+	expressions := append([]metav1.LabelSelectorRequirement{}, selector.MatchExpressions...)
+	sort.Slice(expressions, func(i, j int) bool {
+		if expressions[i].Key != expressions[j].Key {
+			return expressions[i].Key < expressions[j].Key
+		}
+		return string(expressions[i].Operator) < string(expressions[j].Operator)
+	})
+	for _, expr := range expressions {
+		values := append([]string{}, expr.Values...)
+		sort.Strings(values)
+		if len(values) == 0 {
+			parts = append(parts, fmt.Sprintf("%s %s", expr.Key, expr.Operator))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s %s (%s)", expr.Key, expr.Operator, strings.Join(values, ",")))
+	}
+	return parts
+}

--- a/pkg/controller/group/endpointgroup_metric_test.go
+++ b/pkg/controller/group/endpointgroup_metric_test.go
@@ -1,0 +1,128 @@
+package group
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
+	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	msconst "github.com/everoute/everoute/pkg/constants/ms"
+	"github.com/everoute/everoute/pkg/labels"
+	"github.com/everoute/everoute/pkg/metrics"
+)
+
+func TestEndpointGroupTargetType(t *testing.T) {
+	tests := []struct {
+		name string
+		spec groupv1alpha1.EndpointGroupSpec
+		want string
+	}{
+		{
+			name: "pod selector",
+			spec: groupv1alpha1.EndpointGroupSpec{
+				EndpointSelector: &labels.Selector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+					msconst.SKSLabelKeyClusterName:      "cluster-a",
+					msconst.SKSLabelKeyClusterNamespace: "default",
+				}}},
+			},
+			want: metrics.EndpointGroupTargetTypePod,
+		},
+		{
+			name: "vnic endpoint",
+			spec: groupv1alpha1.EndpointGroupSpec{
+				Endpoint: &securityv1alpha1.NamespacedName{Namespace: "tower-space", Name: "vnic-a"},
+			},
+			want: metrics.EndpointGroupTargetTypeVNIC,
+		},
+		{
+			name: "vm label selector",
+			spec: groupv1alpha1.EndpointGroupSpec{
+				EndpointSelector: &labels.Selector{LabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}}},
+			},
+			want: metrics.EndpointGroupTargetTypeVMLabel,
+		},
+		{
+			name: "unknown",
+			spec: groupv1alpha1.EndpointGroupSpec{},
+			want: metrics.EndpointGroupTargetTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := endpointGroupTargetType(&tt.spec); got != tt.want {
+				t.Fatalf("expected target type %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestEndpointGroupTargetDisplayStable(t *testing.T) {
+	spec := &groupv1alpha1.EndpointGroupSpec{
+		EndpointSelector: &labels.Selector{
+			LabelSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"z": "1",
+					"a": "2",
+				},
+			},
+			ExtendMatchLabels: map[string][]string{
+				"extend": {"b", "a"},
+			},
+		},
+	}
+
+	want := "a=2,z=1,extend in (a,b)"
+	if got := (&Reconciler{}).endpointGroupTargetDisplay(context.Background(), spec, metrics.EndpointGroupTargetTypeVMLabel); got != want {
+		t.Fatalf("expected display %q, got %q", want, got)
+	}
+}
+
+func TestEndpointGroupVNICTargetDisplay(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := securityv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add security scheme: %s", err)
+	}
+
+	reconciler := &Reconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(&securityv1alpha1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "tower-space",
+			Name:      "endpoint-a",
+		},
+		Spec: securityv1alpha1.EndpointSpec{
+			VMID: "vm-a",
+		},
+	}).Build()}
+
+	spec := &groupv1alpha1.EndpointGroupSpec{Endpoint: &securityv1alpha1.NamespacedName{
+		Namespace: "tower-space",
+		Name:      "endpoint-a",
+	}}
+
+	if got := reconciler.endpointGroupTargetDisplay(context.Background(), spec, metrics.EndpointGroupTargetTypeVNIC); got != "vm-a" {
+		t.Fatalf("expected vm id display %q, got %q", "vm-a", got)
+	}
+
+	spec.Endpoint = &securityv1alpha1.NamespacedName{Namespace: "tower-space", Name: "endpoint-missing"}
+	if got := reconciler.endpointGroupTargetDisplay(context.Background(), spec, metrics.EndpointGroupTargetTypeVNIC); got != "tower-space/endpoint-missing" {
+		t.Fatalf("expected endpoint ref fallback %q, got %q", "tower-space/endpoint-missing", got)
+	}
+
+	spec.Endpoint = &securityv1alpha1.NamespacedName{Namespace: "tower-space", Name: "endpoint-a"}
+	endpoint := securityv1alpha1.Endpoint{}
+	if err := reconciler.Get(context.Background(), k8stypes.NamespacedName{Namespace: "tower-space", Name: "endpoint-a"}, &endpoint); err != nil {
+		t.Fatalf("get endpoint: %s", err)
+	}
+	endpoint.Spec.VMID = ""
+	if err := reconciler.Update(context.Background(), &endpoint); err != nil {
+		t.Fatalf("update endpoint: %s", err)
+	}
+	if got := reconciler.endpointGroupTargetDisplay(context.Background(), spec, metrics.EndpointGroupTargetTypeVNIC); got != "tower-space/endpoint-a" {
+		t.Fatalf("expected endpoint ref fallback %q, got %q", "tower-space/endpoint-a", got)
+	}
+}

--- a/pkg/controller/group/group_controller.go
+++ b/pkg/controller/group/group_controller.go
@@ -42,6 +42,7 @@ import (
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
 	"github.com/everoute/everoute/pkg/constants"
 	"github.com/everoute/everoute/pkg/labels"
+	"github.com/everoute/everoute/pkg/metrics"
 	"github.com/everoute/everoute/pkg/utils"
 )
 
@@ -49,7 +50,8 @@ import (
 // or delete groupmembers and groupmemberspatches according to group members changes.
 type Reconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme              *runtime.Scheme
+	EndpointGroupMetric *metrics.EndpointGroupInfoMetric
 }
 
 // Reconcile receive endpointgroup from work queue, first it create groupmemberspatch,
@@ -63,8 +65,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
 		// on deleted requests.
+		if apierrors.IsNotFound(err) {
+			r.EndpointGroupMetric.Delete(req.Name)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	r.recordEndpointGroupInfo(ctx, &group)
 
 	if r.isNewEndpointGroup(&group) {
 		klog.Infof("process endpointgroup %s create request", group.Name)
@@ -445,6 +452,7 @@ func (r *Reconciler) processEndpointGroupCreate(ctx context.Context, group *grou
 
 func (r *Reconciler) processEndpointGroupDelete(ctx context.Context, group *groupv1alpha1.EndpointGroup) (ctrl.Result, error) {
 	klog.V(2).Infof("clean group dependents for deleting endpointgroup %s", group.Name)
+	r.EndpointGroupMetric.Delete(group.Name)
 
 	// clean all group dependents groupmembers & groupmemberslist
 	err := r.DeleteAllOf(ctx, &groupv1alpha1.GroupMembersPatch{}, client.MatchingLabels{constants.OwnerGroupLabelKey: group.Name})

--- a/pkg/metrics/agent_metrics.go
+++ b/pkg/metrics/agent_metrics.go
@@ -58,9 +58,8 @@ type AgentMetric struct {
 	policyMemoryUsageBytes             prometheus.GaugeVec
 	policyMemoryThresholdBytes         prometheus.GaugeVec
 
-	policyRuleEstimateLimit           prometheus.GaugeVec
-	policyRuleEstimateRejectedObjects prometheus.GaugeVec
-	policyRuleEstimateRejectedValue   prometheus.GaugeVec
+	policyRuleEstimateLimit         prometheus.GaugeVec
+	policyRuleEstimateRejectedValue prometheus.GaugeVec
 }
 
 func newAgentCounterOpt(name, help string) prometheus.CounterOpts {
@@ -131,6 +130,7 @@ func NewAgentMetric() *AgentMetric {
 
 func (m *AgentMetric) initPolicyGuardMetrics() {
 	policyObjectLabels := []string{"resource", "namespace", "name", "operation", "reason"}
+	policyRuleObjectLabels := []string{"resource", "namespace", "name", "tower_id", "operation", "reason"}
 	memoryEventLabels := []string{"reason"}
 	guardLabels := []string{"type"}
 
@@ -166,14 +166,10 @@ func (m *AgentMetric) initPolicyGuardMetrics() {
 		"policy_rule_estimate_limit",
 		"The current policy rule estimate admission limit",
 	), nil)
-	m.policyRuleEstimateRejectedObjects = *prometheus.NewGaugeVec(newAgentGaugeOpt(
-		"policy_rule_estimate_rejected_objects",
-		"The policy objects currently rejected by rule estimate admission",
-	), policyObjectLabels)
 	m.policyRuleEstimateRejectedValue = *prometheus.NewGaugeVec(newAgentGaugeOpt(
 		"policy_rule_estimate_rejected_value",
-		"The latest rejected rule estimate value for a policy object",
-	), policyObjectLabels)
+		"The estimated rule count for policy objects rejected by rule estimate admission",
+	), policyRuleObjectLabels)
 }
 
 func (m *AgentMetric) UpdatePolicyName(policyID string, policy *securityv1alpha1.SecurityPolicy) {
@@ -255,7 +251,6 @@ func (m *AgentMetric) GetCollectors() []prometheus.Collector {
 			m.policyMemoryUsageBytes,
 			m.policyMemoryThresholdBytes,
 			m.policyRuleEstimateLimit,
-			m.policyRuleEstimateRejectedObjects,
 			m.policyRuleEstimateRejectedValue)
 	}
 	if config.EnableTR {
@@ -294,12 +289,18 @@ func (m *AgentMetric) SetPolicyGuardEnabled(guardType string, enabled bool) {
 	m.policyGuardEnabled.WithLabelValues(guardType).Set(boolToFloat64(enabled))
 }
 
-func (m *AgentMetric) SetPolicyRuleEstimateRejectedObject(resource, namespace, name, operation, reason string, rejected bool) {
-	m.policyRuleEstimateRejectedObjects.WithLabelValues(resource, namespace, name, operation, reason).Set(boolToFloat64(rejected))
+func (m *AgentMetric) SetPolicyRuleEstimateRejectedValue(resource, namespace, name, towerID, operation, reason string, value uint64) {
+	m.policyRuleEstimateRejectedValue.WithLabelValues(resource, namespace, name, towerID, operation, reason).Set(float64(value))
 }
 
-func (m *AgentMetric) SetPolicyRuleEstimateRejectedValue(resource, namespace, name, operation, reason string, value uint64) {
-	m.policyRuleEstimateRejectedValue.WithLabelValues(resource, namespace, name, operation, reason).Set(float64(value))
+func (m *AgentMetric) DeletePolicyRuleEstimateRejectedValue(resource, namespace, name, operation, reason string) {
+	m.policyRuleEstimateRejectedValue.DeletePartialMatch(prometheus.Labels{
+		"resource":  resource,
+		"namespace": namespace,
+		"name":      name,
+		"operation": operation,
+		"reason":    reason,
+	})
 }
 
 func (m *AgentMetric) SetSeqIDInfo(module string, exhaust bool, used int) {

--- a/pkg/metrics/agent_metrics_test.go
+++ b/pkg/metrics/agent_metrics_test.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestPolicyRuleEstimateRejectedValueMetric(t *testing.T) {
+	metric := NewAgentMetric()
+
+	metric.SetPolicyRuleEstimateRejectedValue("policy", "tower-space", "policy-a", "tower-policy-a", "add", "rule_estimate_exceeded", 20020)
+	metric.SetPolicyRuleEstimateRejectedValue("group_members", "tower-space", "group-a", "", "update", "rule_estimate_exceeded", 20021)
+
+	expected := `
+# HELP everoute_ms_policy_rule_estimate_rejected_value The estimated rule count for policy objects rejected by rule estimate admission
+# TYPE everoute_ms_policy_rule_estimate_rejected_value gauge
+everoute_ms_policy_rule_estimate_rejected_value{name="group-a",namespace="tower-space",operation="update",reason="rule_estimate_exceeded",resource="group_members",tower_id=""} 20021
+everoute_ms_policy_rule_estimate_rejected_value{name="policy-a",namespace="tower-space",operation="add",reason="rule_estimate_exceeded",resource="policy",tower_id="tower-policy-a"} 20020
+`
+	if err := testutil.CollectAndCompare(&metric.policyRuleEstimateRejectedValue, strings.NewReader(expected)); err != nil {
+		t.Fatalf("unexpected rejected value metric: %s", err)
+	}
+
+	metric.DeletePolicyRuleEstimateRejectedValue("policy", "tower-space", "policy-a", "add", "rule_estimate_exceeded")
+	metric.DeletePolicyRuleEstimateRejectedValue("group_members", "tower-space", "group-a", "update", "rule_estimate_exceeded")
+	if count := testutil.CollectAndCount(&metric.policyRuleEstimateRejectedValue); count != 0 {
+		t.Fatalf("expected rejected value metric to be deleted, got %d metrics", count)
+	}
+}

--- a/pkg/metrics/controller_active_metric.go
+++ b/pkg/metrics/controller_active_metric.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	constants "github.com/everoute/everoute/pkg/constants/ms"
+)
+
+type ControllerActiveMetric struct {
+	data *prometheus.GaugeVec
+}
+
+func NewControllerActiveMetric() *ControllerActiveMetric {
+	return &ControllerActiveMetric{
+		data: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.MetricNamespace,
+			Subsystem: constants.MetricSubSystem,
+			Name:      "controller_active",
+			Help:      "Whether this controller instance is active",
+		}, nil),
+	}
+}
+
+func (m *ControllerActiveMetric) SetActive(active bool) {
+	if m == nil {
+		return
+	}
+	m.data.WithLabelValues().Set(boolToFloat64(active))
+}
+
+func (m *ControllerActiveMetric) Start(ctx context.Context) error {
+	m.SetActive(true)
+	<-ctx.Done()
+	m.SetActive(false)
+	return nil
+}
+
+func (m *ControllerActiveMetric) NeedLeaderElection() bool {
+	return true
+}

--- a/pkg/metrics/controller_active_metric_test.go
+++ b/pkg/metrics/controller_active_metric_test.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestControllerActiveMetric(t *testing.T) {
+	metric := NewControllerActiveMetric()
+
+	metric.SetActive(true)
+	expectedActive := `
+# HELP everoute_ms_controller_active Whether this controller instance is active
+# TYPE everoute_ms_controller_active gauge
+everoute_ms_controller_active 1
+`
+	if err := testutil.CollectAndCompare(metric.data, strings.NewReader(expectedActive)); err != nil {
+		t.Fatalf("unexpected active metric: %s", err)
+	}
+
+	metric.SetActive(false)
+	expectedInactive := `
+# HELP everoute_ms_controller_active Whether this controller instance is active
+# TYPE everoute_ms_controller_active gauge
+everoute_ms_controller_active 0
+`
+	if err := testutil.CollectAndCompare(metric.data, strings.NewReader(expectedInactive)); err != nil {
+		t.Fatalf("unexpected inactive metric: %s", err)
+	}
+}
+
+func TestControllerActiveMetricStart(t *testing.T) {
+	metric := NewControllerActiveMetric()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		_ = metric.Start(ctx)
+	}()
+	cancel()
+	<-done
+
+	expected := `
+# HELP everoute_ms_controller_active Whether this controller instance is active
+# TYPE everoute_ms_controller_active gauge
+everoute_ms_controller_active 0
+`
+	if err := testutil.CollectAndCompare(metric.data, strings.NewReader(expected)); err != nil {
+		t.Fatalf("unexpected stopped active metric: %s", err)
+	}
+	if !metric.NeedLeaderElection() {
+		t.Fatalf("expected controller active metric to need leader election")
+	}
+}

--- a/pkg/metrics/controller_metrics.go
+++ b/pkg/metrics/controller_metrics.go
@@ -12,14 +12,20 @@ import (
 )
 
 type ControllerMetric struct {
-	reg *prometheus.Registry
-	ipM *IPMigrateCount
+	reg                        *prometheus.Registry
+	ipM                        *IPMigrateCount
+	endpointGroupInfo          *EndpointGroupInfoMetric
+	endpointGroupSecurityGroup *EndpointGroupSecurityGroupMetric
+	controllerActive           *ControllerActiveMetric
 }
 
 func NewControllerMetric() *ControllerMetric {
 	return &ControllerMetric{
-		reg: prometheus.NewRegistry(),
-		ipM: NewIPMigrateCount(),
+		reg:                        prometheus.NewRegistry(),
+		ipM:                        NewIPMigrateCount(),
+		endpointGroupInfo:          NewEndpointGroupInfoMetric(),
+		endpointGroupSecurityGroup: NewEndpointGroupSecurityGroupMetric(),
+		controllerActive:           NewControllerActiveMetric(),
 	}
 }
 
@@ -27,10 +33,31 @@ func (c *ControllerMetric) Init() {
 	if err := c.reg.Register(c.ipM.data); err != nil {
 		klog.Fatalf("Failed to init controllerMetric %s", err)
 	}
+	if err := c.reg.Register(c.endpointGroupInfo.data); err != nil {
+		klog.Fatalf("Failed to init endpointGroupInfo metric %s", err)
+	}
+	if err := c.reg.Register(c.endpointGroupSecurityGroup.data); err != nil {
+		klog.Fatalf("Failed to init endpointGroupSecurityGroup metric %s", err)
+	}
+	if err := c.reg.Register(c.controllerActive.data); err != nil {
+		klog.Fatalf("Failed to init controllerActive metric %s", err)
+	}
 }
 
 func (c *ControllerMetric) GetIPMigrateCount() *IPMigrateCount {
 	return c.ipM
+}
+
+func (c *ControllerMetric) GetEndpointGroupInfo() *EndpointGroupInfoMetric {
+	return c.endpointGroupInfo
+}
+
+func (c *ControllerMetric) GetEndpointGroupSecurityGroup() *EndpointGroupSecurityGroupMetric {
+	return c.endpointGroupSecurityGroup
+}
+
+func (c *ControllerMetric) GetControllerActive() *ControllerActiveMetric {
+	return c.controllerActive
 }
 
 func (c *ControllerMetric) InstallHandler(registryFunc func(path string, handler http.Handler)) {

--- a/pkg/metrics/endpointgroup_metrics.go
+++ b/pkg/metrics/endpointgroup_metrics.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	constants "github.com/everoute/everoute/pkg/constants/ms"
+)
+
+const (
+	EndpointGroupTargetTypePod     = "pod"
+	EndpointGroupTargetTypeVNIC    = "vnic"
+	EndpointGroupTargetTypeVMLabel = "vm_label"
+	EndpointGroupTargetTypeUnknown = "unknown"
+
+	SecurityGroupTypePod = "pod"
+)
+
+type endpointGroupInfoLabels struct {
+	name          string
+	targetType    string
+	targetDisplay string
+}
+
+type EndpointGroupInfoMetric struct {
+	lock sync.Mutex
+	data *prometheus.GaugeVec
+	last map[string]endpointGroupInfoLabels
+}
+
+func NewEndpointGroupInfoMetric() *EndpointGroupInfoMetric {
+	return &EndpointGroupInfoMetric{
+		data: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.MetricNamespace,
+			Subsystem: constants.MetricSubSystem,
+			Name:      "endpointgroup_info",
+			Help:      "The display information of EndpointGroup for policy guard alerts",
+		}, []string{"name", "target_type", "target_display"}),
+		last: make(map[string]endpointGroupInfoLabels),
+	}
+}
+
+func (m *EndpointGroupInfoMetric) Set(name, targetType, targetDisplay string) {
+	if m == nil {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if old, ok := m.last[name]; ok && old != (endpointGroupInfoLabels{name: name, targetType: targetType, targetDisplay: targetDisplay}) {
+		m.data.DeleteLabelValues(old.name, old.targetType, old.targetDisplay)
+	}
+
+	labels := endpointGroupInfoLabels{name: name, targetType: targetType, targetDisplay: targetDisplay}
+	m.data.WithLabelValues(labels.name, labels.targetType, labels.targetDisplay).Set(1)
+	m.last[name] = labels
+}
+
+func (m *EndpointGroupInfoMetric) Delete(name string) {
+	if m == nil {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if old, ok := m.last[name]; ok {
+		m.data.DeleteLabelValues(old.name, old.targetType, old.targetDisplay)
+		delete(m.last, name)
+	}
+}
+
+type EndpointGroupSecurityGroupMetric struct {
+	lock sync.Mutex
+	data *prometheus.GaugeVec
+	last map[string]map[string]struct{}
+}
+
+func NewEndpointGroupSecurityGroupMetric() *EndpointGroupSecurityGroupMetric {
+	return &EndpointGroupSecurityGroupMetric{
+		data: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: constants.MetricNamespace,
+			Subsystem: constants.MetricSubSystem,
+			Name:      "securitygroup_info",
+			Help:      "The Tower SecurityGroup to EndpointGroup mapping for policy guard alerts",
+		}, []string{"name", "securitygroup_id", "securitygroup_type"}),
+		last: make(map[string]map[string]struct{}),
+	}
+}
+
+func (m *EndpointGroupSecurityGroupMetric) SetSecurityGroup(securityGroupID string, endpointGroupNames []string) {
+	if m == nil {
+		return
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if oldNames, ok := m.last[securityGroupID]; ok {
+		for name := range oldNames {
+			m.data.DeleteLabelValues(name, securityGroupID, SecurityGroupTypePod)
+		}
+	}
+
+	nextNames := make(map[string]struct{}, len(endpointGroupNames))
+	for _, name := range endpointGroupNames {
+		if name == "" {
+			continue
+		}
+		if _, ok := nextNames[name]; ok {
+			continue
+		}
+		m.data.WithLabelValues(name, securityGroupID, SecurityGroupTypePod).Set(1)
+		nextNames[name] = struct{}{}
+	}
+	if len(nextNames) == 0 {
+		delete(m.last, securityGroupID)
+		return
+	}
+	m.last[securityGroupID] = nextNames
+}
+
+func (m *EndpointGroupSecurityGroupMetric) DeleteSecurityGroup(securityGroupID string) {
+	if m == nil {
+		return
+	}
+	m.SetSecurityGroup(securityGroupID, nil)
+}

--- a/pkg/metrics/endpointgroup_metrics_test.go
+++ b/pkg/metrics/endpointgroup_metrics_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestEndpointGroupInfoMetricSetDeletesOldLabelState(t *testing.T) {
+	metric := NewEndpointGroupInfoMetric()
+
+	metric.Set("group-a", EndpointGroupTargetTypePod, "old")
+	metric.Set("group-a", EndpointGroupTargetTypeVMLabel, "new")
+
+	if len(metric.last) != 1 {
+		t.Fatalf("expected one cached label set, got %d", len(metric.last))
+	}
+	got := metric.last["group-a"]
+	if got.targetType != EndpointGroupTargetTypeVMLabel || got.targetDisplay != "new" {
+		t.Fatalf("unexpected cached labels: %+v", got)
+	}
+
+	metric.Delete("group-a")
+	if len(metric.last) != 0 {
+		t.Fatalf("expected cached labels to be deleted, got %d", len(metric.last))
+	}
+}
+
+func TestEndpointGroupSecurityGroupMetricSetReplacesSecurityGroupMappings(t *testing.T) {
+	metric := NewEndpointGroupSecurityGroupMetric()
+
+	metric.SetSecurityGroup("sg-a", []string{"group-a", "group-b", "group-a"})
+	if got := len(metric.last["sg-a"]); got != 2 {
+		t.Fatalf("expected duplicate endpointgroups to be deduplicated, got %d", got)
+	}
+
+	metric.SetSecurityGroup("sg-a", []string{"group-c"})
+	if got := len(metric.last["sg-a"]); got != 1 {
+		t.Fatalf("expected one endpointgroup after replace, got %d", got)
+	}
+	if _, ok := metric.last["sg-a"]["group-c"]; !ok {
+		t.Fatalf("expected group-c mapping after replace")
+	}
+
+	expected := `
+# HELP everoute_ms_securitygroup_info The Tower SecurityGroup to EndpointGroup mapping for policy guard alerts
+# TYPE everoute_ms_securitygroup_info gauge
+everoute_ms_securitygroup_info{name="group-c",securitygroup_id="sg-a",securitygroup_type="pod"} 1
+`
+	if err := testutil.CollectAndCompare(metric.data, strings.NewReader(expected)); err != nil {
+		t.Fatalf("unexpected securitygroup info metric: %s", err)
+	}
+
+	metric.DeleteSecurityGroup("sg-a")
+	if _, ok := metric.last["sg-a"]; ok {
+		t.Fatalf("expected securitygroup mapping to be deleted")
+	}
+}

--- a/plugin/tower/pkg/controller/policy/controller.go
+++ b/plugin/tower/pkg/controller/policy/controller.go
@@ -41,6 +41,7 @@ import (
 	crd "github.com/everoute/everoute/pkg/client/informers_generated/externalversions"
 	"github.com/everoute/everoute/pkg/constants"
 	msconst "github.com/everoute/everoute/pkg/constants/ms"
+	ctrlpolicy "github.com/everoute/everoute/pkg/controller/policy"
 	"github.com/everoute/everoute/pkg/labels"
 	"github.com/everoute/everoute/pkg/utils"
 	"github.com/everoute/everoute/plugin/tower/pkg/controller/endpoint"
@@ -76,6 +77,11 @@ const (
 
 	K8sNsNameLabel = "kubernetes.io/metadata.name"
 )
+
+type EndpointGroupSecurityGroupMetric interface {
+	SetSecurityGroup(securityGroupID string, endpointGroupNames []string)
+	DeleteSecurityGroup(securityGroupID string)
+}
 
 // Controller sync SecurityPolicy and IsolationPolicy as v1alpha1.SecurityPolicy
 // from tower. For v1alpha1.SecurityPolicy, has the following naming rules:
@@ -136,6 +142,8 @@ type Controller struct {
 	serviceInformer       cache.SharedIndexInformer
 	serviceLister         informer.Lister
 	serviceInformerSynced cache.InformerSynced
+
+	sgMetric EndpointGroupSecurityGroupMetric
 }
 
 // New creates a new instance of controller.
@@ -149,6 +157,7 @@ func New(
 	namespace string,
 	podNamespace string,
 	everouteCluster string,
+	endpointGroupSecurityGroupMetrics ...EndpointGroupSecurityGroupMetric,
 ) *Controller {
 	crdPolicyInformer := crdFactory.Security().V1alpha1().SecurityPolicies().Informer()
 	vmInformer := towerFactory.VM()
@@ -159,6 +168,10 @@ func New(
 	systemEndpointInformer := towerFactory.SystemEndpoints()
 	securityGroupInformer := towerFactory.SecurityGroup()
 	serviceInformer := towerFactory.Service()
+	var sgMetric EndpointGroupSecurityGroupMetric
+	if len(endpointGroupSecurityGroupMetrics) > 0 {
+		sgMetric = endpointGroupSecurityGroupMetrics[0]
+	}
 
 	c := &Controller{
 		name:                          "PolicyController",
@@ -181,6 +194,7 @@ func New(
 		serviceInformer:               serviceInformer,
 		serviceLister:                 serviceInformer.GetIndexer(),
 		serviceInformerSynced:         serviceInformer.HasSynced,
+		sgMetric:                      sgMetric,
 		crdPolicyInformer:             crdPolicyInformer,
 		crdPolicyLister:               crdPolicyInformer.GetIndexer(),
 		crdPolicyInformerSynced:       crdPolicyInformer.HasSynced,
@@ -687,6 +701,9 @@ func (c *Controller) handleSecurityGroup(obj interface{}) {
 		securityGroup.EverouteCluster.ID != c.everouteCluster {
 		return
 	}
+	if securityGroup.EverouteCluster.ID == "" {
+		c.deleteSGMetric(securityGroup.GetID())
+	}
 
 	securityPolicies, _ := c.securityPolicyLister.ByIndex(securityGroupIndex, securityGroup.GetID())
 	for _, securityPolicy := range securityPolicies {
@@ -707,6 +724,20 @@ func (c *Controller) updateSecurityGroup(old, new interface{}) {
 		return
 	}
 	c.handleSecurityGroup(newGroup)
+}
+
+func (c *Controller) setSGMetric(securityGroupID string, endpointGroupNames []string) {
+	if c == nil || c.sgMetric == nil {
+		return
+	}
+	c.sgMetric.SetSecurityGroup(securityGroupID, endpointGroupNames)
+}
+
+func (c *Controller) deleteSGMetric(securityGroupID string) {
+	if c == nil || c.sgMetric == nil {
+		return
+	}
+	c.sgMetric.DeleteSecurityGroup(securityGroupID)
 }
 
 func (c *Controller) handleService(obj interface{}) {
@@ -1532,6 +1563,7 @@ func (c *Controller) parseIPSecurityGroup(securityGroup *schema.SecurityGroup) (
 
 func (c *Controller) parsePodSecurityGroup(securityGroup *schema.SecurityGroup) ([]v1alpha1.ApplyToPeer, error) {
 	var appliedPeers []v1alpha1.ApplyToPeer
+	endpointGroupNames := make([]string, 0, len(securityGroup.PodLabelGroups))
 	for _, podLabelGroup := range securityGroup.PodLabelGroups {
 		matchLabels := make(map[string]string, 2)
 		matchLabels[msconst.SKSLabelKeyClusterName] = utils.GetValidLabelString(podLabelGroup.KSC.Name)
@@ -1554,10 +1586,24 @@ func (c *Controller) parsePodSecurityGroup(securityGroup *schema.SecurityGroup) 
 			}
 			selector.LabelSelector.MatchExpressions = []metav1.LabelSelectorRequirement{matchExpre}
 		}
-		appliedPeers = append(appliedPeers, v1alpha1.ApplyToPeer{
+		appliedPeer := v1alpha1.ApplyToPeer{
 			EndpointSelector: selector,
-		})
+		}
+		appliedPeers = append(appliedPeers, appliedPeer)
+		// The same Pod SecurityGroup can be converted to an EndpointGroup through
+		// different policy paths. Record both possible EndpointGroup names so
+		// alerts can join the generated group back to the source SecurityGroup.
+		if group := ctrlpolicy.PeerAsEndpointGroup(c.podNamespace, ctrlpolicy.AppliedAsSecurityPeer(c.podNamespace, appliedPeer)); group != nil {
+			endpointGroupNames = append(endpointGroupNames, group.Name)
+		}
+		if group := ctrlpolicy.PeerAsEndpointGroup(c.podNamespace, v1alpha1.SecurityPolicyPeer{
+			EndpointSelector:  selector,
+			NamespaceSelector: c.genNamespaceSelector(true),
+		}); group != nil {
+			endpointGroupNames = append(endpointGroupNames, group.Name)
+		}
 	}
+	c.setSGMetric(securityGroup.GetID(), endpointGroupNames)
 	return appliedPeers, nil
 }
 
@@ -1573,12 +1619,14 @@ func (c *Controller) parseSecurityGroup(securityGroupRef *schema.ObjectReference
 	}
 	switch memberType {
 	case schema.VMGroupType:
+		c.deleteSGMetric(securityGroup.GetID())
 		vmPeers, err := c.parseVMSecurityGroup(securityGroup)
 		return vmPeers, false, err
 	case schema.PodGroupType:
 		podPeers, err := c.parsePodSecurityGroup(securityGroup)
 		return podPeers, true, err
 	case schema.IPGroupType:
+		c.deleteSGMetric(securityGroup.GetID())
 		ipPeers, err := c.parseIPSecurityGroup(securityGroup)
 		return ipPeers, false, err
 	default:

--- a/plugin/tower/pkg/register/manager.go
+++ b/plugin/tower/pkg/register/manager.go
@@ -55,8 +55,9 @@ type Options struct {
 	Namespace    string
 	PodNamespace string
 	// which EverouteCluster should synchronize SecurityPolicy from
-	EverouteCluster string
-	SharedFactory   informer.SharedInformerFactory
+	EverouteCluster                  string
+	SharedFactory                    informer.SharedInformerFactory
+	EndpointGroupSecurityGroupMetric policy.EndpointGroupSecurityGroupMetric
 }
 
 // InitFlags set and load options from flagset.
@@ -123,7 +124,8 @@ func AddToManager(opts *Options, mgr manager.Manager) error {
 	// cache endpoints and security policies in the namespace
 	crdFactory := externalversions.NewSharedInformerFactoryWithOptions(crdClient, opts.ResyncPeriod)
 	endpointController := endpoint.New(opts.SharedFactory, crdFactory, crdClient, opts.ResyncPeriod, opts.Namespace)
-	policyController := policy.New(opts.SharedFactory, crdFactory, crdClient, opts.ResyncPeriod, opts.Namespace, opts.PodNamespace, opts.EverouteCluster)
+	policyController := policy.New(opts.SharedFactory, crdFactory, crdClient, opts.ResyncPeriod, opts.Namespace, opts.PodNamespace,
+		opts.EverouteCluster, opts.EndpointGroupSecurityGroupMetric)
 	globalController := global.New(opts.SharedFactory, crdFactory, crdClient, opts.ResyncPeriod, opts.EverouteCluster)
 	elfController := &computecluster.Controller{EverouteClusterID: opts.EverouteCluster, ConfigMapNamespace: opts.Namespace}
 	if err := elfController.Setup(opts.SharedFactory, k8sFactory, k8sClient); err != nil {


### PR DESCRIPTION
## 目的

根据熔断告警要求，修改和新增告警链路需要的 metrics，让告警能够直接反映熔断对象，并补齐 Tower 对象标识、`EndpointGroup` 目标信息和 `SecurityGroup` 映射信息，方便告警文案展示和后续名称查询。

## 方案

先说 agent 侧，agent 侧这次主要调整的是 `rule estimate` 熔断相关指标。

### Agent 侧改动

- `policy_rule_estimate_rejected_value`
  - 改动：增加 `tower_id` label。
  - 目的：告警触发时可以直接在告警文案中插入 `tower_id`，或者再根据 `tower_id` 去 Redis 中查询对应名称，减少二次反查成本。

- `policy_rule_estimate_rejected_value` / `policy_rule_estimate_rejected_objects`
  - 改动：
    - 删除独立的 `policy_rule_estimate_rejected_objects` 指标。
    - 保留 `policy_rule_estimate_rejected_value` 作为唯一的 rule estimate rejection 指标。
    - 对象恢复后，不再把 `policy_rule_estimate_rejected_value` 置为 `0`，而是直接删除对应时间序列。
  - 目的：
    - `policy_rule_estimate_rejected_value` 可以同时表达 `policy_rule_estimate_rejected_objects` 的语义。
    - 避免保留值为 `0` 的陈旧指标，减少告警判断歧义，让当前被拒绝对象集合更准确。

### Controller 侧改动

- `controller_active`
  - 改动：新增 `controller_active` metric，用于在 controller 实例启动后标记 active 状态，在退出时清理状态。
  - 目的：告警时仅取 leader 节点的 metric，避免使用 follower 节点残留的 metric。

- `endpointgroup_info`
  - 改动：新增 `endpointgroup_info{name, target_type, target_display}`，用于记录 `EndpointGroup` 的目标类型和展示信息。
  - 目的：让告警拿到 `EndpointGroup` 后，可以继续展示它实际对应的目标对象。
  - `target_type=vnic`：`target_display` 优先记录 `VMID`，取不到时 fallback 为 `endpoint namespace/name`。告警侧优先根据 `VMID` 去 Redis 获取并展示 `VMName`；如果没有 `VMID`，也至少能展示到具体 endpoint 引用。
  - `target_type=pod`：`target_display` 记录 pod 侧 selector，以及 `namespace` / `namespaceSelector` 信息。告警侧先根据 `EndpointGroup` 名称，到 `securitygroup_info` 中反查关联它的 `securitygroup_id`，再根据这个 Tower `SecurityGroup ID` 去 Redis 查询并展示安全组名称。
  - `target_type=vm_label`：`target_display` 记录 VM 标签选择器内容。告警侧可以直接展示该 `EndpointGroup` 的标签匹配条件。
  - `target_type=unknown`：`target_display` 记录兜底展示内容，避免遇到未覆盖类型时告警侧完全没有可展示信息。

- `securitygroup_info`
  - 改动：新增 `securitygroup_info{name, securitygroup_id, securitygroup_type}`，由 Tower policy controller 维护 `SecurityGroup -> EndpointGroup` 的映射。
  - 目的：把 Tower `SecurityGroup` 和 Everoute `EndpointGroup` 串起来。
  - 串联方式：这里的 `name` 是 Everoute 侧的 `EndpointGroup` 名称，`securitygroup_id` 是 Tower 侧 `SecurityGroup` 的 ID。
  - 告警侧用法：先从熔断对象关联到 `EndpointGroup`，再用 `EndpointGroup.name` 去匹配 `securitygroup_info.name`，得到对应的 `securitygroup_id`，最后再根据这个 `securitygroup_id` 去 Redis 查询 `SecurityGroup` 名称并展示。

## 限制

- controller metric 和 agent metric 不是同一时刻更新，存在时间差。
- 在这段时间差内，可能出现 agent 侧已经产出熔断指标，但 controller 侧关联信息还没更新完成的情况。
- 结果可能是：
  - 告警条件匹配失败，导致未能成功报警。
  - 告警能发出，但文案里缺少 `Tower policy name`、`VMName`、`SecurityGroup name` 或 `EndpointGroup` 目标展示等补充字段。
