### PR TITLE
Add k8scluster policy skip fields

### DIFF
--- a/deploy/chart/templates/crds/pod.everoute.io_k8sclusters.yaml
+++ b/deploy/chart/templates/crds/pod.everoute.io_k8sclusters.yaml
@@ -56,6 +56,10 @@ spec:
                 description: K8sClusterManagedPlatform the platform that a k8scluster
                   managedby.
                 type: string
+              skipEICPodSecurityPolicy:
+                type: boolean
+              skipNodeSecurityPolicy:
+                type: boolean
               sksOption:
                 properties:
                   kscName:

--- a/deploy/everoute.yaml
+++ b/deploy/everoute.yaml
@@ -923,6 +923,10 @@ spec:
                 description: K8sClusterManagedPlatform the platform that a k8scluster
                   managedby.
                 type: string
+              skipEICPodSecurityPolicy:
+                type: boolean
+              skipNodeSecurityPolicy:
+                type: boolean
               sksOption:
                 properties:
                   kscName:

--- a/deploy/microsegment/chart/templates/crds/pod.everoute.io_k8sclusters.yaml
+++ b/deploy/microsegment/chart/templates/crds/pod.everoute.io_k8sclusters.yaml
@@ -56,6 +56,10 @@ spec:
                 description: K8sClusterManagedPlatform the platform that a k8scluster
                   managedby.
                 type: string
+              skipEICPodSecurityPolicy:
+                type: boolean
+              skipNodeSecurityPolicy:
+                type: boolean
               sksOption:
                 properties:
                   kscName:

--- a/pkg/apis/pod/v1alpha1/types.go
+++ b/pkg/apis/pod/v1alpha1/types.go
@@ -42,7 +42,9 @@ type K8sClusterSpec struct {
 	CNI                   K8sClusterCNIType         `json:"cni"`
 	ManagedBy             K8sClusterManagedPlatform `json:"managedBy"`
 
-	SksOption *SksOption `json:"sksOption,omitempty"`
+	SksOption                *SksOption `json:"sksOption,omitempty"`
+	SkipNodeSecurityPolicy   bool       `json:"skipNodeSecurityPolicy,omitempty"`
+	SkipEICPodSecurityPolicy bool       `json:"skipEICPodSecurityPolicy,omitempty"`
 }
 
 type SksOption struct {


### PR DESCRIPTION
## Purpose
Add Everoute-controlled K8sCluster flags for suppressing generated security policies.

## Changes
- Add `spec.skipNodeSecurityPolicy` to K8sCluster CRD/API.
- Add `spec.skipEICPodSecurityPolicy` to K8sCluster CRD/API.
- Regenerate chart CRDs and rendered `deploy/everoute.yaml`.

## Tests
- `make docker-generate`
- `make image-debug`, produced and pushed `registry.smtx.io/everoute/debug:451c66c`
- Deployed debug controller image to `172.21.150.120`, `172.21.150.121`, and `172.21.150.122`; each `eradm update --allow-pull` completed and `https://127.0.0.1:9445/healthz` returned `ok`.

## Notes
- Companion sks-plugin PR: https://github.com/everoute/sks-plugin/pull/21
