### PR TITLE
feat: support crcwatch https insecure config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/coreos/go-iptables v0.7.0
 	github.com/everoute/container v0.0.0-20231227060557-cbcbd25ae991
 	github.com/everoute/ctlabels-go v0.0.0-20251223084813-611df91d7fa7
-	github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786
+	github.com/everoute/graphc v0.0.0-20260622102003-1a5fac10bce2
 	github.com/everoute/ipam v1.2.1-0.20240510092120-066023ea9f99
 	github.com/everoute/numeric-go v0.0.0-20251223074813-1affd646f5e4
 	github.com/everoute/trafficredirect v0.0.0-20250928025708-f06e9064969e

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/everoute/container v0.0.0-20231227060557-cbcbd25ae991 h1:pgZ5WgLyTOCF
 github.com/everoute/container v0.0.0-20231227060557-cbcbd25ae991/go.mod h1:YdIf7ANCOIBGgxnyN7SZkQjUBHmOw0UZSV9O43A6PXs=
 github.com/everoute/ctlabels-go v0.0.0-20251223084813-611df91d7fa7 h1:S8FLk9mbPIHy206graV0zd74PiYjADrnwZ8in/sVkaY=
 github.com/everoute/ctlabels-go v0.0.0-20251223084813-611df91d7fa7/go.mod h1:8TeecKjSx4VRpaZh51eG298z1HzmAkLbLEcb9qBSqoY=
-github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786 h1:6V/pwZD//tGz/dMXZr8QjhUkOd1yOORyFjtDdcqT9Xk=
-github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786/go.mod h1:7qfJw7/eKRaSpiwi2ClmCIo1KWpwp6oec67Ln8hg8Kg=
+github.com/everoute/graphc v0.0.0-20260622102003-1a5fac10bce2 h1:zuuyylQGmDMsi0EMdDLsq8YIQPjD5uyDZC9ZLJ9xOcU=
+github.com/everoute/graphc v0.0.0-20260622102003-1a5fac10bce2/go.mod h1:7qfJw7/eKRaSpiwi2ClmCIo1KWpwp6oec67Ln8hg8Kg=
 github.com/everoute/ipam v1.2.1-0.20240510092120-066023ea9f99 h1:ACUaMP14gg2INkSMUrcyK91qb1s+v9aa7Jp74/cF2bM=
 github.com/everoute/ipam v1.2.1-0.20240510092120-066023ea9f99/go.mod h1:tVA1ktFobpf679E6GU3b3VoXpkyWtNbU5ZkaGinxgzI=
 github.com/everoute/libOpenflow v1.0.1-0.20241023024533-3fff8fcc5e74 h1:d4ZkDRNWQTZGsQF7ioTzkmgMFVaJuh73v5XRlKo0ze4=

--- a/plugin/tower/pkg/informer/factory_crc.go
+++ b/plugin/tower/pkg/informer/factory_crc.go
@@ -18,8 +18,8 @@ package informer
 
 import (
 	"encoding/json"
+	"net/url"
 	"reflect"
-	"strings"
 	"time"
 
 	graphcclient "github.com/everoute/graphc/pkg/client"
@@ -63,12 +63,15 @@ func MustNewCrcFactory(c *client.Client) *CrcFactory {
 		"SecurityGroup",
 		"NetworkPolicyRuleService",
 	}
-	host := strings.TrimPrefix(c.URL, "https://")
-	host = strings.TrimSuffix(host, "/api")
-	var err error
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		klog.Fatalf("unable parse url %s: %s", c.URL, err)
+	}
 	factory.w, err = crcwatch.NewWatch(resTypes, crcwatch.SetUserInfo(userInfo),
 		crcwatch.SetAPIAuth(c.APIUsername, c.APIPassword),
-		crcwatch.SetHost(host),
+		crcwatch.SetHost(u.Host),
+		crcwatch.SetScheme(u.Scheme),
+		crcwatch.SetAllowInsecure(c.AllowInsecure),
 		crcwatch.SetPollingInterval(10*time.Second))
 	if err != nil {
 		klog.Fatalln("fail to init crc watch client", err)

--- a/plugin/tower/pkg/informer/factory_crc_test.go
+++ b/plugin/tower/pkg/informer/factory_crc_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/agiledragon/gomonkey"
+	"github.com/everoute/graphc/pkg/crcwatch"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -44,6 +45,7 @@ var (
 	crcFactory               *informer.CrcFactory
 	eventChanLabel           chan *informer.CrcEvent
 	eventChanEverouteCluster chan *informer.CrcEvent
+	crcWatchOpts             *crcwatch.Options
 )
 
 const (
@@ -56,6 +58,24 @@ func TestFactorCrc(t *testing.T) {
 	RunSpecs(t, "Factory CRC test suit")
 }
 
+type fakeResourceChangeWatcher struct{}
+
+func (f *fakeResourceChangeWatcher) Start(_ *watchor.ResourceChangeWatchStartParams) error {
+	return nil
+}
+
+func (f *fakeResourceChangeWatcher) Channel() <-chan *models.ResourceChangeEvent {
+	return eventChanInject
+}
+
+func (f *fakeResourceChangeWatcher) ErrorChannel() <-chan *watchor.ErrorEvent {
+	return errorChanInject
+}
+
+func (f *fakeResourceChangeWatcher) WarningChannel() <-chan *watchor.WarningEvent {
+	return nil
+}
+
 var _ = BeforeSuite(func() {
 	eventChanInject = make(chan *models.ResourceChangeEvent, 100)
 	errorChanInject = make(chan *watchor.ErrorEvent, 100)
@@ -64,6 +84,12 @@ var _ = BeforeSuite(func() {
 		func(_ apiclient.ClientConfig, _ apiclient.UserConfig) (*apiclient.Cloudtower, error) {
 			By("gomonkey apiclient.NewWithUserConfig")
 			return &apiclient.Cloudtower{}, nil
+		})
+	mock.ApplyFunc(crcwatch.NewWatchClient,
+		func(_ []string, opts *crcwatch.Options) (crcwatch.ResourceChangeWatcher, error) {
+			By("gomonkey crcwatch.NewWatchClient")
+			crcWatchOpts = opts
+			return &fakeResourceChangeWatcher{}, nil
 		})
 	mock.ApplyMethod(reflect.TypeOf(&watchor.ResourceChangeWatchClient{}), "Start",
 		func(m *watchor.ResourceChangeWatchClient, p *watchor.ResourceChangeWatchStartParams) error {
@@ -82,7 +108,9 @@ var _ = BeforeSuite(func() {
 		})
 
 	crcFactory = informer.MustNewCrcFactory(&client.Client{
-		UserInfo: &client.UserInfo{},
+		URL:           "https://127.0.0.1:21003/api",
+		AllowInsecure: true,
+		UserInfo:      &client.UserInfo{},
 	})
 
 	eventChanLabel = crcFactory.RegisterEvent(reflect.TypeOf(&schema.Label{}))
@@ -103,6 +131,12 @@ var _ = Describe("Factory CRC", func() {
 		})
 		It("should create factory", func() {
 			Expect(crcFactory).NotTo(BeNil())
+		})
+		It("should configure crcwatch endpoint", func() {
+			Expect(crcWatchOpts).NotTo(BeNil())
+			Expect(crcWatchOpts.Host).To(Equal("127.0.0.1:21003"))
+			Expect(crcWatchOpts.Scheme).To(Equal("https"))
+			Expect(crcWatchOpts.AllowInsecure).To(BeTrue())
 		})
 
 		When("common resource event - label event", func() {


### PR DESCRIPTION
## Summary
- update graphc to the merged main version with crcwatch client options
- configure crcwatch scheme and insecure settings from tower options
- add tests for crcwatch client configuration

## Test
- go test ./plugin/tower/pkg/informer