### PR TITLE
feat: allow memory usage equal to policy guard threshold

### DIFF
--- a/pkg/agent/controller/policy/policy_guard.go
+++ b/pkg/agent/controller/policy/policy_guard.go
@@ -201,7 +201,7 @@ func (g *MemoryGuard) refresh(reason string) (bool, error) {
 	usage := readMemoryUsage()
 	g.recordMemoryUsage(usage, threshold)
 
-	if usage >= threshold {
+	if usage > threshold {
 		return g.markOpen(reason), nil
 	}
 
@@ -218,7 +218,7 @@ func (g *MemoryGuard) refresh(reason string) (bool, error) {
 
 	usage = readMemoryUsage()
 	g.recordMemoryUsage(usage, threshold)
-	if usage >= threshold {
+	if usage > threshold {
 		return g.markOpen(reason), nil
 	}
 

--- a/pkg/agent/controller/policy/policy_guard_test.go
+++ b/pkg/agent/controller/policy/policy_guard_test.go
@@ -106,6 +106,25 @@ func TestMemoryGuardAdmitRejectAndDisableReset(t *testing.T) {
 	}
 }
 
+func TestMemoryGuardAllowsUsageEqualToThreshold(t *testing.T) {
+	patches := gomonkey.ApplyFuncReturn(readMemoryUsage, uint64(100))
+	defer patches.Reset()
+
+	guard := newMemoryGuard(metrics.NewAgentMetric(), 100)
+	req := newAdmissionRequest(policyGuardResourcePolicy, "ns", "policy-a", policyGuardOperationUpdate)
+
+	res := guard.admit(context.Background(), req)
+	if !res.Allowed {
+		t.Fatalf("expected memory guard to allow usage equal to threshold: %+v", res)
+	}
+	if guard.isOpen() {
+		t.Fatalf("expected memory breaker to stay closed when usage equals threshold")
+	}
+	if len(guard.rejectedByMemory) != 0 {
+		t.Fatalf("expected no memory rejected object, got %d", len(guard.rejectedByMemory))
+	}
+}
+
 func TestMemoryGuardUnlimitedThresholdAllowsAndClosesBreaker(t *testing.T) {
 	patches := gomonkey.ApplyFuncReturn(readMemoryUsage, uint64(200))
 	defer patches.Reset()


### PR DESCRIPTION
## Purpose

Make memory guard threshold boundary semantics consistent with policy rule estimate limit semantics: reaching the configured value is allowed, exceeding it is rejected.

## Changes

- Change policy memory breaker open condition from `usage >= threshold` to `usage > threshold`.
- Apply the same boundary rule to the second 5-second recovery sample.
- Add a unit test covering `usage == threshold`, ensuring the request is allowed and the breaker remains closed.

## Tests

- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test --gcflags=all=-l ./pkg/agent/controller/policy -run "Test.*Guard" -count=1`
- `make docker-generate`
