### PR TITLE
feat(erctl): add conntrack matcher and ctlabel decode support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/99designs/gqlgen v0.17.16
+	github.com/BurntSushi/toml v1.3.2
 	github.com/agiledragon/gomonkey v2.0.2+incompatible
 	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/alessio/shellescape v1.4.2
@@ -43,10 +44,12 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/samber/lo v1.39.0
+	github.com/samber/mo v1.17.0
 	github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/smartxworks/cloudtower-go-sdk/v2 v2.22.1-rc.1
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/vektah/gqlparser/v2 v2.5.2-0.20230422221642-25e09f9d292d
@@ -132,9 +135,7 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/thoas/go-funk v0.9.3 // indirect
 	github.com/ti-mo/netfilter v0.3.1 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -830,7 +832,6 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
@@ -838,6 +839,8 @@ github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 h1:ZFfeKAhIQiiOrQ
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
 github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
+github.com/samber/mo v1.17.0 h1:EbeLc7nxIdpalstxQQakLOcXxULuMRqo7PJPtY18bQg=
+github.com/samber/mo v1.17.0/go.mod h1:DlgzJ4SYhOh41nP1L9kh9rDNERuf8IqWSAs+gj2Vxag=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=

--- a/pkg/agent/datapath/conntrack/clear_conntrack_test.go
+++ b/pkg/agent/datapath/conntrack/clear_conntrack_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/netip"
 	"os"
 	"strconv"
 	"sync"
@@ -194,19 +193,21 @@ func TestUpdateConntrackFlows_MatchAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Skipf("conntrack create failed (may need root): %v", err)
 	}
-	matcher := Matcher{
-		ID:             "test-match",
-		SrcIP:          netIPTo16(flow.Forward.SrcIP),
-		SrcIPPrefixLen: 128,
-		DstIP:          netIPTo16(flow.Forward.DstIP),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		SrcPort:        9999,
-		SrcPortMask:    0xffff,
-		DstPort:        8080,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "test-match",
+		IPTuple: IPTuple{
+			SrcIP:          netIPTo16(flow.Forward.SrcIP),
+			SrcIPPrefixLen: 128,
+			DstIP:          netIPTo16(flow.Forward.DstIP),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			SrcPort:        9999,
+			SrcPortMask:    0xffff,
+			DstPort:        8080,
+			DstPortMask:    0xffff,
+		},
 	}
-	matchers := CookMatcherBatch([]Matcher{matcher})
+	matchers := CookTupleMatcherBatch([]TupleMatcher{matcher})
 	pool := sync.Pool{New: func() any { return &netlink.ConntrackFlow{} }}
 	allocator := func() *netlink.ConntrackFlow { return pool.Get().(*netlink.ConntrackFlow) }
 	deallocator := func(f *netlink.ConntrackFlow) { pool.Put(f) }
@@ -219,7 +220,7 @@ func TestUpdateConntrackFlows_MatchAndUpdate(t *testing.T) {
 		f.LabelsMask[0] = 0xFF
 		return true
 	}
-	dumpCount, matchCount, successCount, failureCount, err := UpdateConntrackFlows(unix.AF_INET, matchers, allocator, deallocator, updateFunc)
+	dumpCount, matchCount, successCount, failureCount, err := UpdateConntrackFlows(unix.AF_INET, &matchers, allocator, deallocator, updateFunc)
 	if err != nil {
 		t.Fatalf("UpdateConntrackFlows failed: %v", err)
 	}
@@ -500,17 +501,8 @@ func initRandomConntrackFlows(familyType uint8, conntrackFlows []netlink.Conntra
 	}
 }
 
-// netIPTo16 converts net.IP to [16]byte (IPv4-mapped for IPv4).
-func netIPTo16(ip net.IP) [16]byte {
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return [16]byte{}
-	}
-	return addr.As16()
-}
-
-func randomMatchersFromFlows(flows []netlink.ConntrackFlow, count int) MatcherBatch {
-	matchers := make([]Matcher, 0, count)
+func randomMatchersFromFlows(flows []netlink.ConntrackFlow, count int) TupleMatcherBatch {
+	matchers := make([]TupleMatcher, 0, count)
 	randomFlows := make([]int, len(flows))
 	for i := 0; i < len(randomFlows); i++ {
 		randomFlows[i] = i
@@ -527,16 +519,18 @@ func randomMatchersFromFlows(flows []netlink.ConntrackFlow, count int) MatcherBa
 			f := flows[randomFlows[i]].Forward
 			srcIP := netIPTo16(f.SrcIP)
 			dstIP := netIPTo16(f.DstIP)
-			matcher := Matcher{
-				ID:             fmt.Sprintf("from-%d", randomFlows[i]),
-				IPFamily:       flows[randomFlows[i]].FamilyType,
-				IPProtocol:     f.Protocol,
-				SrcIP:          srcIP,
-				DstIP:          dstIP,
-				SrcIPPrefixLen: prefixLen,
-				DstIPPrefixLen: prefixLen,
-				SrcPort:        f.SrcPort,
-				DstPort:        f.DstPort,
+			matcher := TupleMatcher{
+				ID: fmt.Sprintf("from-%d", randomFlows[i]),
+				IPTuple: IPTuple{
+					IPFamily:       flows[randomFlows[i]].FamilyType,
+					IPProtocol:     f.Protocol,
+					SrcIP:          srcIP,
+					DstIP:          dstIP,
+					SrcIPPrefixLen: prefixLen,
+					DstIPPrefixLen: prefixLen,
+					SrcPort:        f.SrcPort,
+					DstPort:        f.DstPort,
+				},
 			}
 			matchers = append(matchers, matcher)
 		}
@@ -547,16 +541,18 @@ func randomMatchersFromFlows(flows []netlink.ConntrackFlow, count int) MatcherBa
 			f := flows[randomFlows[i]].Forward
 			srcIP := netIPTo16(f.SrcIP)
 			dstIP := netIPTo16(f.DstIP)
-			matcher := Matcher{
-				ID:             fmt.Sprintf("from-%d", randomFlows[i]),
-				IPFamily:       flows[randomFlows[i]].FamilyType,
-				IPProtocol:     f.Protocol,
-				SrcIP:          srcIP,
-				DstIP:          dstIP,
-				SrcIPPrefixLen: prefixLen,
-				DstIPPrefixLen: prefixLen,
-				SrcPort:        f.SrcPort,
-				DstPort:        f.DstPort,
+			matcher := TupleMatcher{
+				ID: fmt.Sprintf("from-%d", randomFlows[i]),
+				IPTuple: IPTuple{
+					IPFamily:       flows[randomFlows[i]].FamilyType,
+					IPProtocol:     f.Protocol,
+					SrcIP:          srcIP,
+					DstIP:          dstIP,
+					SrcIPPrefixLen: prefixLen,
+					DstIPPrefixLen: prefixLen,
+					SrcPort:        f.SrcPort,
+					DstPort:        f.DstPort,
+				},
 			}
 			matchers = append(matchers, matcher)
 		}
@@ -565,24 +561,26 @@ func randomMatchersFromFlows(flows []netlink.ConntrackFlow, count int) MatcherBa
 			f := flows[randomFlows[randomIndex]].Forward
 			srcIP := netIPTo16(f.SrcIP)
 			dstIP := netIPTo16(f.DstIP)
-			matcher := Matcher{
-				ID:             fmt.Sprintf("from-%d-extra-%d", randomFlows[randomIndex], i),
-				IPFamily:       flows[randomFlows[randomIndex]].FamilyType,
-				IPProtocol:     f.Protocol,
-				SrcIP:          srcIP,
-				DstIP:          dstIP,
-				SrcIPPrefixLen: prefixLen,
-				DstIPPrefixLen: prefixLen,
-				SrcPort:        f.SrcPort,
-				DstPort:        f.DstPort,
+			matcher := TupleMatcher{
+				ID: fmt.Sprintf("from-%d-extra-%d", randomFlows[randomIndex], i),
+				IPTuple: IPTuple{
+					IPFamily:       flows[randomFlows[randomIndex]].FamilyType,
+					IPProtocol:     f.Protocol,
+					SrcIP:          srcIP,
+					DstIP:          dstIP,
+					SrcIPPrefixLen: prefixLen,
+					DstIPPrefixLen: prefixLen,
+					SrcPort:        f.SrcPort,
+					DstPort:        f.DstPort,
+				},
 			}
 			matchers = append(matchers, matcher)
 		}
 	}
-	return CookMatcherBatch(matchers)
+	return CookTupleMatcherBatch(matchers)
 }
 
-func prepareFlowsAndMatchers(zone uint16, ipFamily uint8, flowCount int, matcherCount int, ctlabels [16]byte, hasLabels bool) ([]netlink.ConntrackFlow, MatcherBatch) {
+func prepareFlowsAndMatchers(zone uint16, ipFamily uint8, flowCount int, matcherCount int, ctlabels [16]byte, hasLabels bool) ([]netlink.ConntrackFlow, TupleMatcherBatch) {
 	flows := make([]netlink.ConntrackFlow, flowCount)
 	for i := 0; i < flowCount; i++ {
 		initRandomConntrackFlow(&flows[i], zone, ipFamily, ctlabels, hasLabels)
@@ -616,7 +614,7 @@ func doBenchmarkClearConntrackFlows(b *testing.B, zone uint16, ipFamily uint8, f
 			flow.LabelsMask[0] = 1<<EgressTreatedXXREG0Bit | 1<<IngressTreatedXXREG0Bit
 			return true
 		}
-		dumpCount, matchCount, successCount, failureCount, err := UpdateConntrackFlows(ipFamily, matchers, allocator, deallocator, unsetTreatedRegs)
+		dumpCount, matchCount, successCount, failureCount, err := UpdateConntrackFlows(ipFamily, &matchers, allocator, deallocator, unsetTreatedRegs)
 		if err != nil {
 			b.Fatalf("clear conntrack worker error, family: %d, err: %v", ipFamily, err)
 		}

--- a/pkg/agent/datapath/conntrack/manager.go
+++ b/pkg/agent/datapath/conntrack/manager.go
@@ -2,6 +2,7 @@ package conntrack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -28,8 +29,9 @@ const (
 type Manager struct {
 	flushTimeout      time.Duration
 	flushingConntrack atomic.Bool
-	v4MatcherChan     chan Matcher
-	v6MatcherChan     chan Matcher
+	// FIXME: adapt more matchers
+	v4MatcherChan chan TupleMatcher
+	v6MatcherChan chan TupleMatcher
 }
 
 func NewManager(flushTimeout time.Duration, v4BufferSize, v6BufferSize int) *Manager {
@@ -43,8 +45,8 @@ func NewManager(flushTimeout time.Duration, v4BufferSize, v6BufferSize int) *Man
 	if v6BufferSize <= 0 {
 		v6BufferSize = DefaultV6BufferSize
 	}
-	v4MatcherChan := make(chan Matcher, v4BufferSize)
-	v6MatcherChan := make(chan Matcher, v6BufferSize)
+	v4MatcherChan := make(chan TupleMatcher, v4BufferSize)
+	v6MatcherChan := make(chan TupleMatcher, v6BufferSize)
 
 	return &Manager{
 		flushTimeout:  flushTimeout,
@@ -88,7 +90,7 @@ func (m *Manager) updateConntrackFlowsLoop(
 	updateFunc UpdateConntrackFlowFunc,
 	updateDelay time.Duration,
 ) {
-	var ctMatcherChan chan Matcher
+	var ctMatcherChan chan TupleMatcher
 	switch family {
 	case unix.AF_INET:
 		ctMatcherChan = m.v4MatcherChan
@@ -114,7 +116,7 @@ func (m *Manager) updateConntrackFlowsLoop(
 // loop body of clearConntrackFlowsLoop
 func updateConntrackFlows(ctx context.Context,
 	family uint8,
-	ctMatcherChan chan Matcher,
+	ctMatcherChan chan TupleMatcher,
 	conntrackFlowAllocator func() *netlink.ConntrackFlow,
 	conntrackFlowDeallocator func(*netlink.ConntrackFlow),
 	updateFunc UpdateConntrackFlowFunc,
@@ -141,10 +143,10 @@ func updateConntrackFlows(ctx context.Context,
 		if updateDelay > 0 {
 			time.Sleep(updateDelay)
 		}
-		ids := sets.NewString(m.ID)
+		ids := sets.NewString(m.GetID())
 		// receive matchers from ctMatcherChan
 		currentBufferredMatchers := len(ctMatcherChan) + 1
-		matchers := make([]Matcher, currentBufferredMatchers)
+		matchers := make([]TupleMatcher, currentBufferredMatchers)
 		matchers[0] = m
 		i := 1
 		for i < currentBufferredMatchers {
@@ -152,10 +154,10 @@ func updateConntrackFlows(ctx context.Context,
 			case <-ctx.Done():
 				return true
 			case matcher := <-ctMatcherChan:
-				if ids.Has(matcher.ID) {
+				if ids.Has(matcher.GetID()) {
 					continue
 				}
-				ids.Insert(matcher.ID)
+				ids.Insert(matcher.GetID())
 				matchers[i] = matcher
 				i++
 			default:
@@ -165,11 +167,11 @@ func updateConntrackFlows(ctx context.Context,
 	endReceive:
 		matchers = matchers[:i]
 
-		cookedMatcher := CookMatcherBatch(matchers)
+		cookedMatcher := CookTupleMatcherBatch(matchers)
 
 		dumpCount, matchCount, successCount, failureCount, err := UpdateConntrackFlows(
 			family,
-			cookedMatcher,
+			&cookedMatcher,
 			conntrackFlowAllocator, conntrackFlowDeallocator,
 			updateFunc,
 		)
@@ -191,7 +193,7 @@ func updateConntrackFlows(ctx context.Context,
 // if skipOnFlushing is false, it will update conntrack flows even if the conntrack is currently flushing
 // onFull is called when the conntrack is full and the update is skipped
 // this function requires StartUpdateConntrackFlows to be called before using it
-func (m *Manager) AsyncUpdateConntrackFlows(family uint8, matcher Matcher, onFull func(), skipOnFlushing bool) {
+func (m *Manager) AsyncUpdateConntrackFlows(family uint8, matcher TupleMatcher, onFull func(), skipOnFlushing bool) {
 	if skipOnFlushing && m.flushingConntrack.Load() {
 		// skip update conntrack flows
 		return
@@ -254,7 +256,7 @@ func (m *Manager) AsyncFlushConntrackFlows() {
 // update conntrack flows
 // return: dumpCount, matchCount, successCount, failureCount, error
 func UpdateConntrackFlows(
-	family uint8, bm MatcherBatch,
+	family uint8, matcher Matcher,
 	conntrackFlowAllocator func() *netlink.ConntrackFlow,
 	conntrackFlowDeallocator func(*netlink.ConntrackFlow),
 	updateFunc UpdateConntrackFlowFunc,
@@ -308,7 +310,7 @@ func UpdateConntrackFlows(
 			continue // never happen
 		}
 		dumpCount++
-		if bm.MatchConntrackFlow(flow) {
+		if matcher != nil && matcher.MatchConntrackFlow(flow) {
 			matchCount++
 			updated := updateFunc(flow)
 			if !updated {
@@ -351,4 +353,128 @@ func UpdateConntrackFlows(
 		conntrackFlowDeallocator(flow)
 	}
 	return dumpCount, matchCount, successCount, failureCount, nil
+}
+
+func DumpConntrackFlows(
+	family uint8, matcher Matcher,
+	conntrackFlowAllocator func() *netlink.ConntrackFlow,
+	conntrackFlowDeallocator func(*netlink.ConntrackFlow),
+	dumpFunc func(*netlink.ConntrackFlow) error,
+) (int, int, error) {
+	if family != unix.AF_INET && family != unix.AF_INET6 {
+		klog.Errorf("invalid family: %d", family)
+		return 0, 0, fmt.Errorf("invalid family: %d", family)
+	}
+	if conntrackFlowAllocator == nil {
+		return 0, 0, fmt.Errorf("conntrackFlowAllocator must not be nil")
+	}
+	if dumpFunc == nil {
+		return 0, 0, fmt.Errorf("dumpFunc must not be nil")
+	}
+
+	conntrackFlowChan := make(chan *netlink.ConntrackFlow, 10000)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(conntrackFlowChan)
+		errCh <- netlink.ConntrackTableListStream(
+			netlink.ConntrackTable,
+			netlink.InetFamily(family),
+			conntrackFlowChan,
+			conntrackFlowAllocator,
+		)
+	}()
+
+	dumpCount := 0
+	matchCount := 0
+	var dumpErr error
+	for flow := range conntrackFlowChan {
+		if flow == nil {
+			continue
+		}
+		dumpCount++
+		if matcher == nil || matcher.MatchConntrackFlow(flow) {
+			matchCount++
+			if dumpErr == nil {
+				dumpErr = dumpFunc(flow)
+			}
+		}
+		if conntrackFlowDeallocator != nil {
+			conntrackFlowDeallocator(flow)
+		}
+	}
+
+	return dumpCount, matchCount, errors.Join(<-errCh, dumpErr)
+}
+
+func DeleteConntrackFlows(
+	family uint8, matcher Matcher,
+	conntrackFlowAllocator func() *netlink.ConntrackFlow,
+	conntrackFlowDeallocator func(*netlink.ConntrackFlow),
+) (int, int, int, int, error) {
+	if family != unix.AF_INET && family != unix.AF_INET6 {
+		klog.Errorf("invalid family: %d", family)
+		return 0, 0, 0, 0, fmt.Errorf("invalid family: %d", family)
+	}
+	if conntrackFlowAllocator == nil {
+		return 0, 0, 0, 0, fmt.Errorf("conntrackFlowAllocator must not be nil")
+	}
+
+	handle, err := netlink.NewHandle(unix.NETLINK_NETFILTER)
+	if err != nil {
+		klog.Errorf("create netlink handle error, err: %s", err)
+		return 0, 0, 0, 0, err
+	}
+	defer handle.Close()
+
+	request := handle.NewConntrackUpdateRequest(netlink.ConntrackTable, netlink.InetFamily(family), true)
+	request.NlMsghdr.Type = uint16((int(netlink.ConntrackTable) << 8) | nl.IPCTNL_MSG_CT_DELETE)
+	request.NlMsghdr.Flags = unix.NLM_F_REQUEST | unix.NLM_F_ACK
+
+	rtAttrs := make([]*nl.RtAttr, 0)
+	rtAttrIndex := 0
+	buffer := make([]nl.NetlinkRequestData, 32)
+
+	successCount := 0
+	failureCount := 0
+	dumpCount, matchCount, err := DumpConntrackFlows(
+		family,
+		matcher,
+		conntrackFlowAllocator,
+		conntrackFlowDeallocator,
+		func(flow *netlink.ConntrackFlow) error {
+			rtAttrIndex = 0
+			newRtAttr := func(attrType int, data []byte) *nl.RtAttr {
+				if rtAttrIndex >= len(rtAttrs) {
+					rtAttr := nl.NewRtAttr(attrType, data)
+					rtAttrs = append(rtAttrs, rtAttr)
+					rtAttrIndex++
+					return rtAttr
+				}
+				attr := rtAttrs[rtAttrIndex]
+				*attr = nl.RtAttr{}
+				attr.RtAttr.Type = uint16(attrType)
+				attr.Data = data
+				rtAttrIndex++
+				return attr
+			}
+			err := handle.ExecuteConntrackRequest(
+				request,
+				flow,
+				newRtAttr, buffer,
+				true,
+			)
+			if err != nil {
+				if !errors.Is(err, syscall.ENOENT) {
+					failureCount++
+					return nil
+				}
+			}
+			successCount++
+			return nil
+		},
+	)
+	if failureCount > 0 {
+		err = errors.Join(err, fmt.Errorf("failed to delete %d conntrack flows", failureCount))
+	}
+	return dumpCount, matchCount, successCount, failureCount, err
 }

--- a/pkg/agent/datapath/conntrack/manager_test.go
+++ b/pkg/agent/datapath/conntrack/manager_test.go
@@ -31,9 +31,11 @@ func TestUpdateConntrackFlows_NoPanicOnChannelClose(t *testing.T) {
 		}
 	}()
 
+	m := CookTupleMatcherBatch(nil)
+
 	_, _, _, _, err := UpdateConntrackFlows(
 		unix.AF_INET,
-		CookMatcherBatch(nil),
+		&m,
 		allocator,
 		deallocator,
 		updateFunc,

--- a/pkg/agent/datapath/conntrack/match.go
+++ b/pkg/agent/datapath/conntrack/match.go
@@ -3,6 +3,7 @@ package conntrack
 import (
 	"net"
 
+	"github.com/samber/mo"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -10,8 +11,13 @@ import (
 	"github.com/everoute/everoute/pkg/utils"
 )
 
-type Matcher struct {
-	ID string
+type Matcher interface {
+	MatchConntrackFlow(flow *netlink.ConntrackFlow) bool
+}
+
+type IPTuple struct {
+	// IP family
+	IPFamily uint8
 	// IPv6 address or IPv4 over IPv6 address
 	SrcIP [16]byte
 	// for single IP address, it is equal to the bit length of the IP address
@@ -22,48 +28,99 @@ type Matcher struct {
 	// for single IP address, it is equal to the bit length of the IP address
 	// for any IP address, it is 0
 	DstIPPrefixLen int
-	// IP family
-	IPFamily uint8
-	// IP protocol number
+
 	IPProtocol uint8
-	// Source port
+
+	// TCP/UDP
 	SrcPort     uint16
 	SrcPortMask uint16
-	// Destination port
-	DstPort        uint16
-	DstPortMask    uint16
-	IcmpTypeEnable bool
-	IcmpType       uint8
+	DstPort     uint16
+	DstPortMask uint16
+
+	// ICMP/ICMPv6
+	IcmpType mo.Option[uint8]
 }
 
-func (r *Matcher) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+type TupleMatcher struct {
+	ID string
+	IPTuple
+}
+
+func (r *TupleMatcher) GetID() string {
+	return r.ID
+}
+
+func (r *TupleMatcher) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 	return r.matchIPTuple(&flow.Forward) || r.matchIPTuple(&flow.Reverse)
 }
 
-func (r *Matcher) matchIPTuple(tuple *netlink.IPTuple) bool {
-	if r.IPProtocol != 0 && r.IPProtocol != tuple.Protocol {
+func (r *TupleMatcher) matchIPTuple(tuple *netlink.IPTuple) bool {
+	return matchTuple(&r.IPTuple, r.IPFamily, tuple)
+}
+
+func matchTuple(m *IPTuple, flowFamily uint8, tuple *netlink.IPTuple) bool {
+	if tuple == nil {
+		return false
+	}
+	if m.IPFamily != 0 && m.IPFamily != flowFamily {
+		return false
+	}
+	if m.IPProtocol != 0 && m.IPProtocol != tuple.Protocol {
 		return false
 	}
 	switch tuple.Protocol {
 	case unix.IPPROTO_TCP, unix.IPPROTO_UDP:
-		if r.SrcPort != 0 && !matchPort(r.SrcPortMask, r.SrcPort, tuple.SrcPort) {
+		if m.SrcPort != 0 && !matchPort(m.SrcPortMask, m.SrcPort, tuple.SrcPort) {
 			return false
 		}
-		if r.DstPort != 0 && !matchPort(r.DstPortMask, r.DstPort, tuple.DstPort) {
+		if m.DstPort != 0 && !matchPort(m.DstPortMask, m.DstPort, tuple.DstPort) {
 			return false
 		}
 	case unix.IPPROTO_ICMP, unix.IPPROTO_ICMPV6:
-		if r.IcmpTypeEnable && r.IcmpType != tuple.ICMPType {
+		if t, ok := m.IcmpType.Get(); ok && t != tuple.ICMPType {
+			return false
+		}
+		if m.SrcPort != 0 || m.DstPort != 0 {
 			return false
 		}
 	}
-	if !matchIP(r.SrcIP, [16]byte(tuple.SrcIP), r.SrcIPPrefixLen) {
+	if !matchIP(m.SrcIP, netIPTo16(tuple.SrcIP), m.SrcIPPrefixLen) {
 		return false
 	}
-	if !matchIP(r.DstIP, [16]byte(tuple.DstIP), r.DstIPPrefixLen) {
+	if !matchIP(m.DstIP, netIPTo16(tuple.DstIP), m.DstIPPrefixLen) {
 		return false
 	}
 
+	return true
+}
+
+func netIPTo16(ip net.IP) [16]byte {
+	if v4 := ip.To4(); v4 != nil {
+		var out [16]byte
+		out[10] = 0xff
+		out[11] = 0xff
+		copy(out[12:], v4)
+		return out
+	}
+	return [16]byte(ip.To16())
+}
+
+func (r *FlowMatcher) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if r.IPFamily != 0 && r.IPFamily != flow.FamilyType {
+		return false
+	}
+	if r.IPProtocol != 0 && r.IPProtocol != flow.Forward.Protocol {
+		return false
+	}
+	if flow.Reverse.Protocol != 0 && r.IPProtocol != 0 && r.IPProtocol != flow.Reverse.Protocol {
+		return false
+	}
+	if !matchTuple(&r.Src, flow.FamilyType, &flow.Forward) {
+		return false
+	}
+	if !matchTuple(&r.Dst, flow.FamilyType, &flow.Reverse) {
+		return false
+	}
 	return true
 }
 
@@ -124,7 +181,7 @@ func matchPort(mask, port1, port2 uint16) bool {
 }
 
 //nolint:gocritic
-func CookMatcherBatch(matchers []Matcher) MatcherBatch {
+func CookTupleMatcherBatch(matchers []TupleMatcher) TupleMatcherBatch {
 	matcherIDs := make([]string, len(matchers))
 
 	exactIPMatchers := make(map[[16]byte]*MatcherNodeValue, len(matchers)/2)
@@ -172,27 +229,27 @@ func CookMatcherBatch(matchers []Matcher) MatcherBatch {
 		switch matchers[i].IPProtocol {
 		case unix.IPPROTO_TCP:
 			if value.TCPMatchers == nil {
-				value.TCPMatchers = make([]Matcher, 0, 4)
+				value.TCPMatchers = make([]TupleMatcher, 0, 4)
 			}
 			value.TCPMatchers = append(value.TCPMatchers, matchers[i])
 		case unix.IPPROTO_UDP:
 			if value.UDPMatchers == nil {
-				value.UDPMatchers = make([]Matcher, 0, 4)
+				value.UDPMatchers = make([]TupleMatcher, 0, 4)
 			}
 			value.UDPMatchers = append(value.UDPMatchers, matchers[i])
 		case unix.IPPROTO_ICMP, unix.IPPROTO_ICMPV6:
 			if value.ICMPMatchers == nil {
-				value.ICMPMatchers = make([]Matcher, 0, 4)
+				value.ICMPMatchers = make([]TupleMatcher, 0, 4)
 			}
 			value.ICMPMatchers = append(value.ICMPMatchers, matchers[i])
 		default:
 			if value.OtherMatchers == nil {
-				value.OtherMatchers = make([]Matcher, 0, 4)
+				value.OtherMatchers = make([]TupleMatcher, 0, 4)
 			}
 			value.OtherMatchers = append(value.OtherMatchers, matchers[i])
 		}
 	}
-	return MatcherBatch{
+	return TupleMatcherBatch{
 		IDs:              matcherIDs,
 		ExactIPMatchers:  exactIPMatchers,
 		PrefixIPMatchers: prefixIPMatchers,
@@ -200,10 +257,10 @@ func CookMatcherBatch(matchers []Matcher) MatcherBatch {
 	}
 }
 
-// MatcherBatch batches policy matchers for matching conntrack flows.
+// TupleMatcherBatch batches policy matchers for matching conntrack flows.
 // Usually the dst IP is the server IP and changes less often than the src IP,
 // so we check dst matchers before src matchers.
-type MatcherBatch struct {
+type TupleMatcherBatch struct {
 	IDs []string // for logging
 
 	// Fast lookup for matchers with prefix length 128 (exact IP, or /32 for IPv4).
@@ -216,16 +273,16 @@ type MatcherBatch struct {
 }
 
 type MatcherNodeValue struct {
-	HasMatchers   bool      // all matchers are nil
-	TCPMatchers   []Matcher // matching TCP protocol
-	UDPMatchers   []Matcher // matching UDP protocol
-	ICMPMatchers  []Matcher // matching ICMP protocol
-	OtherMatchers []Matcher // matching other protocols or any protocol
+	HasMatchers   bool           // all matchers are nil
+	TCPMatchers   []TupleMatcher // matching TCP protocol
+	UDPMatchers   []TupleMatcher // matching UDP protocol
+	ICMPMatchers  []TupleMatcher // matching ICMP protocol
+	OtherMatchers []TupleMatcher // matching other protocols or any protocol
 }
 
 var MatcherNodeValueAllocator = utils.NewSlabBinaryTrieNodeAllocator[MatcherNodeValue](0)
 
-func (bm *MatcherBatch) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+func (bm *TupleMatcherBatch) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 	// Convert IPv4 to IPv4-mapped format. Callers can assume IP length is 16 after this.
 	oldSrcIP := flow.Forward.SrcIP
 	oldDstIP := flow.Forward.DstIP
@@ -262,7 +319,7 @@ func (bm *MatcherBatch) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 	return matched
 }
 
-func (bm *MatcherBatch) matchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+func (bm *TupleMatcherBatch) matchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 	// not everoute conntrack flows, skip
 	if flow.Zone < constants.CTZoneForPolicyMin || flow.Zone > constants.CTZoneForPolicyMax {
 		return false
@@ -281,7 +338,7 @@ func (bm *MatcherBatch) matchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 	for _, ip := range ips {
 		matcher, ok := bm.ExactIPMatchers[ip]
 		if ok && matcher != nil {
-			if matchConntrackFlow(matcher, flow) {
+			if matcher.matchConntrackFlow(flow) {
 				return true
 			}
 		}
@@ -292,37 +349,37 @@ func (bm *MatcherBatch) matchConntrackFlow(flow *netlink.ConntrackFlow) bool {
 			return true
 		}
 	}
-	return matchConntrackFlow(bm.AnyIPMatchers, flow)
+	return bm.AnyIPMatchers.matchConntrackFlow(flow)
 }
 
-func matchConntrackFlow(matcher *MatcherNodeValue, flow *netlink.ConntrackFlow) bool {
-	if !matcher.HasMatchers {
+func (m *MatcherNodeValue) matchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if !m.HasMatchers {
 		return false
 	}
 	switch flow.Forward.Protocol {
 	case unix.IPPROTO_TCP:
-		matchers := matcher.TCPMatchers
+		matchers := m.TCPMatchers
 		for i := range matchers {
 			if matchers[i].MatchConntrackFlow(flow) {
 				return true
 			}
 		}
 	case unix.IPPROTO_UDP:
-		matchers := matcher.UDPMatchers
+		matchers := m.UDPMatchers
 		for i := range matchers {
 			if matchers[i].MatchConntrackFlow(flow) {
 				return true
 			}
 		}
 	case unix.IPPROTO_ICMP, unix.IPPROTO_ICMPV6:
-		matchers := matcher.ICMPMatchers
+		matchers := m.ICMPMatchers
 		for i := range matchers {
 			if matchers[i].MatchConntrackFlow(flow) {
 				return true
 			}
 		}
 	}
-	matchers := matcher.OtherMatchers // other protocols, or any protocol when IPProtocol is 0
+	matchers := m.OtherMatchers // other protocols, or any protocol when IPProtocol is 0
 	for i := range matchers {
 		if matchers[i].MatchConntrackFlow(flow) {
 			return true
@@ -381,4 +438,18 @@ func matchConntrackFlowWithTrie(
 	}
 	utils.VisitBinaryTriePrefixes(node, ip[:], 128, visitor)
 	return matched
+}
+
+type FlowMatcher struct {
+	ID  string
+	Src IPTuple
+	Dst IPTuple
+	// IP family
+	IPFamily uint8
+	// IP protocol number
+	IPProtocol uint8
+}
+
+func (r *FlowMatcher) GetID() string {
+	return r.ID
 }

--- a/pkg/agent/datapath/conntrack/match_test.go
+++ b/pkg/agent/datapath/conntrack/match_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/samber/mo"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -389,17 +390,19 @@ func makeFlowGeneric(zone uint16, family uint8, srcIP, dstIP string, proto uint8
 }
 
 func TestMatcher_MatchConntrackFlow(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		SrcPort:        12345,
-		SrcPortMask:    0xffff,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			SrcPort:        12345,
+			SrcPortMask:    0xffff,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 12345, 80, unix.IPPROTO_TCP)
@@ -433,15 +436,17 @@ func TestMatcher_MatchConntrackFlow(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_Subnet(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.0.0"),
-		SrcIPPrefixLen: toIpv6PrefixLen(24),
-		DstIP:          ipTo16("10.0.0.0"),
-		DstIPPrefixLen: toIpv6PrefixLen(16),
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        443,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.0.0"),
+			SrcIPPrefixLen: toIpv6PrefixLen(24),
+			DstIP:          ipTo16("10.0.0.0"),
+			DstIPPrefixLen: toIpv6PrefixLen(16),
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        443,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	// src in 192.168.0.0/24, dst in 10.0.0.0/16
@@ -464,14 +469,16 @@ func TestMatcher_MatchConntrackFlow_Subnet(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_OnlySrcIP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIPPrefixLen: 0,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIPPrefixLen: 0,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "1.2.3.4", 12345, 80, unix.IPPROTO_TCP)
@@ -486,14 +493,16 @@ func TestMatcher_MatchConntrackFlow_OnlySrcIP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_OnlyDstIP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIPPrefixLen: 0,
-		DstIP:          ipTo16("10.0.0.1"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        22,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIPPrefixLen: 0,
+			DstIP:          ipTo16("10.0.0.1"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        22,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "10.0.0.1", 12345, 22, unix.IPPROTO_TCP)
@@ -508,17 +517,19 @@ func TestMatcher_MatchConntrackFlow_OnlyDstIP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_PortMask(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		SrcPort:        1024,
-		SrcPortMask:    0xfff0, // match 1024-1039
-		DstPort:        80,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			SrcPort:        1024,
+			SrcPortMask:    0xfff0, // match 1024-1039
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 1025, 80, unix.IPPROTO_TCP)
@@ -533,15 +544,17 @@ func TestMatcher_MatchConntrackFlow_PortMask(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_AnyProtocol(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     0,
-		SrcPort:        0,
-		DstPort:        0,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     0,
+			SrcPort:        0,
+			DstPort:        0,
+		},
 	}
 
 	// should match TCP
@@ -563,32 +576,62 @@ func TestMatcher_MatchConntrackFlow_AnyProtocol(t *testing.T) {
 	}
 }
 
-func TestCookMatcherBatch(t *testing.T) {
-	matchers := []Matcher{
-		{
-			ID:             "r1",
-			DstIP:          ipTo16("10.0.0.1"),
-			DstIPPrefixLen: toIpv6PrefixLen(32),
-			IPProtocol:     unix.IPPROTO_TCP,
+func TestMatcher_MatchConntrackFlow_PortFilterWithoutProtocolDoesNotMatchICMP(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
 			DstPort:        80,
 			DstPortMask:    0xffff,
 		},
+	}
+
+	flowTCP := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 12345, 80, unix.IPPROTO_TCP)
+	if !matcher.MatchConntrackFlow(flowTCP) {
+		t.Error("expected port-filter matcher without protocol to match TCP")
+	}
+
+	flowICMP := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 0, unix.IPPROTO_ICMP)
+	if matcher.MatchConntrackFlow(flowICMP) {
+		t.Error("expected port-filter matcher without protocol to NOT match ICMP")
+	}
+}
+
+func TestCookTupleMatcherBatch(t *testing.T) {
+	matchers := []TupleMatcher{
 		{
-			ID:             "r2",
-			SrcIP:          ipTo16("10.0.0.2"),
-			SrcIPPrefixLen: toIpv6PrefixLen(32),
-			IPProtocol:     unix.IPPROTO_UDP,
-			SrcPort:        53,
-			SrcPortMask:    0xffff,
+			ID: "r1",
+			IPTuple: IPTuple{
+				DstIP:          ipTo16("10.0.0.1"),
+				DstIPPrefixLen: toIpv6PrefixLen(32),
+				IPProtocol:     unix.IPPROTO_TCP,
+				DstPort:        80,
+				DstPortMask:    0xffff,
+			},
 		},
 		{
-			ID:             "r3",
-			DstIP:          ipTo16("192.168.0.0"),
-			DstIPPrefixLen: toIpv6PrefixLen(24),
-			IPProtocol:     unix.IPPROTO_TCP,
+			ID: "r2",
+			IPTuple: IPTuple{
+				SrcIP:          ipTo16("10.0.0.2"),
+				SrcIPPrefixLen: toIpv6PrefixLen(32),
+				IPProtocol:     unix.IPPROTO_UDP,
+				SrcPort:        53,
+				SrcPortMask:    0xffff,
+			},
+		},
+		{
+			ID: "r3",
+			IPTuple: IPTuple{
+				DstIP:          ipTo16("192.168.0.0"),
+				DstIPPrefixLen: toIpv6PrefixLen(24),
+				IPProtocol:     unix.IPPROTO_TCP,
+			},
 		},
 	}
-	bm := CookMatcherBatch(matchers)
+	bm := CookTupleMatcherBatch(matchers)
 	if len(bm.IDs) != 3 {
 		t.Errorf("IDs len = %d, want 3", len(bm.IDs))
 	}
@@ -611,7 +654,7 @@ func TestCookMatcherBatch(t *testing.T) {
 }
 
 func TestCookMatcherBatch_Empty(t *testing.T) {
-	bm := CookMatcherBatch(nil)
+	bm := CookTupleMatcherBatch(nil)
 	if bm.IDs == nil {
 		t.Error("IDs should not be nil (empty slice)")
 	}
@@ -630,41 +673,44 @@ func TestCookMatcherBatch_Empty(t *testing.T) {
 }
 
 func TestCookMatcherBatch_MultiProtocol(t *testing.T) {
-	matchers := []Matcher{
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_TCP, ID: "tcp"},
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_UDP, ID: "udp"},
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_ICMP, ID: "icmp"},
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: 50, ID: "esp"}, // OtherMatchers
+	matchers := []TupleMatcher{
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_TCP}, ID: "tcp"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_UDP}, ID: "udp"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_ICMP}, ID: "icmp"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: 50}, ID: "esp"}, // OtherMatchers
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: 50}, ID: "esp"}, // OtherMatchers
 	}
-	bm := CookMatcherBatch(matchers)
-	if len(bm.IDs) != 4 {
-		t.Errorf("IDs len = %d, want 4", len(bm.IDs))
+	bm := CookTupleMatcherBatch(matchers)
+	if len(bm.IDs) != 5 {
+		t.Errorf("IDs len = %d, want 5", len(bm.IDs))
 	}
 	if !bm.AnyIPMatchers.HasMatchers {
 		t.Error("AnyIPMatchers.HasMatchers should be true")
 	}
 	if len(bm.AnyIPMatchers.TCPMatchers) != 1 || len(bm.AnyIPMatchers.UDPMatchers) != 1 ||
-		len(bm.AnyIPMatchers.ICMPMatchers) != 1 || len(bm.AnyIPMatchers.OtherMatchers) != 1 {
-		t.Errorf("AnyIPMatchers should have 1 matcher each: Tcp=%d Udp=%d Icmp=%d Other=%d",
+		len(bm.AnyIPMatchers.ICMPMatchers) != 1 || len(bm.AnyIPMatchers.OtherMatchers) != 2 {
+		t.Errorf("AnyIPMatchers should keep duplicates: Tcp=%d Udp=%d Icmp=%d Other=%d",
 			len(bm.AnyIPMatchers.TCPMatchers), len(bm.AnyIPMatchers.UDPMatchers),
 			len(bm.AnyIPMatchers.ICMPMatchers), len(bm.AnyIPMatchers.OtherMatchers))
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.10.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.10.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		SrcPort:        1000,
-		SrcPortMask:    0xffff,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.10.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.10.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			SrcPort:        1000,
+			SrcPortMask:    0xffff,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.10.1", "192.168.10.2", 1000, 80, unix.IPPROTO_TCP)
 	if !bm.MatchConntrackFlow(flow) {
@@ -682,18 +728,20 @@ func TestMatcherBatch_MatchConntrackFlow(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_ZoneBoundary(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow_ZoneBoundary(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	// zone at min - should match
 	flowMinZone := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 80, unix.IPPROTO_TCP)
@@ -720,18 +768,20 @@ func TestMatcherBatch_MatchConntrackFlow_ZoneBoundary(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_Prefix(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("10.0.0.0"),
-		SrcIPPrefixLen: toIpv6PrefixLen(24),
-		DstIP:          ipTo16("192.168.0.0"),
-		DstIPPrefixLen: toIpv6PrefixLen(24),
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow_Prefix(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("10.0.0.0"),
+			SrcIPPrefixLen: toIpv6PrefixLen(24),
+			DstIP:          ipTo16("192.168.0.0"),
+			DstIPPrefixLen: toIpv6PrefixLen(24),
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "10.0.0.50", "192.168.0.100", 12345, 80, unix.IPPROTO_TCP)
 	if !bm.MatchConntrackFlow(flowMatch) {
@@ -744,18 +794,20 @@ func TestMatcherBatch_MatchConntrackFlow_Prefix(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_IPv4Conversion(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow_IPv4Conversion(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	// flow with 4-byte IPv4 - MatchConntrackFlow converts to IPv4-mapped internally
 	flow := &netlink.ConntrackFlow{
@@ -782,30 +834,34 @@ func TestMatcherBatch_MatchConntrackFlow_IPv4Conversion(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_Multiple(t *testing.T) {
-	matchers := []Matcher{
+func TestTupleMatcherBatch_MatchConntrackFlow_Multiple(t *testing.T) {
+	matchers := []TupleMatcher{
 		{
-			ID:             "r1",
-			SrcIP:          ipTo16("192.168.1.1"),
-			SrcIPPrefixLen: 128,
-			DstIP:          ipTo16("192.168.1.2"),
-			DstIPPrefixLen: 128,
-			IPProtocol:     unix.IPPROTO_TCP,
-			DstPort:        80,
-			DstPortMask:    0xffff,
+			ID: "r1",
+			IPTuple: IPTuple{
+				SrcIP:          ipTo16("192.168.1.1"),
+				SrcIPPrefixLen: 128,
+				DstIP:          ipTo16("192.168.1.2"),
+				DstIPPrefixLen: 128,
+				IPProtocol:     unix.IPPROTO_TCP,
+				DstPort:        80,
+				DstPortMask:    0xffff,
+			},
 		},
 		{
-			ID:             "r2",
-			SrcIP:          ipTo16("192.168.1.3"),
-			SrcIPPrefixLen: 128,
-			DstIP:          ipTo16("192.168.1.4"),
-			DstIPPrefixLen: 128,
-			IPProtocol:     unix.IPPROTO_TCP,
-			DstPort:        443,
-			DstPortMask:    0xffff,
+			ID: "r2",
+			IPTuple: IPTuple{
+				SrcIP:          ipTo16("192.168.1.3"),
+				SrcIPPrefixLen: 128,
+				DstIP:          ipTo16("192.168.1.4"),
+				DstIPPrefixLen: 128,
+				IPProtocol:     unix.IPPROTO_TCP,
+				DstPort:        443,
+				DstPortMask:    0xffff,
+			},
 		},
 	}
-	bm := CookMatcherBatch(matchers)
+	bm := CookTupleMatcherBatch(matchers)
 
 	// first matcher matches
 	flow1 := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 80, unix.IPPROTO_TCP)
@@ -826,16 +882,18 @@ func TestMatcherBatch_MatchConntrackFlow_Multiple(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_AnyIP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIPPrefixLen: 0,
-		DstIPPrefixLen: 0,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        443,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow_AnyIP(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIPPrefixLen: 0,
+			DstIPPrefixLen: 0,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        443,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "1.2.3.4", "5.6.7.8", 12345, 443, unix.IPPROTO_TCP)
 	if !bm.MatchConntrackFlow(flow) {
@@ -849,15 +907,17 @@ func TestMatcherBatch_MatchConntrackFlow_AnyIP(t *testing.T) {
 	}
 
 	// UDP any-IP matcher
-	matcherUDP := Matcher{
-		ID:             "r2",
-		SrcIPPrefixLen: 0,
-		DstIPPrefixLen: 0,
-		IPProtocol:     unix.IPPROTO_UDP,
-		DstPort:        53,
-		DstPortMask:    0xffff,
+	matcherUDP := TupleMatcher{
+		ID: "r2",
+		IPTuple: IPTuple{
+			SrcIPPrefixLen: 0,
+			DstIPPrefixLen: 0,
+			IPProtocol:     unix.IPPROTO_UDP,
+			DstPort:        53,
+			DstPortMask:    0xffff,
+		},
 	}
-	bmUDP := CookMatcherBatch([]Matcher{matcherUDP})
+	bmUDP := CookTupleMatcherBatch([]TupleMatcher{matcherUDP})
 	flowUDP := makeIPv4Flow(constants.CTZoneForPolicyMin, "8.8.8.8", "1.1.1.1", 54321, 53, unix.IPPROTO_UDP)
 	if !bmUDP.MatchConntrackFlow(flowUDP) {
 		t.Error("expected any-IP UDP matcher to match flow")
@@ -865,15 +925,16 @@ func TestMatcherBatch_MatchConntrackFlow_AnyIP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_ICMP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_ICMP,
-		IcmpTypeEnable: true,
-		IcmpType:       8,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_ICMP,
+			IcmpType:       mo.Some(uint8(8)),
+		},
 	}
 
 	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 0, unix.IPPROTO_ICMP)
@@ -893,14 +954,16 @@ func TestMatcher_MatchConntrackFlow_ICMP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_ICMP_AnyType(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_ICMP,
-		IcmpTypeEnable: false,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_ICMP,
+			IcmpType:       mo.None[uint8](),
+		},
 	}
 
 	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 0, unix.IPPROTO_ICMP)
@@ -917,18 +980,19 @@ func TestMatcher_MatchConntrackFlow_ICMP_AnyType(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_ICMP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_ICMP,
-		IcmpTypeEnable: true,
-		IcmpType:       8,
+func TestTupleMatcherBatch_MatchConntrackFlow_ICMP(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_ICMP,
+			IcmpType:       mo.Some(uint8(8)),
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 0, 0, unix.IPPROTO_ICMP)
 	flow.Forward.ICMPType = 8
@@ -938,17 +1002,19 @@ func TestMatcherBatch_MatchConntrackFlow_ICMP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_UDP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_UDP,
-		SrcPort:        54321,
-		SrcPortMask:    0xffff,
-		DstPort:        53,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_UDP,
+			SrcPort:        54321,
+			SrcPortMask:    0xffff,
+			DstPort:        53,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 54321, 53, unix.IPPROTO_UDP)
@@ -968,15 +1034,17 @@ func TestMatcher_MatchConntrackFlow_UDP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_IPv6_TCP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("2001:db8::1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("2001:db8::2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        443,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("2001:db8::1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("2001:db8::2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        443,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv6Flow(constants.CTZoneForPolicyMin, "2001:db8::1", "2001:db8::2", 12345, 443, unix.IPPROTO_TCP)
@@ -991,15 +1059,17 @@ func TestMatcher_MatchConntrackFlow_IPv6_TCP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_IPv6_UDP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("2001:db8::1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("2001:db8::2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_UDP,
-		DstPort:        53,
-		DstPortMask:    0xffff,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("2001:db8::1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("2001:db8::2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_UDP,
+			DstPort:        53,
+			DstPortMask:    0xffff,
+		},
 	}
 
 	flowMatch := makeIPv6Flow(constants.CTZoneForPolicyMin, "2001:db8::1", "2001:db8::2", 54321, 53, unix.IPPROTO_UDP)
@@ -1009,15 +1079,16 @@ func TestMatcher_MatchConntrackFlow_IPv6_UDP(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_IPv6_ICMPv6(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("2001:db8::1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("2001:db8::2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_ICMPV6,
-		IcmpTypeEnable: true,
-		IcmpType:       128, // ICMPv6 echo request
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("2001:db8::1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("2001:db8::2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_ICMPV6,
+			IcmpType:       mo.Some(uint8(128)), // ICMPv6 echo request
+		},
 	}
 
 	flow := makeFlowWithICMP(constants.CTZoneForPolicyMin, unix.AF_INET6, "2001:db8::1", "2001:db8::2", 128, 0, 1, unix.IPPROTO_ICMPV6)
@@ -1032,13 +1103,15 @@ func TestMatcher_MatchConntrackFlow_IPv6_ICMPv6(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_GRE(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_GRE,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_GRE,
+		},
 	}
 
 	flowMatch := makeFlowGeneric(constants.CTZoneForPolicyMin, unix.AF_INET, "192.168.1.1", "192.168.1.2", unix.IPPROTO_GRE)
@@ -1053,13 +1126,15 @@ func TestMatcher_MatchConntrackFlow_GRE(t *testing.T) {
 }
 
 func TestMatcher_MatchConntrackFlow_IPIP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("10.0.0.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("10.0.0.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_IPIP,
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("10.0.0.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("10.0.0.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_IPIP,
+		},
 	}
 
 	flowMatch := makeFlowGeneric(constants.CTZoneForPolicyMin, unix.AF_INET, "10.0.0.1", "10.0.0.2", unix.IPPROTO_IPIP)
@@ -1073,16 +1148,18 @@ func TestMatcher_MatchConntrackFlow_IPIP(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_GRE(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("192.168.1.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("192.168.1.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_GRE,
+func TestTupleMatcherBatch_MatchConntrackFlow_GRE(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_GRE,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeFlowGeneric(constants.CTZoneForPolicyMin, unix.AF_INET, "192.168.1.1", "192.168.1.2", unix.IPPROTO_GRE)
 	if !bm.MatchConntrackFlow(flow) {
@@ -1090,16 +1167,18 @@ func TestMatcherBatch_MatchConntrackFlow_GRE(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_IPIP(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("10.0.0.1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("10.0.0.2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_IPIP,
+func TestTupleMatcherBatch_MatchConntrackFlow_IPIP(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("10.0.0.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("10.0.0.2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_IPIP,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeFlowGeneric(constants.CTZoneForPolicyMin, unix.AF_INET, "10.0.0.1", "10.0.0.2", unix.IPPROTO_IPIP)
 	if !bm.MatchConntrackFlow(flow) {
@@ -1107,18 +1186,20 @@ func TestMatcherBatch_MatchConntrackFlow_IPIP(t *testing.T) {
 	}
 }
 
-func TestMatcherBatch_MatchConntrackFlow_IPv6(t *testing.T) {
-	matcher := Matcher{
-		ID:             "r1",
-		SrcIP:          ipTo16("2001:db8::1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("2001:db8::2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_TCP,
-		DstPort:        80,
-		DstPortMask:    0xffff,
+func TestTupleMatcherBatch_MatchConntrackFlow_IPv6(t *testing.T) {
+	matcher := TupleMatcher{
+		ID: "r1",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("2001:db8::1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("2001:db8::2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_TCP,
+			DstPort:        80,
+			DstPortMask:    0xffff,
+		},
 	}
-	bm := CookMatcherBatch([]Matcher{matcher})
+	bm := CookTupleMatcherBatch([]TupleMatcher{matcher})
 
 	flow := makeIPv6Flow(constants.CTZoneForPolicyMin, "2001:db8::1", "2001:db8::2", 12345, 80, unix.IPPROTO_TCP)
 	if !bm.MatchConntrackFlow(flow) {
@@ -1126,36 +1207,71 @@ func TestMatcherBatch_MatchConntrackFlow_IPv6(t *testing.T) {
 	}
 
 	flowICMPv6 := makeFlowWithICMP(constants.CTZoneForPolicyMin, unix.AF_INET6, "2001:db8::1", "2001:db8::2", 128, 0, 1, unix.IPPROTO_ICMPV6)
-	matcherICMPv6 := Matcher{
-		ID:             "r2",
-		SrcIP:          ipTo16("2001:db8::1"),
-		SrcIPPrefixLen: 128,
-		DstIP:          ipTo16("2001:db8::2"),
-		DstIPPrefixLen: 128,
-		IPProtocol:     unix.IPPROTO_ICMPV6,
-		IcmpTypeEnable: true,
-		IcmpType:       128,
+	matcherICMPv6 := TupleMatcher{
+		ID: "r2",
+		IPTuple: IPTuple{
+			SrcIP:          ipTo16("2001:db8::1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("2001:db8::2"),
+			DstIPPrefixLen: 128,
+			IPProtocol:     unix.IPPROTO_ICMPV6,
+			IcmpType:       mo.Some(uint8(128)),
+		},
 	}
-	bmICMPv6 := CookMatcherBatch([]Matcher{matcherICMPv6})
+	bmICMPv6 := CookTupleMatcherBatch([]TupleMatcher{matcherICMPv6})
 	if !bmICMPv6.MatchConntrackFlow(flowICMPv6) {
 		t.Error("expected batch matcher to match IPv6 ICMPv6 flow")
 	}
 }
 
-func TestCookMatcherBatch_ICMPv6AndGRE(t *testing.T) {
-	matchers := []Matcher{
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_ICMPV6, ID: "icmpv6"},
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_GRE, ID: "gre"},
-		{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_IPIP, ID: "ipip"},
+func TestFlowMatcher_MatchConntrackFlow(t *testing.T) {
+	matcher := FlowMatcher{
+		IPFamily:   unix.AF_INET,
+		IPProtocol: unix.IPPROTO_TCP,
+		Src: IPTuple{
+			SrcIP:          ipTo16("192.168.1.1"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.2"),
+			DstIPPrefixLen: 128,
+			SrcPort:        12345,
+			DstPort:        80,
+		},
+		Dst: IPTuple{
+			SrcIP:          ipTo16("192.168.1.2"),
+			SrcIPPrefixLen: 128,
+			DstIP:          ipTo16("192.168.1.1"),
+			DstIPPrefixLen: 128,
+			SrcPort:        80,
+			DstPort:        12345,
+		},
 	}
-	bm := CookMatcherBatch(matchers)
-	if len(bm.IDs) != 3 {
-		t.Errorf("IDs len = %d, want 3", len(bm.IDs))
+
+	flow := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.1", "192.168.1.2", 12345, 80, unix.IPPROTO_TCP)
+	if !matcher.MatchConntrackFlow(flow) {
+		t.Fatalf("expected flow matcher to match forward/reply tuples")
+	}
+
+	reversed := makeIPv4Flow(constants.CTZoneForPolicyMin, "192.168.1.2", "192.168.1.1", 80, 12345, unix.IPPROTO_TCP)
+	if matcher.MatchConntrackFlow(reversed) {
+		t.Fatalf("expected flow matcher not to match reversed tuples")
+	}
+}
+
+func TestCookMatcherBatch_ICMPv6AndGRE(t *testing.T) {
+	matchers := []TupleMatcher{
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_ICMPV6}, ID: "icmpv6"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_GRE}, ID: "gre"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_IPIP}, ID: "ipip"},
+		{IPTuple: IPTuple{SrcIPPrefixLen: 0, DstIPPrefixLen: 0, IPProtocol: unix.IPPROTO_IPIP}, ID: "ipip"},
+	}
+	bm := CookTupleMatcherBatch(matchers)
+	if len(bm.IDs) != 4 {
+		t.Errorf("IDs len = %d, want 4", len(bm.IDs))
 	}
 	if len(bm.AnyIPMatchers.ICMPMatchers) != 1 {
 		t.Errorf("ICMPMatchers len = %d, want 1 (ICMPv6)", len(bm.AnyIPMatchers.ICMPMatchers))
 	}
-	if len(bm.AnyIPMatchers.OtherMatchers) != 2 {
-		t.Errorf("OtherMatchers len = %d, want 2 (GRE, IPIP)", len(bm.AnyIPMatchers.OtherMatchers))
+	if len(bm.AnyIPMatchers.OtherMatchers) != 3 {
+		t.Errorf("OtherMatchers len = %d, want 3 (GRE, IPIP, IPIP)", len(bm.AnyIPMatchers.OtherMatchers))
 	}
 }

--- a/pkg/agent/datapath/rule.go
+++ b/pkg/agent/datapath/rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/contiv/ofnet/ofctrl"
+	"github.com/samber/mo"
 
 	"github.com/everoute/everoute/pkg/agent/datapath/conntrack"
 	"github.com/everoute/everoute/pkg/utils"
@@ -54,22 +55,27 @@ func (r *EveroutePolicyRule) DeepCopy() *EveroutePolicyRule {
 	}
 }
 
-func (r *EveroutePolicyRule) ToMatcher() (conntrack.Matcher, error) {
-	res := conntrack.Matcher{
-		ID:             r.RuleID,
-		IPProtocol:     r.IPProtocol,
-		IPFamily:       r.IPFamily,
-		SrcPort:        r.SrcPort,
-		SrcPortMask:    r.SrcPortMask,
-		DstPort:        r.DstPort,
-		DstPortMask:    r.DstPortMask,
-		IcmpTypeEnable: r.IcmpTypeEnable,
-		IcmpType:       r.IcmpType,
+func (r *EveroutePolicyRule) ToMatcher() (conntrack.TupleMatcher, error) {
+	icmpType := mo.Option[uint8]{}
+	if r.IcmpTypeEnable {
+		icmpType = mo.Some(r.IcmpType)
+	}
+	res := conntrack.TupleMatcher{
+		ID: r.RuleID,
+		IPTuple: conntrack.IPTuple{
+			IPProtocol:  r.IPProtocol,
+			IPFamily:    r.IPFamily,
+			SrcPort:     r.SrcPort,
+			SrcPortMask: r.SrcPortMask,
+			DstPort:     r.DstPort,
+			DstPortMask: r.DstPortMask,
+			IcmpType:    icmpType,
+		},
 	}
 	if r.SrcIPAddr != "" {
 		ip, prefixLen, ok := utils.ParseIPStringToIPAndSubnetPrefixLen(r.SrcIPAddr)
 		if !ok {
-			return conntrack.Matcher{}, fmt.Errorf("failed to parse src ip: %s", r.SrcIPAddr)
+			return conntrack.TupleMatcher{}, fmt.Errorf("failed to parse src ip: %s", r.SrcIPAddr)
 		}
 		res.SrcIP = ip.As16()
 		if prefixLen != 0 && ip.Is4() {
@@ -81,7 +87,7 @@ func (r *EveroutePolicyRule) ToMatcher() (conntrack.Matcher, error) {
 	if r.DstIPAddr != "" {
 		ip, prefixLen, ok := utils.ParseIPStringToIPAndSubnetPrefixLen(r.DstIPAddr)
 		if !ok {
-			return conntrack.Matcher{}, fmt.Errorf("failed to parse dst ip: %s", r.DstIPAddr)
+			return conntrack.TupleMatcher{}, fmt.Errorf("failed to parse dst ip: %s", r.DstIPAddr)
 		}
 		res.DstIP = ip.As16()
 		if prefixLen != 0 && ip.Is4() {

--- a/pkg/agent/datapath/rule_test.go
+++ b/pkg/agent/datapath/rule_test.go
@@ -41,7 +41,7 @@ func TestToMatcher(t *testing.T) {
 		name    string
 		src     EveroutePolicyRule
 		wantErr bool
-		check   func(t *testing.T, got conntrack.Matcher)
+		check   func(t *testing.T, got conntrack.TupleMatcher)
 	}{
 		{
 			name: "complete rule with src and dst",
@@ -59,7 +59,7 @@ func TestToMatcher(t *testing.T) {
 				IcmpType:       13,
 			},
 			wantErr: false,
-			check: func(t *testing.T, got conntrack.Matcher) {
+			check: func(t *testing.T, got conntrack.TupleMatcher) {
 				if got.ID != "rule1" || got.SrcPort != 60 || got.DstPort != 12 {
 					t.Errorf("ID/SrcPort/DstPort mismatch: got %+v", got)
 				}
@@ -96,7 +96,7 @@ func TestToMatcher(t *testing.T) {
 				IcmpType:       13,
 			},
 			wantErr: false,
-			check: func(t *testing.T, got conntrack.Matcher) {
+			check: func(t *testing.T, got conntrack.TupleMatcher) {
 				if got.SrcIPPrefixLen != 0 || got.DstIPPrefixLen != 0 {
 					t.Errorf("expect any IP (prefix 0), got Src=%d Dst=%d",
 						got.SrcIPPrefixLen, got.DstIPPrefixLen)
@@ -119,7 +119,7 @@ func TestToMatcher(t *testing.T) {
 				IcmpType:       13,
 			},
 			wantErr: false,
-			check: func(t *testing.T, got conntrack.Matcher) {
+			check: func(t *testing.T, got conntrack.TupleMatcher) {
 				expDst := ipTo16("12.1.1.4")
 				if got.DstIP != expDst {
 					t.Errorf("DstIP got %x, want %x", got.DstIP, expDst)

--- a/pkg/erctl/cmd/conntrack.go
+++ b/pkg/erctl/cmd/conntrack.go
@@ -1,0 +1,930 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	numeric "github.com/everoute/numeric-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	ctmgr "github.com/everoute/everoute/pkg/agent/datapath/conntrack"
+)
+
+const (
+	conntrackFamilyAll  = "all"
+	conntrackFamilyIPv4 = "ipv4"
+	conntrackFamilyIPv6 = "ipv6"
+	conntrackMaxUint16  = 1<<16 - 1
+)
+
+type conntrackFilterOptions struct {
+	family       string
+	protocol     string
+	zone         int
+	origSrcIP    string
+	origDstIP    string
+	origSrcPort  int
+	origDstPort  int
+	replySrcIP   string
+	replyDstIP   string
+	replySrcPort int
+	replyDstPort int
+}
+
+type conntrackDumpOptions struct {
+	matchersFile string
+	decode       bool
+}
+
+type conntrackDeleteOptions struct {
+	matchersFile string
+	all          bool
+}
+
+type conntrackMatcher struct {
+	zone        *uint16
+	flowMatcher ctmgr.FlowMatcher
+}
+
+func (m *conntrackMatcher) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if m == nil {
+		return true
+	}
+	if m.zone != nil && flow.Zone != *m.zone {
+		return false
+	}
+	return m.flowMatcher.MatchConntrackFlow(flow)
+}
+
+type conntrackMultiMatcher struct {
+	matchers []ctmgr.Matcher
+}
+
+func (m *conntrackMultiMatcher) MatchConntrackFlow(flow *netlink.ConntrackFlow) bool {
+	if m == nil {
+		return true
+	}
+	for i := range m.matchers {
+		if m.matchers[i] != nil && m.matchers[i].MatchConntrackFlow(flow) {
+			return true
+		}
+	}
+	return false
+}
+
+type conntrackRuleFile struct {
+	All  conntrackRuleFileMatcherList `toml:"all"`
+	IPv4 conntrackRuleFileMatcherList `toml:"ipv4"`
+	IPv6 conntrackRuleFileMatcherList `toml:"ipv6"`
+}
+
+type conntrackRuleFileMatcherList struct {
+	Matchers []conntrackRuleFileMatcher `toml:"matchers"`
+}
+
+type conntrackRuleFileMatcher struct {
+	Protocol string `toml:"protocol"`
+	Zone     *int   `toml:"zone"`
+
+	OrigSrcIP string `toml:"orig_src_ip"`
+	SrcIP     string `toml:"src_ip"`
+	OrigDstIP string `toml:"orig_dst_ip"`
+	DstIP     string `toml:"dst_ip"`
+
+	OrigSrcPort *int `toml:"orig_src_port"`
+	SrcPort     *int `toml:"src_port"`
+	OrigDstPort *int `toml:"orig_dst_port"`
+	DstPort     *int `toml:"dst_port"`
+
+	ReplySrcIP   string `toml:"reply_src_ip"`
+	ReplyDstIP   string `toml:"reply_dst_ip"`
+	ReplySrcPort *int   `toml:"reply_src_port"`
+	ReplyDstPort *int   `toml:"reply_dst_port"`
+}
+
+var (
+	conntrackDumpOpts   = conntrackDumpOptions{}
+	conntrackDeleteOpts = conntrackDeleteOptions{}
+)
+
+var conntrackCmd = &cobra.Command{
+	Use:   "conntrack",
+	Short: "Manage conntrack entries",
+	Long: "Manage conntrack entries.\n" +
+		"Matcher flags are accepted only after -- separators, or from --matchers-file.",
+	Example: "erctl conntrack dump -- --protocol=tcp --orig-dst-port=80\n" +
+		"erctl conntrack delete -- --zone=10 --protocol=udp --orig-dst-port=53\n" +
+		"erctl conntrack delete --all",
+}
+
+var conntrackDumpCmd = &cobra.Command{
+	Use:     "dump [-- <matcher-flags>]...",
+	Short:   "Dump conntrack entries",
+	Long:    conntrackMatcherCommandLong("Dump conntrack entries.", false),
+	Example: conntrackMatcherCommandExample("dump"),
+	Args:    cobra.ArbitraryArgs,
+	RunE: func(_ *cobra.Command, args []string) error {
+		matcher, _, err := buildConntrackMatchers(args, conntrackDumpOpts.matchersFile)
+		if err != nil {
+			return err
+		}
+
+		out, err := setOutput()
+		if err != nil {
+			return err
+		}
+		return writeConntrackFlows(out, conntrackFamiliesAll(), matcher, conntrackDumpOpts.decode)
+	},
+}
+
+var conntrackDeleteCmd = &cobra.Command{
+	Use:     "delete [--all] [-- <matcher-flags>]...",
+	Short:   "Delete conntrack entries",
+	Long:    conntrackMatcherCommandLong("Delete conntrack entries.", true),
+	Example: conntrackMatcherCommandExample("delete"),
+	Args:    cobra.ArbitraryArgs,
+	RunE: func(_ *cobra.Command, args []string) error {
+		matcher, hasFilter, err := buildConntrackMatchers(args, conntrackDeleteOpts.matchersFile)
+		if err != nil {
+			return err
+		}
+
+		if conntrackDeleteOpts.all {
+			if hasFilter {
+				return fmt.Errorf("--all cannot be used with filters, -- separators, or --matchers-file")
+			}
+
+			if err := netlink.ConntrackTableFlush(netlink.ConntrackTable); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if !hasFilter {
+			return fmt.Errorf("at least one filter, matcher after --, or --matchers-file is required")
+		}
+
+		_, err = deleteConntrackFlows(conntrackFamiliesAll(), matcher)
+		return err
+	},
+}
+
+var conntrackUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update conntrack entries (not implemented)",
+	Long:  "Update conntrack entries (not implemented).",
+	Args:  cobra.NoArgs,
+	Run: func(_ *cobra.Command, _ []string) {
+		log.Fatal("not implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(conntrackCmd)
+
+	conntrackCmd.AddCommand(conntrackDumpCmd)
+	conntrackCmd.AddCommand(conntrackDeleteCmd)
+	conntrackCmd.AddCommand(conntrackUpdateCmd)
+
+	bindConntrackMatchersFileFlag(conntrackDumpCmd, &conntrackDumpOpts.matchersFile)
+	conntrackDumpCmd.Flags().BoolVarP(&conntrackDumpOpts.decode, "decode", "D", false, "decode conntrack labels and append decoded fields")
+
+	bindConntrackMatchersFileFlag(conntrackDeleteCmd, &conntrackDeleteOpts.matchersFile)
+	conntrackDeleteCmd.Flags().BoolVar(&conntrackDeleteOpts.all, "all", false, "delete all conntrack entries")
+}
+
+func defaultConntrackFilterOptions() conntrackFilterOptions {
+	return conntrackFilterOptions{
+		family:       conntrackFamilyAll,
+		zone:         -1,
+		origSrcPort:  -1,
+		origDstPort:  -1,
+		replySrcPort: -1,
+		replyDstPort: -1,
+	}
+}
+
+func bindConntrackMatchersFileFlag(cmd *cobra.Command, matchersFile *string) {
+	cmd.Flags().StringVar(matchersFile, "matchers-file", "", "read matchers from a TOML file with [[all.matchers]], [[ipv4.matchers]], or [[ipv6.matchers]]")
+}
+
+func bindConntrackMatcherFlags(flagSet *pflag.FlagSet, options *conntrackFilterOptions, includeFamily bool) {
+	if includeFamily {
+		flagSet.StringVar(&options.family, "family", conntrackFamilyAll, "matcher family: all, ipv4, ipv6")
+	}
+	flagSet.StringVar(&options.protocol, "protocol", "", "L4 protocol name or number, such as tcp, udp, icmp")
+	flagSet.IntVar(&options.zone, "zone", -1, "conntrack zone")
+	flagSet.StringVar(&options.origSrcIP, "orig-src-ip", "", "origin tuple source IP")
+	flagSet.StringVar(&options.origSrcIP, "src-ip", "", "alias of --orig-src-ip")
+	flagSet.StringVar(&options.origDstIP, "orig-dst-ip", "", "origin tuple destination IP")
+	flagSet.StringVar(&options.origDstIP, "dst-ip", "", "alias of --orig-dst-ip")
+	flagSet.IntVar(&options.origSrcPort, "orig-src-port", -1, "origin tuple source port")
+	flagSet.IntVar(&options.origSrcPort, "src-port", -1, "alias of --orig-src-port")
+	flagSet.IntVar(&options.origDstPort, "orig-dst-port", -1, "origin tuple destination port")
+	flagSet.IntVar(&options.origDstPort, "dst-port", -1, "alias of --orig-dst-port")
+	flagSet.StringVar(&options.replySrcIP, "reply-src-ip", "", "reply source IP")
+	flagSet.StringVar(&options.replyDstIP, "reply-dst-ip", "", "reply destination IP")
+	flagSet.IntVar(&options.replySrcPort, "reply-src-port", -1, "reply source port")
+	flagSet.IntVar(&options.replyDstPort, "reply-dst-port", -1, "reply destination port")
+}
+
+func conntrackMatcherCommandLong(summary string, includeAll bool) string {
+	var b strings.Builder
+	b.WriteString(summary)
+	b.WriteString("\n\n")
+	b.WriteString("Top-level flags:\n")
+	b.WriteString("  --matchers-file\n")
+	if includeAll {
+		b.WriteString("  --all\n")
+	}
+	b.WriteString("\n")
+	b.WriteString("Command-line matcher syntax:\n")
+	b.WriteString("  erctl conntrack ")
+	if includeAll {
+		b.WriteString("delete")
+	} else {
+		b.WriteString("dump")
+	}
+	b.WriteString(" -- <matcher-1 flags> [-- <matcher-2 flags> ...]\n\n")
+	b.WriteString("Matcher semantics:\n")
+	b.WriteString("  - flags within one matcher are ANDed\n")
+	b.WriteString("  - multiple matchers are ORed\n\n")
+	b.WriteString("Matcher flags (only valid after --, or in --matchers-file):\n")
+	b.WriteString("  --family\n")
+	b.WriteString("  --zone\n")
+	b.WriteString("  --protocol\n")
+	b.WriteString("  --orig-src-ip, --src-ip\n")
+	b.WriteString("  --orig-dst-ip, --dst-ip\n")
+	b.WriteString("  --orig-src-port, --src-port\n")
+	b.WriteString("  --orig-dst-port, --dst-port\n")
+	b.WriteString("  --reply-src-ip\n")
+	b.WriteString("  --reply-dst-ip\n")
+	b.WriteString("  --reply-src-port\n")
+	b.WriteString("  --reply-dst-port\n")
+	if includeAll {
+		b.WriteString("\n")
+		b.WriteString("--all cannot be combined with matchers or --matchers-file.\n")
+	}
+	return b.String()
+}
+
+func conntrackMatcherCommandExample(subcommand string) string {
+	return fmt.Sprintf("erctl conntrack %s -- --protocol=tcp --orig-dst-port=80\n"+
+		"erctl conntrack %s -- --zone=10 --protocol=tcp --orig-dst-port=80 -- --family=ipv6 --zone=10 --protocol=udp --orig-dst-port=53\n"+
+		"erctl conntrack %s --matchers-file /path/to/conntrack-matchers.toml", subcommand, subcommand, subcommand)
+}
+
+func parseConntrackMatcherFamily(value string) (uint8, bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", conntrackFamilyAll:
+		return 0, false, nil
+	case "4", "v4", conntrackFamilyIPv4:
+		return unix.AF_INET, true, nil
+	case "6", "v6", conntrackFamilyIPv6:
+		return unix.AF_INET6, true, nil
+	default:
+		return 0, false, fmt.Errorf("unsupported conntrack family %q", value)
+	}
+}
+
+func parseConntrackProtocol(value string) (uint8, bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return 0, false, nil
+	case "tcp":
+		return 6, true, nil
+	case "udp":
+		return 17, true, nil
+	case "icmp":
+		return 1, true, nil
+	case "icmpv6":
+		return 58, true, nil
+	case "sctp":
+		return 132, true, nil
+	}
+
+	protocol, err := strconv.ParseUint(value, 10, 8)
+	if err != nil || protocol == 0 {
+		return 0, false, fmt.Errorf("unsupported conntrack protocol %q", value)
+	}
+	return uint8(protocol), true, nil
+}
+
+func parseConntrackUint16Flag(name string, value int) (uint16, bool, error) {
+	if value < 0 {
+		return 0, false, nil
+	}
+	if value > conntrackMaxUint16 {
+		return 0, false, fmt.Errorf("%s must be in range [0, %d]", name, conntrackMaxUint16)
+	}
+	return uint16(value), true, nil
+}
+
+func buildConntrackFilter(options conntrackFilterOptions, includeFamily bool, includeZone bool) (ctmgr.Matcher, bool, error) {
+	filter := &conntrackMatcher{}
+	hasFilter := false
+
+	if includeFamily {
+		hasFamily, err := applyConntrackFamilyFilter(filter, options.family)
+		if err != nil {
+			return nil, false, err
+		}
+		hasFilter = hasFilter || hasFamily
+	}
+
+	hasProtocol, err := applyConntrackProtocolFilter(filter, options.protocol)
+	if err != nil {
+		return nil, false, err
+	}
+	hasFilter = hasFilter || hasProtocol
+
+	if includeZone {
+		hasZone, err := applyConntrackZoneFilter(filter, options.zone)
+		if err != nil {
+			return nil, false, err
+		}
+		hasFilter = hasFilter || hasZone
+	}
+
+	hasIPFilter, err := applyConntrackIPFilters(filter, options)
+	if err != nil {
+		return nil, false, err
+	}
+	hasFilter = hasFilter || hasIPFilter
+
+	hasPortFilter, err := applyConntrackPortFilters(filter, options)
+	if err != nil {
+		return nil, false, err
+	}
+	hasFilter = hasFilter || hasPortFilter
+
+	if !hasFilter {
+		return nil, false, nil
+	}
+	return filter, true, nil
+}
+
+func applyConntrackFamilyFilter(filter *conntrackMatcher, familyValue string) (bool, error) {
+	family, hasFamily, err := parseConntrackMatcherFamily(familyValue)
+	if err != nil {
+		return false, err
+	}
+	if hasFamily {
+		filter.flowMatcher.IPFamily = family
+	}
+	return hasFamily, nil
+}
+
+func applyConntrackProtocolFilter(filter *conntrackMatcher, protocolValue string) (bool, error) {
+	protocol, hasProtocol, err := parseConntrackProtocol(protocolValue)
+	if err != nil {
+		return false, err
+	}
+	if hasProtocol {
+		filter.flowMatcher.IPProtocol = protocol
+	}
+	return hasProtocol, nil
+}
+
+func applyConntrackZoneFilter(filter *conntrackMatcher, zoneValue int) (bool, error) {
+	zone, hasZone, err := parseConntrackUint16Flag("--zone", zoneValue)
+	if err != nil {
+		return false, err
+	}
+	if hasZone {
+		filter.zone = &zone
+	}
+	return hasZone, nil
+}
+
+func applyConntrackIPFilter(value, flagName string, targetIP *[16]byte, targetLen *int) (bool, error) {
+	if value == "" {
+		return false, nil
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		return false, fmt.Errorf("invalid %s %q", flagName, value)
+	}
+	*targetIP = ipTo16(ip)
+	*targetLen = 128
+	return true, nil
+}
+
+func applyConntrackIPFilters(filter *conntrackMatcher, options conntrackFilterOptions) (bool, error) {
+	hasFilter := false
+	for _, ipField := range []struct {
+		value     string
+		flagName  string
+		targetIP  *[16]byte
+		targetLen *int
+	}{
+		{options.origSrcIP, "--orig-src-ip", &filter.flowMatcher.Src.SrcIP, &filter.flowMatcher.Src.SrcIPPrefixLen},
+		{options.origDstIP, "--orig-dst-ip", &filter.flowMatcher.Src.DstIP, &filter.flowMatcher.Src.DstIPPrefixLen},
+		{options.replySrcIP, "--reply-src-ip", &filter.flowMatcher.Dst.SrcIP, &filter.flowMatcher.Dst.SrcIPPrefixLen},
+		{options.replyDstIP, "--reply-dst-ip", &filter.flowMatcher.Dst.DstIP, &filter.flowMatcher.Dst.DstIPPrefixLen},
+	} {
+		applied, err := applyConntrackIPFilter(ipField.value, ipField.flagName, ipField.targetIP, ipField.targetLen)
+		if err != nil {
+			return false, err
+		}
+		hasFilter = hasFilter || applied
+	}
+	return hasFilter, nil
+}
+
+func applyConntrackPortFilter(value int, flagName string, target *uint16) (bool, error) {
+	port, hasPort, err := parseConntrackUint16Flag(flagName, value)
+	if err != nil {
+		return false, err
+	}
+	if hasPort {
+		*target = port
+	}
+	return hasPort, nil
+}
+
+func applyConntrackPortFilters(filter *conntrackMatcher, options conntrackFilterOptions) (bool, error) {
+	hasFilter := false
+	for _, portField := range []struct {
+		value    int
+		flagName string
+		target   *uint16
+	}{
+		{options.origSrcPort, "--orig-src-port", &filter.flowMatcher.Src.SrcPort},
+		{options.origDstPort, "--orig-dst-port", &filter.flowMatcher.Src.DstPort},
+		{options.replySrcPort, "--reply-src-port", &filter.flowMatcher.Dst.SrcPort},
+		{options.replyDstPort, "--reply-dst-port", &filter.flowMatcher.Dst.DstPort},
+	} {
+		applied, err := applyConntrackPortFilter(portField.value, portField.flagName, portField.target)
+		if err != nil {
+			return false, err
+		}
+		hasFilter = hasFilter || applied
+	}
+	return hasFilter, nil
+}
+
+func buildConntrackMatchers(args []string, matchersFile string) (ctmgr.Matcher, bool, error) {
+	matchers := make([]ctmgr.Matcher, 0, 4)
+	extraMatchers, err := parseConntrackMatchersFromArgs(args)
+	if err != nil {
+		return nil, false, err
+	}
+	matchers = append(matchers, extraMatchers...)
+
+	fileMatchers, err := loadConntrackMatchersFromTOMLFile(matchersFile)
+	if err != nil {
+		return nil, false, err
+	}
+	matchers = append(matchers, fileMatchers...)
+
+	return mergeConntrackMatchers(matchers)
+}
+
+func parseConntrackMatchersFromArgs(args []string) ([]ctmgr.Matcher, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	groups := splitConntrackMatcherArgs(args)
+	matchers := make([]ctmgr.Matcher, 0, len(groups))
+	for i := range groups {
+		if len(groups[i]) == 0 {
+			return nil, fmt.Errorf("empty matcher around -- separator")
+		}
+
+		options := defaultConntrackFilterOptions()
+		flagSet := pflag.NewFlagSet(fmt.Sprintf("conntrack-matcher-%d", i+1), pflag.ContinueOnError)
+		flagSet.SetOutput(io.Discard)
+		bindConntrackMatcherFlags(flagSet, &options, true)
+		if err := flagSet.Parse(groups[i]); err != nil {
+			return nil, fmt.Errorf("parse matcher %d after --: %w", i+1, err)
+		}
+		if len(flagSet.Args()) != 0 {
+			return nil, fmt.Errorf("unexpected positional args in matcher %d: %v", i+1, flagSet.Args())
+		}
+
+		matcher, hasFilter, err := buildConntrackFilter(options, true, true)
+		if err != nil {
+			return nil, fmt.Errorf("build matcher %d after --: %w", i+1, err)
+		}
+		if !hasFilter {
+			return nil, fmt.Errorf("matcher %d after -- is empty", i+1)
+		}
+		matchers = append(matchers, matcher)
+	}
+	return matchers, nil
+}
+
+func splitConntrackMatcherArgs(args []string) [][]string {
+	groups := make([][]string, 0, 1)
+	current := make([]string, 0, len(args))
+	for i := range args {
+		if args[i] == "--" {
+			groups = append(groups, current)
+			current = nil
+			continue
+		}
+		current = append(current, args[i])
+	}
+	groups = append(groups, current)
+	return groups
+}
+
+func loadConntrackMatchersFromTOMLFile(matchersFile string) ([]ctmgr.Matcher, error) {
+	if matchersFile == "" {
+		return nil, nil
+	}
+
+	var config conntrackRuleFile
+	md, err := toml.DecodeFile(matchersFile, &config)
+	if err != nil {
+		return nil, err
+	}
+	if undecoded := md.Undecoded(); len(undecoded) != 0 {
+		return nil, fmt.Errorf("unknown keys in matchers file %q: %v", matchersFile, undecoded)
+	}
+	if len(config.All.Matchers) == 0 && len(config.IPv4.Matchers) == 0 && len(config.IPv6.Matchers) == 0 {
+		return nil, fmt.Errorf("matchers file %q does not contain any [[all.matchers]], [[ipv4.matchers]], or [[ipv6.matchers]]", matchersFile)
+	}
+
+	matchers := make([]ctmgr.Matcher, 0, len(config.All.Matchers)+len(config.IPv4.Matchers)+len(config.IPv6.Matchers))
+	appendMatchers := func(defaultFamily string, items []conntrackRuleFileMatcher, baseIndex int) error {
+		for i := range items {
+			options, err := items[i].toFilterOptions(defaultFamily)
+			if err != nil {
+				return fmt.Errorf("matchers file %q matcher %d: %w", matchersFile, baseIndex+i+1, err)
+			}
+			matcher, hasFilter, err := buildConntrackFilter(options, true, true)
+			if err != nil {
+				return fmt.Errorf("matchers file %q matcher %d: %w", matchersFile, baseIndex+i+1, err)
+			}
+			if !hasFilter {
+				return fmt.Errorf("matchers file %q matcher %d is empty", matchersFile, baseIndex+i+1)
+			}
+			matchers = append(matchers, matcher)
+		}
+		return nil
+	}
+	base := 0
+	if err := appendMatchers(conntrackFamilyAll, config.All.Matchers, base); err != nil {
+		return nil, err
+	}
+	base += len(config.All.Matchers)
+	if err := appendMatchers(conntrackFamilyIPv4, config.IPv4.Matchers, base); err != nil {
+		return nil, err
+	}
+	base += len(config.IPv4.Matchers)
+	if err := appendMatchers(conntrackFamilyIPv6, config.IPv6.Matchers, base); err != nil {
+		return nil, err
+	}
+	return matchers, nil
+}
+
+func (m conntrackRuleFileMatcher) toFilterOptions(defaultFamily string) (conntrackFilterOptions, error) {
+	options := defaultConntrackFilterOptions()
+	options.family = defaultFamily
+	var err error
+	options.protocol = strings.TrimSpace(m.Protocol)
+
+	if m.Zone != nil {
+		options.zone = *m.Zone
+	}
+
+	options.origSrcIP, err = chooseStringValue("orig_src_ip", m.OrigSrcIP, "src_ip", m.SrcIP)
+	if err != nil {
+		return options, err
+	}
+	options.origDstIP, err = chooseStringValue("orig_dst_ip", m.OrigDstIP, "dst_ip", m.DstIP)
+	if err != nil {
+		return options, err
+	}
+	options.origSrcPort, err = chooseIntValue("orig_src_port", m.OrigSrcPort, "src_port", m.SrcPort, -1)
+	if err != nil {
+		return options, err
+	}
+	options.origDstPort, err = chooseIntValue("orig_dst_port", m.OrigDstPort, "dst_port", m.DstPort, -1)
+	if err != nil {
+		return options, err
+	}
+
+	options.replySrcIP = strings.TrimSpace(m.ReplySrcIP)
+	options.replyDstIP = strings.TrimSpace(m.ReplyDstIP)
+	options.replySrcPort = derefIntOr(m.ReplySrcPort, -1)
+	options.replyDstPort = derefIntOr(m.ReplyDstPort, -1)
+
+	return options, nil
+}
+
+func chooseStringValue(canonicalName, canonicalValue, aliasName, aliasValue string) (string, error) {
+	canonicalValue = strings.TrimSpace(canonicalValue)
+	aliasValue = strings.TrimSpace(aliasValue)
+	switch {
+	case canonicalValue == "":
+		return aliasValue, nil
+	case aliasValue == "":
+		return canonicalValue, nil
+	case canonicalValue == aliasValue:
+		return canonicalValue, nil
+	default:
+		return "", fmt.Errorf("%s conflicts with %s", canonicalName, aliasName)
+	}
+}
+
+func chooseIntValue(canonicalName string, canonicalValue *int, aliasName string, aliasValue *int, defaultValue int) (int, error) {
+	switch {
+	case canonicalValue == nil && aliasValue == nil:
+		return defaultValue, nil
+	case canonicalValue == nil:
+		return *aliasValue, nil
+	case aliasValue == nil:
+		return *canonicalValue, nil
+	case *canonicalValue == *aliasValue:
+		return *canonicalValue, nil
+	default:
+		return defaultValue, fmt.Errorf("%s conflicts with %s", canonicalName, aliasName)
+	}
+}
+
+func derefIntOr(value *int, defaultValue int) int {
+	if value == nil {
+		return defaultValue
+	}
+	return *value
+}
+
+func mergeConntrackMatchers(matchers []ctmgr.Matcher) (ctmgr.Matcher, bool, error) {
+	switch len(matchers) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		return matchers[0], true, nil
+	default:
+		return &conntrackMultiMatcher{matchers: matchers}, true, nil
+	}
+}
+
+func writeConntrackFlows(out io.Writer, families []uint8, matcher ctmgr.Matcher, decode bool) error {
+	conntrackFlowAllocator, conntrackFlowDeallocator := newConntrackFlowPool()
+	for i := range families {
+		_, _, err := ctmgr.DumpConntrackFlows(
+			families[i],
+			matcher,
+			conntrackFlowAllocator,
+			conntrackFlowDeallocator,
+			func(flow *netlink.ConntrackFlow) error {
+				_, err := fmt.Fprintln(out, formatConntrackFlowOVS(flow, decode))
+				return err
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteConntrackFlows(families []uint8, matcher ctmgr.Matcher) (uint, error) {
+	conntrackFlowAllocator, conntrackFlowDeallocator := newConntrackFlowPool()
+	var deleted uint
+	for i := range families {
+		_, _, successCount, _, err := ctmgr.DeleteConntrackFlows(
+			families[i],
+			matcher,
+			conntrackFlowAllocator,
+			conntrackFlowDeallocator,
+		)
+		deleted += uint(successCount)
+		if err != nil {
+			return deleted, err
+		}
+	}
+	return deleted, nil
+}
+
+func newConntrackFlowPool() (func() *netlink.ConntrackFlow, func(*netlink.ConntrackFlow)) {
+	pool := sync.Pool{
+		New: func() any {
+			return &netlink.ConntrackFlow{}
+		},
+	}
+	return func() *netlink.ConntrackFlow {
+			return pool.Get().(*netlink.ConntrackFlow)
+		}, func(flow *netlink.ConntrackFlow) {
+			pool.Put(flow)
+		}
+}
+
+func conntrackFamiliesAll() []uint8 {
+	return []uint8{unix.AF_INET, unix.AF_INET6}
+}
+
+func ipTo16(ip net.IP) [16]byte {
+	var out [16]byte
+	if v4 := ip.To4(); v4 != nil {
+		out[10] = 0xff
+		out[11] = 0xff
+		copy(out[12:], v4)
+		return out
+	}
+	copy(out[:], ip.To16())
+	return out
+}
+
+func formatConntrackFlowOVS(flow *netlink.ConntrackFlow, decode bool) string {
+	var b strings.Builder
+	b.WriteString(protocolName(flow.Forward.Protocol))
+	b.WriteString(",orig=(")
+	b.WriteString(formatConntrackTupleOVS(&flow.Forward))
+	b.WriteString("),reply=(")
+	b.WriteString(formatConntrackTupleOVS(&flow.Reverse))
+
+	b.WriteString(")")
+	if flow.TimeStart != 0 {
+		b.WriteString(",start=")
+		b.WriteString(formatConntrackTimestamp(flow.TimeStart))
+	}
+	if flow.TimeStop != 0 {
+		b.WriteString(",stop=")
+		b.WriteString(formatConntrackTimestamp(flow.TimeStop))
+	}
+	if flow.ID != 0 {
+		b.WriteString(",id=")
+		b.WriteString(strconv.FormatUint(uint64(flow.ID), 10))
+	}
+	b.WriteString(",zone=")
+	b.WriteString(strconv.FormatUint(uint64(flow.Zone), 10))
+	if flow.HasStatus || flow.Status != 0 {
+		b.WriteString(",status=")
+		b.WriteString(formatConntrackStatus(flow.Status))
+	}
+	if flow.HasTimeout || flow.TimeOut != 0 {
+		b.WriteString(",timeout=")
+		b.WriteString(strconv.FormatUint(uint64(flow.TimeOut), 10))
+	}
+	if flow.HasMark || flow.Mark != 0 {
+		b.WriteString(",mark=")
+		b.WriteString(strconv.FormatUint(uint64(flow.Mark), 10))
+	}
+	if flow.HasLabels {
+		b.WriteString(",labels=0x")
+		b.WriteString(formatConntrackLabelHex(flow.Labels))
+		if flow.HasLabelsMask {
+			b.WriteString("/0x")
+			b.WriteString(formatConntrackLabelHex(flow.LabelsMask))
+		}
+	}
+	if flow.Use != 0 {
+		b.WriteString(",use=")
+		b.WriteString(strconv.FormatUint(uint64(flow.Use), 10))
+	}
+	if decode {
+		appendDecodedCTLabelFields(&b, flow)
+	}
+
+	return b.String()
+}
+
+func appendDecodedCTLabelFields(b *strings.Builder, flow *netlink.ConntrackFlow) {
+	if !flow.HasLabels {
+		return
+	}
+
+	_, info, err := decodeConntrackLabel(flow.Labels[:])
+	if err != nil {
+		b.WriteString(",label_decode_error=")
+		b.WriteString(err.Error())
+		return
+	}
+
+	for _, field := range collectFormattedInfoFields(info) {
+		if field.Key == "" {
+			continue
+		}
+		b.WriteString(",label_")
+		b.WriteString(field.Key)
+		b.WriteString("=")
+		b.WriteString(field.Value)
+	}
+}
+
+func formatConntrackLabelHex(label [16]byte) string {
+	value := numeric.Uint128FromLittleEndianBytes(label[:])
+	return fmt.Sprintf("%016x%016x", value.High, value.Low)
+}
+
+func formatConntrackTupleOVS(tuple *netlink.IPTuple) string {
+	var b strings.Builder
+	b.WriteString("src=")
+	b.WriteString(tuple.SrcIP.String())
+	b.WriteString(",dst=")
+	b.WriteString(tuple.DstIP.String())
+	b.WriteString(",proto=")
+	b.WriteString(protocolName(tuple.Protocol))
+
+	switch tuple.Protocol {
+	case unix.IPPROTO_ICMP, unix.IPPROTO_ICMPV6:
+		b.WriteString(",id=")
+		b.WriteString(strconv.FormatUint(uint64(tuple.ICMPID), 10))
+		b.WriteString(",type=")
+		b.WriteString(strconv.FormatUint(uint64(tuple.ICMPType), 10))
+		b.WriteString(",code=")
+		b.WriteString(strconv.FormatUint(uint64(tuple.ICMPCode), 10))
+	default:
+		b.WriteString(",sport=")
+		b.WriteString(strconv.FormatUint(uint64(tuple.SrcPort), 10))
+		b.WriteString(",dport=")
+		b.WriteString(strconv.FormatUint(uint64(tuple.DstPort), 10))
+	}
+
+	b.WriteString(",packets=")
+	b.WriteString(strconv.FormatUint(tuple.Packets, 10))
+	b.WriteString(",bytes=")
+	b.WriteString(strconv.FormatUint(tuple.Bytes, 10))
+	return b.String()
+}
+
+func formatConntrackTimestamp(nsec uint64) string {
+	return time.Unix(0, int64(nsec)).UTC().Format("2006-01-02T15:04:05.000000000Z")
+}
+
+type conntrackStatusFlag struct {
+	mask uint32
+	name string
+}
+
+var conntrackStatusFlags = []conntrackStatusFlag{
+	{mask: 1 << 0, name: "EXPECTED"},
+	{mask: 1 << 1, name: "SEEN_REPLY"},
+	{mask: 1 << 2, name: "ASSURED"},
+	{mask: 1 << 3, name: "CONFIRMED"},
+	{mask: 1 << 4, name: "SRC_NAT"},
+	{mask: 1 << 5, name: "DST_NAT"},
+	{mask: 1 << 6, name: "SEQ_ADJUST"},
+	{mask: 1 << 7, name: "SRC_NAT_DONE"},
+	{mask: 1 << 8, name: "DST_NAT_DONE"},
+	{mask: 1 << 9, name: "DYING"},
+	{mask: 1 << 10, name: "FIXED_TIMEOUT"},
+	{mask: 1 << 11, name: "TEMPLATE"},
+}
+
+func formatConntrackStatus(status uint32) string {
+	if status == 0 {
+		return "0x0"
+	}
+
+	parts := make([]string, 0, len(conntrackStatusFlags))
+	remaining := status
+	for i := range conntrackStatusFlags {
+		if status&conntrackStatusFlags[i].mask == 0 {
+			continue
+		}
+		parts = append(parts, conntrackStatusFlags[i].name)
+		remaining &^= conntrackStatusFlags[i].mask
+	}
+
+	if remaining != 0 || len(parts) == 0 {
+		parts = append(parts, "0x"+strconv.FormatUint(uint64(remaining), 16))
+	}
+
+	return strings.Join(parts, "|")
+}
+
+func protocolName(proto uint8) string {
+	switch proto {
+	case unix.IPPROTO_TCP:
+		return "tcp"
+	case unix.IPPROTO_UDP:
+		return "udp"
+	case unix.IPPROTO_ICMP:
+		return "icmp"
+	case unix.IPPROTO_ICMPV6:
+		return "icmpv6"
+	case unix.IPPROTO_SCTP:
+		return "sctp"
+	case unix.IPPROTO_UDPLITE:
+		return "udplite"
+	case unix.IPPROTO_DCCP:
+		return "dccp"
+	case unix.IPPROTO_IGMP:
+		return "igmp"
+	case unix.IPPROTO_IPIP:
+		return "ip"
+	case unix.IPPROTO_IPV6:
+		return "ipv6"
+	case unix.IPPROTO_GRE:
+		return "gre"
+	default:
+		return strconv.FormatUint(uint64(proto), 10)
+	}
+}

--- a/pkg/erctl/cmd/conntrack_test.go
+++ b/pkg/erctl/cmd/conntrack_test.go
@@ -1,0 +1,472 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+func TestBuildConntrackMatchersFromSeparatedArgs(t *testing.T) {
+	matcher, hasFilter, err := buildConntrackMatchers(
+		[]string{
+			"--protocol=tcp",
+			"--orig-dst-port=80",
+			"--",
+			"--family=ipv6",
+			"--protocol=udp",
+			"--orig-dst-port=53",
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildConntrackMatchers returned error: %v", err)
+	}
+	if !hasFilter {
+		t.Fatalf("expected matcher to be built")
+	}
+
+	if !matcher.MatchConntrackFlow(makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)) {
+		t.Fatalf("expected tcp matcher to match")
+	}
+	if matcher.MatchConntrackFlow(makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 53, unix.IPPROTO_UDP)) {
+		t.Fatalf("did not expect ipv4 udp flow to match ipv6-scoped matcher")
+	}
+	if !matcher.MatchConntrackFlow(makeIPv6ConntrackFlow("2001:db8::1", "2001:db8::2", 12345, 53, unix.IPPROTO_UDP)) {
+		t.Fatalf("expected ipv6 udp matcher to match")
+	}
+	if matcher.MatchConntrackFlow(makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 443, unix.IPPROTO_TCP)) {
+		t.Fatalf("did not expect unmatched flow to match")
+	}
+}
+
+func TestBuildConntrackMatchersMatcherZoneWorks(t *testing.T) {
+	matcher, hasFilter, err := buildConntrackMatchers(
+		[]string{
+			"--zone=7",
+			"--protocol=tcp",
+			"--orig-dst-port=80",
+			"--",
+			"--family=ipv6",
+			"--zone=7",
+			"--protocol=udp",
+			"--orig-dst-port=53",
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildConntrackMatchers returned error: %v", err)
+	}
+	if !hasFilter {
+		t.Fatalf("expected matcher to be built")
+	}
+
+	flow1 := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)
+	flow1.Zone = 7
+	if !matcher.MatchConntrackFlow(flow1) {
+		t.Fatalf("expected first zone-scoped matcher to match")
+	}
+
+	flow2 := makeIPv6ConntrackFlow("2001:db8::1", "2001:db8::2", 12345, 53, unix.IPPROTO_UDP)
+	flow2.Zone = 7
+	if !matcher.MatchConntrackFlow(flow2) {
+		t.Fatalf("expected second zone-scoped matcher to match")
+	}
+
+	flow3 := makeIPv6ConntrackFlow("2001:db8::1", "2001:db8::2", 12345, 53, unix.IPPROTO_UDP)
+	flow3.Zone = 8
+	if matcher.MatchConntrackFlow(flow3) {
+		t.Fatalf("did not expect flow in another zone to match")
+	}
+}
+
+func TestBuildConntrackMatchersPortFilterWithoutProtocolDoesNotMatchICMP(t *testing.T) {
+	matcher, hasFilter, err := buildConntrackMatchers(
+		[]string{
+			"--orig-src-ip=10.0.0.1",
+			"--orig-dst-ip=10.0.0.2",
+			"--orig-dst-port=80",
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildConntrackMatchers returned error: %v", err)
+	}
+	if !hasFilter {
+		t.Fatalf("expected matcher to be built")
+	}
+
+	if !matcher.MatchConntrackFlow(makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)) {
+		t.Fatalf("expected tcp flow to match port filter without protocol")
+	}
+
+	if matcher.MatchConntrackFlow(makeICMPConntrackFlow("10.0.0.1", "10.0.0.2", unix.IPPROTO_ICMP)) {
+		t.Fatalf("did not expect icmp flow to match port filter without protocol")
+	}
+}
+
+func TestBuildConntrackMatchersFromRulesFile(t *testing.T) {
+	dir := t.TempDir()
+	rulesFile := filepath.Join(dir, "conntrack.toml")
+	content := `[[all.matchers]]
+protocol = "tcp"
+orig_src_ip = "10.0.0.1"
+orig_dst_port = 80
+
+[[ipv4.matchers]]
+zone = 7
+reply_dst_ip = "10.0.0.3"
+
+[[ipv6.matchers]]
+protocol = "udp"
+orig_dst_port = 53
+`
+	if err := os.WriteFile(rulesFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write rules file: %v", err)
+	}
+
+	matcher, hasFilter, err := buildConntrackMatchers(nil, rulesFile)
+	if err != nil {
+		t.Fatalf("buildConntrackMatchers returned error: %v", err)
+	}
+	if !hasFilter {
+		t.Fatalf("expected matcher to be built from rules file")
+	}
+
+	flow1 := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)
+	if !matcher.MatchConntrackFlow(flow1) {
+		t.Fatalf("expected first matcher from rules file to match")
+	}
+
+	flow2 := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 8080, unix.IPPROTO_TCP)
+	flow2.Zone = 7
+	flow2.Reverse.DstIP = net.ParseIP("10.0.0.3")
+	if !matcher.MatchConntrackFlow(flow2) {
+		t.Fatalf("expected second matcher from rules file to match")
+	}
+
+	if !matcher.MatchConntrackFlow(makeIPv6ConntrackFlow("2001:db8::1", "2001:db8::2", 12345, 53, unix.IPPROTO_UDP)) {
+		t.Fatalf("expected ipv6 matcher from rules file to match")
+	}
+
+	if matcher.MatchConntrackFlow(makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 53, unix.IPPROTO_UDP)) {
+		t.Fatalf("did not expect ipv4 udp flow to match ipv6 matcher from rules file")
+	}
+}
+
+func TestBuildConntrackMatchersFromRulesFileRejectsLegacyMatchersSection(t *testing.T) {
+	dir := t.TempDir()
+	rulesFile := filepath.Join(dir, "conntrack.toml")
+	content := `[[matchers]]
+protocol = "tcp"
+orig_dst_port = 80
+`
+	if err := os.WriteFile(rulesFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write rules file: %v", err)
+	}
+
+	_, _, err := buildConntrackMatchers(nil, rulesFile)
+	if err == nil {
+		t.Fatalf("expected legacy [[matchers]] section to be rejected")
+	}
+}
+
+func TestFormatConntrackFlowOVS(t *testing.T) {
+	flow := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)
+	flow.Zone = 7
+	flow.Mark = 42
+	flow.HasMark = true
+	flow.Status = 0xe
+	flow.HasStatus = true
+	flow.TimeOut = 30
+	flow.HasTimeout = true
+	flow.Forward.Packets = 11
+	flow.Forward.Bytes = 111
+	flow.Reverse.Packets = 22
+	flow.Reverse.Bytes = 222
+
+	got := formatConntrackFlowOVS(flow, false)
+	want := "tcp,orig=(src=10.0.0.1,dst=10.0.0.2,proto=tcp,sport=12345,dport=80,packets=11,bytes=111),reply=(src=10.0.0.2,dst=10.0.0.1,proto=tcp,sport=80,dport=12345,packets=22,bytes=222),zone=7,status=SEEN_REPLY|ASSURED|CONFIRMED,timeout=30,mark=42"
+	if got != want {
+		t.Fatalf("unexpected conntrack format:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestFormatConntrackFlowOVS_ICMP(t *testing.T) {
+	flow := &netlink.ConntrackFlow{
+		FamilyType: unix.AF_INET,
+		Zone:       9,
+		Forward: netlink.IPTuple{
+			SrcIP:    net.ParseIP("10.0.0.1"),
+			DstIP:    net.ParseIP("10.0.0.2"),
+			Protocol: unix.IPPROTO_ICMP,
+			ICMPID:   10,
+			ICMPType: 8,
+			ICMPCode: 0,
+			Packets:  1,
+			Bytes:    64,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    net.ParseIP("10.0.0.2"),
+			DstIP:    net.ParseIP("10.0.0.1"),
+			Protocol: unix.IPPROTO_ICMP,
+			ICMPID:   10,
+			ICMPType: 0,
+			ICMPCode: 0,
+			Packets:  1,
+			Bytes:    64,
+		},
+	}
+
+	got := formatConntrackFlowOVS(flow, false)
+	want := "icmp,orig=(src=10.0.0.1,dst=10.0.0.2,proto=icmp,id=10,type=8,code=0,packets=1,bytes=64),reply=(src=10.0.0.2,dst=10.0.0.1,proto=icmp,id=10,type=0,code=0,packets=1,bytes=64),zone=9"
+	if got != want {
+		t.Fatalf("unexpected icmp conntrack format:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestFormatConntrackFlowOVS_ICMPv6(t *testing.T) {
+	flow := &netlink.ConntrackFlow{
+		FamilyType: unix.AF_INET6,
+		Zone:       3,
+		Forward: netlink.IPTuple{
+			SrcIP:    net.ParseIP("2001:db8::1"),
+			DstIP:    net.ParseIP("2001:db8::2"),
+			Protocol: unix.IPPROTO_ICMPV6,
+			ICMPID:   10,
+			ICMPType: 128,
+			ICMPCode: 0,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    net.ParseIP("2001:db8::2"),
+			DstIP:    net.ParseIP("2001:db8::1"),
+			Protocol: unix.IPPROTO_ICMPV6,
+			ICMPID:   10,
+			ICMPType: 129,
+			ICMPCode: 0,
+		},
+	}
+
+	got := formatConntrackFlowOVS(flow, false)
+	want := "icmpv6,orig=(src=2001:db8::1,dst=2001:db8::2,proto=icmpv6,id=10,type=128,code=0,packets=0,bytes=0),reply=(src=2001:db8::2,dst=2001:db8::1,proto=icmpv6,id=10,type=129,code=0,packets=0,bytes=0),zone=3"
+	if got != want {
+		t.Fatalf("unexpected icmpv6 conntrack format:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestFormatConntrackFlowOVSOrderMatchesOVSStyle(t *testing.T) {
+	flow := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)
+	flow.TimeStart = 1
+	flow.TimeStop = 2
+	flow.ID = 99
+	flow.Zone = 7
+	flow.Status = 0x1234
+	flow.HasStatus = true
+	flow.TimeOut = 30
+	flow.HasTimeout = true
+	flow.Mark = 42
+	flow.HasMark = true
+	flow.Labels = [16]byte{0xaa, 0xbb}
+	flow.HasLabels = true
+	flow.Use = 8
+
+	got := formatConntrackFlowOVS(flow, false)
+
+	assertBefore := func(a, b string) {
+		aIdx := strings.Index(got, a)
+		bIdx := strings.Index(got, b)
+		if aIdx == -1 || bIdx == -1 {
+			t.Fatalf("missing %q or %q in %q", a, b, got)
+		}
+		if aIdx >= bIdx {
+			t.Fatalf("expected %q before %q in %q", a, b, got)
+		}
+	}
+
+	assertBefore(",reply=(", ",start=")
+	assertBefore(",start=", ",stop=")
+	assertBefore(",stop=", ",id=")
+	assertBefore(",id=", ",zone=")
+	assertBefore(",zone=", ",status=")
+	assertBefore(",status=", ",timeout=")
+	assertBefore(",timeout=", ",mark=")
+	assertBefore(",mark=", ",labels=")
+	assertBefore(",labels=", ",use=")
+}
+
+func TestFormatConntrackFlowOVS_DecodeCTLabelAppendsDecodedFields(t *testing.T) {
+	flow := makeConntrackFlow("10.0.0.1", "10.0.0.2", 12345, 80, unix.IPPROTO_TCP)
+	flow.Zone = 7
+	flow.Labels = [16]byte{
+		0x01, 0x23, 0x45, 0x67,
+		0x89, 0xab, 0xcd, 0xef,
+		0x10, 0x32, 0x54, 0x76,
+		0x98, 0xba, 0xdc, 0xfe,
+	}
+	flow.HasLabels = true
+
+	got := formatConntrackFlowOVS(flow, true)
+
+	assertContains := func(substr string) {
+		if !strings.Contains(got, substr) {
+			t.Fatalf("expected %q in %q", substr, got)
+		}
+	}
+
+	assertContains(",labels=0xfedcba9876543210efcdab8967452301")
+	assertContains(",label_round_number=0x1")
+	assertContains(",label_origin_inport=43399")
+	assertContains(",label_reply_inport=60875")
+	assertContains(",label_encoding_scheme=micro segmentation")
+	assertContains(",label_origin_packet_source=local bridge")
+	assertContains(",label_reply_packet_source=0x01")
+	assertContains(",label_monitor_policy_action_drop=true")
+	assertContains(",label_work_policy_action_drop=true")
+
+	if strings.Index(got, ",labels=") >= strings.Index(got, ",label_round_number=") {
+		t.Fatalf("expected decoded ctlabel fields appended after labels: %q", got)
+	}
+}
+
+func TestFormatConntrackLabelHexUsesDecodeCTLabelEndian(t *testing.T) {
+	label := [16]byte{
+		0x01, 0x23, 0x45, 0x67,
+		0x89, 0xab, 0xcd, 0xef,
+		0x10, 0x32, 0x54, 0x76,
+		0x98, 0xba, 0xdc, 0xfe,
+	}
+
+	got := formatConntrackLabelHex(label)
+	want := "fedcba9876543210efcdab8967452301"
+	if got != want {
+		t.Fatalf("unexpected conntrack label hex:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestFormatConntrackStatus(t *testing.T) {
+	if got, want := formatConntrackStatus(0xe), "SEEN_REPLY|ASSURED|CONFIRMED"; got != want {
+		t.Fatalf("unexpected status format: got %q, want %q", got, want)
+	}
+	if got, want := formatConntrackStatus(1<<1|1<<14), "SEEN_REPLY|0x4000"; got != want {
+		t.Fatalf("unexpected mixed status format: got %q, want %q", got, want)
+	}
+}
+
+func TestConntrackCommandsDoNotExposeTopLevelFamilyFlag(t *testing.T) {
+	for _, cmd := range []*cobra.Command{conntrackDumpCmd, conntrackDeleteCmd, conntrackUpdateCmd} {
+		if flag := cmd.Flags().Lookup("family"); flag != nil {
+			t.Fatalf("did not expect top-level --family on %q", cmd.Name())
+		}
+	}
+}
+
+func TestConntrackDumpCommandExposesDecodeFlag(t *testing.T) {
+	if flag := conntrackDumpCmd.Flags().Lookup("decode"); flag == nil {
+		t.Fatalf("expected top-level --decode on %q", conntrackDumpCmd.Name())
+	} else if flag.Shorthand != "D" {
+		t.Fatalf("expected --decode shorthand to be -D on %q", conntrackDumpCmd.Name())
+	}
+}
+
+func TestConntrackCommandsExposeMatchersFileFlag(t *testing.T) {
+	for _, cmd := range []*cobra.Command{conntrackDumpCmd, conntrackDeleteCmd} {
+		if flag := cmd.Flags().Lookup("matchers-file"); flag == nil {
+			t.Fatalf("expected top-level --matchers-file on %q", cmd.Name())
+		}
+		if flag := cmd.Flags().Lookup("rules-file"); flag != nil {
+			t.Fatalf("did not expect legacy --rules-file on %q", cmd.Name())
+		}
+	}
+}
+
+func TestConntrackCommandsDoNotExposeTopLevelMatcherFlags(t *testing.T) {
+	for _, cmd := range []*cobra.Command{conntrackDumpCmd, conntrackDeleteCmd, conntrackUpdateCmd} {
+		for _, name := range []string{
+			"zone",
+			"protocol",
+			"orig-src-ip",
+			"src-ip",
+			"orig-dst-ip",
+			"dst-ip",
+			"orig-src-port",
+			"src-port",
+			"orig-dst-port",
+			"dst-port",
+			"reply-src-ip",
+			"reply-dst-ip",
+			"reply-src-port",
+			"reply-dst-port",
+		} {
+			if flag := cmd.Flags().Lookup(name); flag != nil {
+				t.Fatalf("did not expect top-level --%s on %q", name, cmd.Name())
+			}
+		}
+	}
+}
+
+func makeConntrackFlow(srcIP, dstIP string, srcPort, dstPort uint16, protocol uint8) *netlink.ConntrackFlow {
+	src := net.ParseIP(srcIP)
+	dst := net.ParseIP(dstIP)
+	return &netlink.ConntrackFlow{
+		FamilyType: unix.AF_INET,
+		Forward: netlink.IPTuple{
+			SrcIP:    src,
+			DstIP:    dst,
+			SrcPort:  srcPort,
+			DstPort:  dstPort,
+			Protocol: protocol,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    dst,
+			DstIP:    src,
+			SrcPort:  dstPort,
+			DstPort:  srcPort,
+			Protocol: protocol,
+		},
+	}
+}
+
+func makeIPv6ConntrackFlow(srcIP, dstIP string, srcPort, dstPort uint16, protocol uint8) *netlink.ConntrackFlow {
+	src := net.ParseIP(srcIP)
+	dst := net.ParseIP(dstIP)
+	return &netlink.ConntrackFlow{
+		FamilyType: unix.AF_INET6,
+		Forward: netlink.IPTuple{
+			SrcIP:    src,
+			DstIP:    dst,
+			SrcPort:  srcPort,
+			DstPort:  dstPort,
+			Protocol: protocol,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    dst,
+			DstIP:    src,
+			SrcPort:  dstPort,
+			DstPort:  srcPort,
+			Protocol: protocol,
+		},
+	}
+}
+
+func makeICMPConntrackFlow(srcIP, dstIP string, protocol uint8) *netlink.ConntrackFlow {
+	src := net.ParseIP(srcIP)
+	dst := net.ParseIP(dstIP)
+	return &netlink.ConntrackFlow{
+		FamilyType: unix.AF_INET,
+		Forward: netlink.IPTuple{
+			SrcIP:    src,
+			DstIP:    dst,
+			Protocol: protocol,
+		},
+		Reverse: netlink.IPTuple{
+			SrcIP:    dst,
+			DstIP:    src,
+			Protocol: protocol,
+		},
+	}
+}

--- a/pkg/erctl/cmd/decode.go
+++ b/pkg/erctl/cmd/decode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -20,20 +21,26 @@ var (
 	humanOutput bool
 )
 
+type formattedInfoField struct {
+	Key   string
+	Value string
+}
+
 var decodeCmd = &cobra.Command{
 	Use:   "decode",
 	Short: "decode some formatted string",
 }
 
-var ctlabelsCmd = &cobra.Command{
-	Use:   "ctlabels",
-	Short: "decode ct labels from hex or binary string",
+var ctlabelCmd = &cobra.Command{
+	Use:     "ctlabel",
+	Aliases: []string{"ctlabels"},
+	Short:   "decode ct labels from hex or binary string",
 	Long: "decode ct labels from hex or binary string, " +
-		"e.g. erctl decode ctlabels 0x0123456789abcdef or " +
-		"erctl decode ctlabels 0b0000000100100011010001010110011110001001101010111100110111101111",
+		"e.g. erctl decode ctlabel 0x0123456789abcdef or " +
+		"erctl decode ctlabel 0b0000000100100011010001010110011110001001101010111100110111101111",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return fmt.Errorf("ctlabels hex or binary string is required")
+			return fmt.Errorf("ctlabel hex or binary string is required")
 		}
 
 		errs := lo.Map(args, func(label string, _ int) (err error) {
@@ -49,9 +56,9 @@ var ctlabelsCmd = &cobra.Command{
 				return fmt.Errorf("parse %s: %v", label, err)
 			}
 
-			scheme, info := lo.Must2(ctlabels.DecodeConntrackLabels(raw))
-			if scheme == ctlabels.EncodingSchemeOld {
-				info = lo.Must(ctlabels.DecodeMicroSegmentation(numeric.Uint128FromLittleEndianBytes(raw)))
+			scheme, info, err := decodeConntrackLabel(raw)
+			if err != nil {
+				return fmt.Errorf("decode %s: %v", label, err)
 			}
 
 			if humanOutput {
@@ -134,6 +141,20 @@ func parseBinaryString(binStr string) ([]byte, error) {
 	}
 
 	return lo.ToPtr(numeric.Uint128FromBigEndianBytes(bytes)).Bytes(), nil
+}
+
+func decodeConntrackLabel(raw []byte) (ctlabels.EncodingScheme, any, error) {
+	scheme, info, err := ctlabels.DecodeConntrackLabels(raw)
+	if err != nil {
+		return scheme, nil, err
+	}
+	if scheme == ctlabels.EncodingSchemeOld {
+		info, err = ctlabels.DecodeMicroSegmentation(numeric.Uint128FromLittleEndianBytes(raw))
+		if err != nil {
+			return scheme, nil, err
+		}
+	}
+	return scheme, info, nil
 }
 
 func printJSONFormat(cmd *cobra.Command, label string, scheme ctlabels.EncodingScheme, info any) error {
@@ -233,44 +254,58 @@ func formatFieldValue(fieldName string, value any) string {
 }
 
 func printHumanInfoStruct(out io.Writer, info any, prefix string) {
+	for _, field := range formattedInfoFields(info, prefix) {
+		fmt.Fprintf(out, "%s\n", field)
+	}
+}
+
+func formattedInfoFields(info any, prefix string) []string {
+	fields := collectFormattedInfoFields(info)
+	lines := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field.Key == "" {
+			lines = append(lines, prefix+field.Value)
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s%s: %s", prefix, field.Key, field.Value))
+	}
+	return lines
+}
+
+func collectFormattedInfoFields(info any) []formattedInfoField {
 	if info == nil {
-		return
+		return nil
 	}
 
 	val := reflect.ValueOf(info)
 	if val.Kind() == reflect.Ptr {
 		if val.IsNil() {
-			return
+			return nil
 		}
 		val = val.Elem()
 	}
 
 	if val.Kind() != reflect.Struct {
-		// Fallback to JSON marshaling for non-struct types
 		infoBytes, err := json.Marshal(info)
 		if err == nil {
 			var infoMap map[string]any
 			if err := json.Unmarshal(infoBytes, &infoMap); err == nil {
-				printHumanInfoMap(out, infoMap, prefix)
-				return
+				return collectFormattedInfoMapFields(infoMap, "")
 			}
 		}
-		fmt.Fprintf(out, "%s%v\n", prefix, info)
-		return
+		return []formattedInfoField{{Value: fmt.Sprintf("%v", info)}}
 	}
 
+	fields := make([]formattedInfoField, 0, val.NumField())
 	typ := val.Type()
 	for i := 0; i < val.NumField(); i++ {
 		field := typ.Field(i)
 		fieldVal := val.Field(i)
-
-		// Skip unexported fields
 		if !fieldVal.CanInterface() {
 			continue
 		}
 
 		fieldName := field.Name
-		// Use json tag if available
 		if jsonTag := field.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
 			if name, _, found := strings.Cut(jsonTag, ","); found {
 				fieldName = name
@@ -279,39 +314,47 @@ func printHumanInfoStruct(out io.Writer, info any, prefix string) {
 			}
 		}
 
-		value := fieldVal.Interface()
-		formattedValue := formatFieldValue(fieldName, value)
-
-		fmt.Fprintf(out, "%s%s: %s\n", prefix, fieldName, formattedValue)
+		fields = append(fields, formattedInfoField{
+			Key:   fieldName,
+			Value: formatFieldValue(fieldName, fieldVal.Interface()),
+		})
 	}
+	return fields
 }
 
-func printHumanInfoMap(out io.Writer, data map[string]any, prefix string) {
-	for k, v := range data {
+func collectFormattedInfoMapFields(data map[string]any, prefix string) []formattedInfoField {
+	keys := lo.Keys(data)
+	sort.Strings(keys)
+
+	fields := make([]formattedInfoField, 0, len(keys))
+	for _, k := range keys {
+		v := data[k]
 		switch val := v.(type) {
 		case map[string]any:
-			fmt.Fprintf(out, "%s%s:\n", prefix, k)
-			printHumanInfoMap(out, val, prefix+"  ")
+			fields = append(fields, collectFormattedInfoMapFields(val, prefix+k+".")...)
 		case []any:
-			fmt.Fprintf(out, "%s%s:\n", prefix, k)
 			for i, item := range val {
 				if itemMap, ok := item.(map[string]any); ok {
-					fmt.Fprintf(out, "%s  [%d]:\n", prefix, i)
-					printHumanInfoMap(out, itemMap, prefix+"    ")
+					fields = append(fields, collectFormattedInfoMapFields(itemMap, fmt.Sprintf("%s%s[%d].", prefix, k, i))...)
 				} else {
-					formattedValue := formatFieldValue(k, item)
-					fmt.Fprintf(out, "%s  [%d]: %s\n", prefix, i, formattedValue)
+					fields = append(fields, formattedInfoField{
+						Key:   fmt.Sprintf("%s%s[%d]", prefix, k, i),
+						Value: formatFieldValue(k, item),
+					})
 				}
 			}
 		default:
-			formattedValue := formatFieldValue(k, v)
-			fmt.Fprintf(out, "%s%s: %s\n", prefix, k, formattedValue)
+			fields = append(fields, formattedInfoField{
+				Key:   prefix + k,
+				Value: formatFieldValue(k, v),
+			})
 		}
 	}
+	return fields
 }
 
 func init() {
 	rootCmd.AddCommand(decodeCmd)
-	decodeCmd.AddCommand(ctlabelsCmd)
-	ctlabelsCmd.Flags().BoolVarP(&humanOutput, "human", "H", false, "display in human-readable format")
+	decodeCmd.AddCommand(ctlabelCmd)
+	ctlabelCmd.Flags().BoolVarP(&humanOutput, "human", "H", false, "display in human-readable format")
 }

--- a/pkg/erctl/cmd/decode_test.go
+++ b/pkg/erctl/cmd/decode_test.go
@@ -119,15 +119,20 @@ var _ = Describe("Decode", func() {
 		})
 	})
 
-	Describe("ctlabelsCmd", func() {
+	Describe("ctlabelCmd", func() {
+		It("should use ctlabel as command name and keep ctlabels alias", func() {
+			Expect(ctlabelCmd.Use).Should(Equal("ctlabel"))
+			Expect(ctlabelCmd.Aliases).Should(ContainElement("ctlabels"))
+		})
+
 		It("should decode hex label and output JSON", func() {
 			// Use a known test case - all zeros
 			label := "0x00000000000000000000000000000000"
 			var buf bytes.Buffer
-			ctlabelsCmd.SetOut(&buf)
+			ctlabelCmd.SetOut(&buf)
 			humanOutput = false
 
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{label})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{label})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			var result map[string]interface{}
@@ -142,10 +147,10 @@ var _ = Describe("Decode", func() {
 			// All zeros in binary
 			label := "0b" + strings.Repeat("0", 128)
 			var buf bytes.Buffer
-			ctlabelsCmd.SetOut(&buf)
+			ctlabelCmd.SetOut(&buf)
 			humanOutput = false
 
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{label})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{label})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			var result map[string]interface{}
@@ -157,10 +162,10 @@ var _ = Describe("Decode", func() {
 		It("should output human-readable format", func() {
 			label := "0x00000000000000000000000000000000"
 			var buf bytes.Buffer
-			ctlabelsCmd.SetOut(&buf)
+			ctlabelCmd.SetOut(&buf)
 			humanOutput = true
 
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{label})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{label})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			output := buf.String()
@@ -168,7 +173,7 @@ var _ = Describe("Decode", func() {
 		})
 
 		It("should return error when no arguments provided", func() {
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{})
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("required"))
 		})
@@ -177,10 +182,10 @@ var _ = Describe("Decode", func() {
 			label1 := "0x00000000000000000000000000000000"
 			label2 := "0x00000000000000000000000000000001"
 			var buf bytes.Buffer
-			ctlabelsCmd.SetOut(&buf)
+			ctlabelCmd.SetOut(&buf)
 			humanOutput = false
 
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{label1, label2})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{label1, label2})
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -189,10 +194,10 @@ var _ = Describe("Decode", func() {
 			// This is a simplified test - actual old scheme detection depends on ctlabels-go
 			label := "0x00000000000000000000000000000003" // May trigger old scheme
 			var buf bytes.Buffer
-			ctlabelsCmd.SetOut(&buf)
+			ctlabelCmd.SetOut(&buf)
 			humanOutput = false
 
-			err := ctlabelsCmd.RunE(ctlabelsCmd, []string{label})
+			err := ctlabelCmd.RunE(ctlabelCmd, []string{label})
 			// Should not error regardless of scheme
 			Expect(err).ShouldNot(HaveOccurred())
 		})


### PR DESCRIPTION
http://jira.smartx.com/browse/ER-1774

# 新增
添加 `erctl conntrack` 子命令，用于 conntrack 相关操作。
- `erctl conntrack dump --all` 约等于 `ovs-dpctl dump-conntrack -m` 并额外能获得时间相关字段。
- `erctl conntrack dump -- --src-ip=1.2.3.4 --protocol=tcp --dst-port=8080` 过滤 conntrack entry
- `erctl conntrack dump [-- <matcher>...]...` 上一条的完整形式，可以通过 `--` 衔接多个 matcher，这些 matcher 之间是 OR  的关系。
- `erctl conntrack dump --matchers-file <file>.toml` 从 toml 文件中读取 matchers，而不是从命令行参数获取。
- `erctl conntrack dump --decode` 或 `erctl conntrack dump -D` 解析 conntrack label 。
- `erctl conntrack delete [-- <matcher>...]...` 删除 conntrack entry，matcher 与 dump 相同
- `erctl conntrack delete --all` 删除全部 conntrack entry，matcher 与 dump 相同
- `erctl conntrack update` 报错 `not implemented`

# 修改

- 修改 `erctl decode ctlabels` 为 `erctl decode ctlabel` 但是 alias 了旧的子命令。
- 重命名 Matcher 到 TupleMatcher

# 测试

dump 与 decode

<img width="1438" height="805" alt="image" src="https://github.com/user-attachments/assets/d4119f82-ebf1-45bb-b8da-16711eedf0e0" />

delete

<img width="1027" height="59" alt="image" src="https://github.com/user-attachments/assets/da336436-1fe0-413b-afca-fadc3f200b68" />
