### PR TITLE
feat(er-1780): wait startup flow sync before cleanup

### DIFF
--- a/cmd/everoute-agent/config.go
+++ b/cmd/everoute-agent/config.go
@@ -49,6 +49,7 @@ type Options struct {
 	disableProbeTimeoutIP    bool
 	readyToProcessGlobalRule bool
 	flowRoundCleanDelay      time.Duration
+	disableInitSyncClean     bool
 	policyRuleEstimateLimit  uint64
 	policyMemoryThreshold    uint64
 	disablePolicyMemoryGuard bool

--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -90,6 +90,8 @@ func main() {
 	flag.BoolVar(&opts.readyToProcessGlobalRule, "ready-to-process-global-rule", false, "Is ready to process global rule when agent start.")
 	flag.DurationVar(&opts.flowRoundCleanDelay, "flow-round-clean-delay", 90*time.Second,
 		"Delay before cleaning previous round flows and persisting current round.")
+	flag.BoolVar(&opts.disableInitSyncClean, "disable-clean-after-init-sync-flow", false,
+		"Disable waiting to clean previous round flows until startup flow sync is complete.")
 	flag.Uint64Var(&opts.policyRuleEstimateLimit, "policy-rule-estimate-limit", policy.DefaultPolicyRuleEstimateLimit,
 		"Maximum estimated policy rule expansion allowed before policy reconcile is rejected. 0 disables the limit.")
 	flag.Uint64Var(&opts.policyMemoryThreshold, "policy-memory-threshold-bytes", 0,
@@ -126,6 +128,9 @@ func main() {
 	// TODO Update vds which is managed by everoute agent from datapathConfig.
 	datapathConfig := opts.getDatapathConfig()
 	datapathManager := datapath.NewDatapathManager(datapathConfig, ofportIPMonitorChan, agentMetric)
+	if !opts.disableInitSyncClean {
+		datapathManager.SetStartupFlowSync(datapath.NewStartupFlowSync())
+	}
 	datapathManager.InitializeDatapath(stopCtx)
 
 	var mgr manager.Manager
@@ -274,6 +279,8 @@ func startManager(ctx context.Context, mgr manager.Manager, datapathManager *dat
 	overlaySyncChan chan event.GenericEvent) (*ctrlProxy.Cache, policy.GuardRuntimeSetter, error) {
 	var err error
 	var policyGuardSetter policy.GuardRuntimeSetter
+	startupPolicyControllerStarted := false
+	startupTRControllerStarted := false
 	if opts.IsEnableMS() {
 		// Policy controller: watch policy related resource and update
 		policyReconciler := &policy.Reconciler{
@@ -282,6 +289,7 @@ func startManager(ctx context.Context, mgr manager.Manager, datapathManager *dat
 			DatapathManager:          datapathManager,
 			ManagedVDSes:             datapathManager.Config.MSVdsSet.Clone(),
 			ReadyToProcessGlobalRule: opts.readyToProcessGlobalRule,
+			StartupFlowSync:          datapathManager.StartupFlowSync(),
 		}
 		if err = policyReconciler.SetupWithManager(
 			mgr,
@@ -292,15 +300,20 @@ func startManager(ctx context.Context, mgr manager.Manager, datapathManager *dat
 			klog.Fatalf("unable to create policy controller: %s", err.Error())
 		}
 		policyGuardSetter = policyReconciler
+		startupPolicyControllerStarted = true
 	}
 	if opts.IsEnableTR() {
-		if err = (&trctrl.Reconciler{
-			Client: mgr.GetClient(),
-			DpMgr:  datapathManager,
-		}).SetupWithManager(mgr); err != nil {
+		trReconciler := &trctrl.Reconciler{
+			Client:          mgr.GetClient(),
+			DpMgr:           datapathManager,
+			StartupFlowSync: datapathManager.StartupFlowSync(),
+		}
+		if err = trReconciler.SetupWithManager(mgr); err != nil {
 			klog.Fatalf("unable to create trafficredirect controller: %s", err.Error())
 		}
+		startupTRControllerStarted = true
 	}
+	markUnstartedStartupFlowSyncDone(datapathManager.StartupFlowSync(), startupPolicyControllerStarted, startupTRControllerStarted)
 
 	var proxyCache *ctrlProxy.Cache
 	if opts.IsEnableCNI() {
@@ -377,6 +390,19 @@ func startManager(ctx context.Context, mgr manager.Manager, datapathManager *dat
 	}()
 
 	return proxyCache, policyGuardSetter, nil
+}
+
+func markUnstartedStartupFlowSyncDone(startupFlowSync *datapath.StartupFlowSync, policyControllerStarted, trControllerStarted bool) {
+	if startupFlowSync == nil {
+		return
+	}
+	if !policyControllerStarted {
+		startupFlowSync.MarkNormalPolicyDone()
+		startupFlowSync.MarkGlobalPolicyDone()
+	}
+	if !trControllerStarted {
+		startupFlowSync.MarkTrafficRedirectDone()
+	}
 }
 
 func resourceInit(ctx context.Context, mgr manager.Manager, datapathManager *datapath.DpManager) {

--- a/pkg/agent/controller/policy/global_policy_controller.go
+++ b/pkg/agent/controller/policy/global_policy_controller.go
@@ -66,6 +66,9 @@ func (r *Reconciler) ReconcileGlobalPolicy(ctx context.Context, _ ctrl.Request) 
 		ctx = context.WithValue(ctx, ertypes.CtxKeyObject, policy.Spec)
 	}
 	_ = r.syncPolicyRulesUntilSuccess(ctx, []string{}, oldPolicyRule, newPolicyRule)
+	if r.StartupFlowSync != nil {
+		r.StartupFlowSync.MarkGlobalPolicyDone()
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/agent/controller/policy/policy_controller.go
+++ b/pkg/agent/controller/policy/policy_controller.go
@@ -39,11 +39,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	crsource "sigs.k8s.io/controller-runtime/pkg/source"
 
 	policycache "github.com/everoute/everoute/pkg/agent/controller/policy/cache"
 	"github.com/everoute/everoute/pkg/agent/datapath"
 	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/common/startupsync"
 	"github.com/everoute/everoute/pkg/constants"
 	msconst "github.com/everoute/everoute/pkg/constants/ms"
 	ctrlpolicy "github.com/everoute/everoute/pkg/controller/policy"
@@ -71,25 +73,34 @@ type Reconciler struct {
 	// before GroupPatch deleted, so save patches in cache.
 	groupCache *policycache.GroupCache
 
-	DatapathManager *datapath.DpManager
-	ManagedVDSes    sets.Set[string]
+	DatapathManager          *datapath.DpManager
+	ManagedVDSes             sets.Set[string]
+	StartupFlowSync          *datapath.StartupFlowSync
+	StartupPolicyQueue       chan event.GenericEvent
+	StartupGroupMembersQueue chan event.GenericEvent
+	StartupGlobalPolicyQueue chan event.GenericEvent
 
-	sysProcessedPolicyLock sync.RWMutex
-	sysProcessedPolicy     sets.Set[k8stypes.NamespacedName]
+	startupPolicySync       *startupsync.Reconciler
+	startupGroupMembersSync *startupsync.Reconciler
 
-	ReadyToProcessGlobalRule     bool
-	globalRuleFirstProcessedTime *time.Time
+	ReadyToProcessGlobalRule bool
 
 	memoryGuard       *MemoryGuard
 	ruleEstimateGuard *RuleEstimateGuard
 }
 
 func (r *Reconciler) ReconcilePolicy(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var policy securityv1alpha1.SecurityPolicy
+	if r.startupPolicySync != nil {
+		return r.startupPolicySync.Reconcile(ctx, req, r.reconcilePolicy)
+	}
+	return r.reconcilePolicy(ctx, req)
+}
 
+func (r *Reconciler) reconcilePolicy(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.reconcilerLock.Lock()
 	defer r.reconcilerLock.Unlock()
 
+	var policy securityv1alpha1.SecurityPolicy
 	log := ctrl.LoggerFrom(ctx)
 	log.V(4).Info("Reconcile start")
 	defer log.V(4).Info("Reconcile end")
@@ -132,6 +143,13 @@ func (r *Reconciler) ReconcilePolicy(ctx context.Context, req ctrl.Request) (ctr
 }
 
 func (r *Reconciler) ReconcileGroupMembers(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if r.startupGroupMembersSync != nil {
+		return r.startupGroupMembersSync.Reconcile(ctx, req, r.reconcileGroupMembers)
+	}
+	return r.reconcileGroupMembers(ctx, req)
+}
+
+func (r *Reconciler) reconcileGroupMembers(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.reconcilerLock.Lock()
 	defer r.reconcilerLock.Unlock()
 
@@ -305,8 +323,6 @@ func (r *Reconciler) SetupWithManager(
 		r.ruleEstimateGuard.setEnabled(false)
 	}
 
-	r.sysProcessedPolicy = make(sets.Set[k8stypes.NamespacedName])
-
 	if policyController, err = controller.New("policy-controller", mgr, controller.Options{
 		MaxConcurrentReconciles: constants.DefaultMaxConcurrentReconciles,
 		Reconciler:              reconcile.Func(r.ReconcilePolicy),
@@ -349,7 +365,33 @@ func (r *Reconciler) SetupWithManager(
 		return err
 	}
 
-	return globalPolicyController.Watch(source.Kind(mgr.GetCache(), &securityv1alpha1.GlobalPolicy{}), &handler.EnqueueRequestForObject{})
+	if err = globalPolicyController.Watch(source.Kind(mgr.GetCache(), &securityv1alpha1.GlobalPolicy{}), &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if r.StartupFlowSync != nil {
+		if r.StartupPolicyQueue == nil {
+			r.StartupPolicyQueue = make(chan event.GenericEvent, 1)
+		}
+		if r.StartupGroupMembersQueue == nil {
+			r.StartupGroupMembersQueue = make(chan event.GenericEvent, 1)
+		}
+		if r.StartupGlobalPolicyQueue == nil {
+			r.StartupGlobalPolicyQueue = make(chan event.GenericEvent, 1)
+		}
+		r.initStartupPolicyReconciler()
+		r.initStartupGroupMembersReconciler()
+		if err = policyController.Watch(&crsource.Channel{Source: r.StartupPolicyQueue}, &handler.EnqueueRequestForObject{}); err != nil {
+			return err
+		}
+		if err = patchController.Watch(&crsource.Channel{Source: r.StartupGroupMembersQueue}, &handler.EnqueueRequestForObject{}); err != nil {
+			return err
+		}
+		if err = globalPolicyController.Watch(&crsource.Channel{Source: r.StartupGlobalPolicyQueue}, &handler.EnqueueRequestForObject{}); err != nil {
+			return err
+		}
+		r.EnqueueStartupFlowSync(context.Background())
+	}
+	return nil
 }
 
 func (r *Reconciler) ruleUpdateByGroup(ctx context.Context, gm *groupv1alpha1.GroupMembers) error {
@@ -521,7 +563,6 @@ func (r *Reconciler) processPolicyUpdate(ctx context.Context, policy *securityv1
 	}
 
 	r.updateCompleteRuleCache(oldCompleteRules, newCompleteRules)
-	r.addProcessedSysPolicy(k8stypes.NamespacedName{Namespace: policy.Namespace, Name: policy.Name})
 	return ctrl.Result{}, nil
 }
 
@@ -922,41 +963,11 @@ func (r *Reconciler) addPolicyRuleToDatapath(ctx context.Context, ruleID string,
 }
 
 func (r *Reconciler) isReadyToProcessGlobalRule(ctx context.Context) bool {
-	log := ctrl.LoggerFrom(ctx)
 	if r.ReadyToProcessGlobalRule {
 		return true
 	}
-	if r.globalRuleFirstProcessedTime == nil {
-		curT := time.Now()
-		r.globalRuleFirstProcessedTime = &curT
-		log.Info("At least wait sometime when first process global rule", "waitTime", msconst.GlobalRuleFirstDelayTime)
-		time.Sleep(msconst.GlobalRuleFirstDelayTime)
-	} else if time.Now().After(r.globalRuleFirstProcessedTime.Add(msconst.GlobalRuleDelayTimeout)) {
-		r.ReadyToProcessGlobalRule = true
-		log.Info("It has waited enough time, begin to process global rule", "timeout", msconst.GlobalRuleDelayTimeout)
-		return true
+	if r.StartupFlowSync != nil {
+		return r.StartupFlowSync.NormalPolicyDone()
 	}
-
-	r.sysProcessedPolicyLock.RLock()
-	defer r.sysProcessedPolicyLock.RUnlock()
-	if !r.sysProcessedPolicy.Has(msconst.SysEPPolicy) {
-		return false
-	}
-	if !r.sysProcessedPolicy.Has(msconst.ERvmPolicy) {
-		return false
-	}
-	if !r.sysProcessedPolicy.Has(msconst.LBPolicy) {
-		return false
-	}
-	r.ReadyToProcessGlobalRule = true
 	return true
-}
-
-func (r *Reconciler) addProcessedSysPolicy(p k8stypes.NamespacedName) {
-	r.sysProcessedPolicyLock.Lock()
-	defer r.sysProcessedPolicyLock.Unlock()
-
-	if p == msconst.SysEPPolicy || p == msconst.ERvmPolicy || p == msconst.LBPolicy {
-		r.sysProcessedPolicy.Insert(p)
-	}
 }

--- a/pkg/agent/controller/policy/policy_controller_helper.go
+++ b/pkg/agent/controller/policy/policy_controller_helper.go
@@ -28,15 +28,95 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	policycache "github.com/everoute/everoute/pkg/agent/controller/policy/cache"
 	"github.com/everoute/everoute/pkg/agent/datapath"
+	groupv1alpha1 "github.com/everoute/everoute/pkg/apis/group/v1alpha1"
 	securityv1alpha1 "github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	"github.com/everoute/everoute/pkg/common/startupsync"
 	"github.com/everoute/everoute/pkg/constants"
+	"github.com/everoute/everoute/pkg/source"
 	ertypes "github.com/everoute/everoute/pkg/types"
 )
 
 const GroupMembersRscType = "groupMembers"
+
+var startupGlobalPolicySyncRequest = types.NamespacedName{Name: "__everoute_startup_global_policy_sync__"}
+
+func (r *Reconciler) EnqueueStartupFlowSync(ctx context.Context) {
+	if r.StartupFlowSync == nil {
+		return
+	}
+	r.startupPolicySync.Enqueue(ctx)
+	r.startupGroupMembersSync.Enqueue(ctx)
+	r.enqueueStartupGlobalPolicySync(ctx)
+}
+
+func (r *Reconciler) initStartupPolicyReconciler() {
+	r.startupPolicySync = &startupsync.Reconciler{
+		Queue:        r.StartupPolicyQueue,
+		ListExpected: r.listStartupPolicyKeys,
+		MarkDone:     r.markStartupNormalPolicyDone,
+	}
+}
+
+func (r *Reconciler) initStartupGroupMembersReconciler() {
+	r.startupGroupMembersSync = &startupsync.Reconciler{
+		Queue:        r.StartupGroupMembersQueue,
+		ListExpected: r.listStartupGroupMembersKeys,
+		MarkDone:     r.markStartupNormalPolicyDone,
+	}
+}
+
+func (r *Reconciler) enqueueStartupGlobalPolicySync(ctx context.Context) {
+	if r.StartupGlobalPolicyQueue == nil {
+		return
+	}
+	log := ctrl.LoggerFrom(ctx)
+	select {
+	case r.StartupGlobalPolicyQueue <- source.NewResourceEvent(startupGlobalPolicySyncRequest.Name, startupGlobalPolicySyncRequest.Namespace):
+		log.Info("Enqueued startup sync request")
+	case <-ctx.Done():
+	default:
+	}
+}
+
+func (r *Reconciler) listStartupPolicyKeys(ctx context.Context) (sets.Set[string], error) {
+	policyList := securityv1alpha1.SecurityPolicyList{}
+	if err := r.List(ctx, &policyList); err != nil {
+		return nil, err
+	}
+	expected := sets.New[string]()
+	for i := range policyList.Items {
+		key := client.ObjectKeyFromObject(&policyList.Items[i])
+		expected.Insert(key.String())
+	}
+	return expected, nil
+}
+
+func (r *Reconciler) listStartupGroupMembersKeys(ctx context.Context) (sets.Set[string], error) {
+	groupMembersList := groupv1alpha1.GroupMembersList{}
+	if err := r.List(ctx, &groupMembersList); err != nil {
+		return nil, err
+	}
+	expected := sets.New[string]()
+	for i := range groupMembersList.Items {
+		key := client.ObjectKeyFromObject(&groupMembersList.Items[i])
+		expected.Insert(key.String())
+	}
+	return expected, nil
+}
+
+func (r *Reconciler) markStartupNormalPolicyDone() {
+	if r.startupPolicySync == nil || r.startupGroupMembersSync == nil {
+		return
+	}
+	if r.startupPolicySync.IsDone() && r.startupGroupMembersSync.IsDone() {
+		r.StartupFlowSync.MarkNormalPolicyDone()
+	}
+}
 
 func NewGroupMembersNotFoundErr(groupName string) error {
 	return ertypes.NewRscInCacheNotFoundErr(GroupMembersRscType, types.NamespacedName{Name: groupName})

--- a/pkg/agent/controller/policy/suite_test.go
+++ b/pkg/agent/controller/policy/suite_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/everoute/everoute/pkg/agent/controller/policy/cache"
 	"github.com/everoute/everoute/pkg/agent/datapath"
 	clientsetscheme "github.com/everoute/everoute/pkg/client/clientset_generated/clientset/scheme"
-	msconst "github.com/everoute/everoute/pkg/constants/ms"
 	"github.com/everoute/everoute/pkg/metrics"
 	"github.com/everoute/everoute/pkg/types"
 	"github.com/everoute/everoute/pkg/utils"
@@ -141,17 +140,13 @@ var _ = BeforeSuite(func() {
 	datapathManager.InitializeDatapath(ctx)
 
 	pCtrl = &Reconciler{
-		Client:          k8sManager.GetClient(),
-		Scheme:          k8sManager.GetScheme(),
-		DatapathManager: datapathManager,
+		Client:                   k8sManager.GetClient(),
+		Scheme:                   k8sManager.GetScheme(),
+		DatapathManager:          datapathManager,
+		ReadyToProcessGlobalRule: true,
 	}
 	err = (pCtrl).SetupWithManager(k8sManager, DefaultPolicyRuleEstimateLimit, 0, false, false)
 	Expect(err).ToNot(HaveOccurred())
-	cutT := time.Now()
-	pCtrl.globalRuleFirstProcessedTime = &cutT
-	pCtrl.sysProcessedPolicy.Insert(msconst.ERvmPolicy)
-	pCtrl.sysProcessedPolicy.Insert(msconst.SysEPPolicy)
-	pCtrl.sysProcessedPolicy.Insert(msconst.LBPolicy)
 
 	ruleCacheLister = pCtrl.GetCompleteRuleLister()
 	Expect(ruleCacheLister).ShouldNot(BeNil())

--- a/pkg/agent/controller/trafficredirect/controller.go
+++ b/pkg/agent/controller/trafficredirect/controller.go
@@ -7,19 +7,27 @@ import (
 	"github.com/everoute/trafficredirect/api/trafficredirect/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	crsource "sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/everoute/everoute/pkg/agent/datapath"
+	"github.com/everoute/everoute/pkg/common/startupsync"
 	"github.com/everoute/everoute/pkg/source"
 )
 
 type Reconciler struct {
 	client.Client
-	DpMgr *datapath.DpManager
-	cache *ruleCache
+	DpMgr           *datapath.DpManager
+	StartupFlowSync *datapath.StartupFlowSync
+	StartupQueue    chan event.GenericEvent
+	cache           *ruleCache
+
+	startupSync *startupsync.Reconciler
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -41,10 +49,30 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return c.Watch(source.Kind(mgr.GetCache(), &v1alpha1.Rule{}), &handler.EnqueueRequestForObject{})
+	if err = c.Watch(source.Kind(mgr.GetCache(), &v1alpha1.Rule{}), &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+	if r.StartupFlowSync != nil {
+		if r.StartupQueue == nil {
+			r.StartupQueue = make(chan event.GenericEvent, 1)
+		}
+		r.initStartupReconciler()
+		if err = c.Watch(&crsource.Channel{Source: r.StartupQueue}, &handler.EnqueueRequestForObject{}); err != nil {
+			return err
+		}
+		r.startupSync.Enqueue(context.Background())
+	}
+	return nil
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if r.startupSync != nil {
+		return r.startupSync.Reconcile(ctx, req, r.reconcile)
+	}
+	return r.reconcile(ctx, req)
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Reconcile start")
 	defer log.Info("Reconcile end")
@@ -93,4 +121,25 @@ func (r *Reconciler) add(ctx context.Context, k types.NamespacedName, newR *Loca
 	}
 	r.cache.add(k, newR)
 	return nil
+}
+
+func (r *Reconciler) initStartupReconciler() {
+	r.startupSync = &startupsync.Reconciler{
+		Queue:        r.StartupQueue,
+		ListExpected: r.listStartupRuleKeys,
+		MarkDone:     r.StartupFlowSync.MarkTrafficRedirectDone,
+	}
+}
+
+func (r *Reconciler) listStartupRuleKeys(ctx context.Context) (sets.Set[string], error) {
+	ruleList := v1alpha1.RuleList{}
+	if err := r.List(ctx, &ruleList); err != nil {
+		return nil, err
+	}
+	expected := sets.New[string]()
+	for i := range ruleList.Items {
+		key := client.ObjectKeyFromObject(&ruleList.Items[i])
+		expected.Insert(key.String())
+	}
+	return expected, nil
 }

--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -283,6 +283,7 @@ type DpManager struct {
 	FlowIDToTRRules           map[uint64]*DPTRRule
 
 	conntrackManager *conntrack.Manager
+	startupFlowSync  *StartupFlowSync
 
 	ArpChan    chan ArpInfo
 	ArpLimiter *rate.Limiter
@@ -488,6 +489,14 @@ func (dp *DpManager) lockRflowReplayWithTimeout() {
 	if !dp.flowReplayMutex.RTryLockWithTimeout(lockTimeout) {
 		klog.Fatalf("fail to acquire datapath flowReplayMutex read lock for %s", lockTimeout)
 	}
+}
+
+func (dp *DpManager) SetStartupFlowSync(startupFlowSync *StartupFlowSync) {
+	dp.startupFlowSync = startupFlowSync
+}
+
+func (dp *DpManager) StartupFlowSync() *StartupFlowSync {
+	return dp.startupFlowSync
 }
 
 // used by unittest
@@ -1228,7 +1237,7 @@ func InitializeVDS(ctx context.Context,
 	}
 
 	go reconcileNoForwardPorts(datapathManager, vdsID)
-	go DeletePreviousRoundFlow(datapathManager, vdsID, roundInfo)
+	go DeletePreviousRoundFlow(ctx, datapathManager, vdsID, roundInfo)
 }
 
 // check no-forward configuration
@@ -1292,13 +1301,17 @@ func reconcileNoForwardPorts(datapathManager *DpManager, vdsID string) {
 	}
 }
 
-// Delete flow with previousRoundNum cookie, and then persistent currentRoundNum to ovsdb. We need to wait for long
-// enough to guarantee that all of the basic flow which we are still required updated with new roundInfo encoding to
-// flow cookie fields. But the time required to update all of the basic flow with updated roundInfo is
-// non-determined.
-// TODO  Implement a deterministic mechanism to control outdated flow flush procedure
-func DeletePreviousRoundFlow(datapathManager *DpManager, vdsID string, roundInfo *RoundInfo) {
-	time.Sleep(datapathManager.Config.FlowRoundCleanDelay)
+// Delete flow with previousRoundNum cookie, and then persist currentRoundNum to ovsdb.
+func DeletePreviousRoundFlow(ctx context.Context, datapathManager *DpManager, vdsID string, roundInfo *RoundInfo) {
+	// Keep the original 90s clean delay because this cleanup also deletes old
+	// flows on non-policy bridges, and deleting them too early may break
+	// forwarding. Internal IP allow flows may also still be initializing; if
+	// global deny has already been installed, deleting the old allow flows too
+	// early may affect host-local traffic.
+	if err := datapathManager.StartupFlowSync().WaitWithMinDelay(ctx, vdsID, datapathManager.Config.FlowRoundCleanDelay, time.Minute); err != nil {
+		klog.Infof("Skip deleting previous round flows because startup flow sync wait stopped before cleanup, vdsID: %s, err: %v", vdsID, err)
+		return
+	}
 
 	klog.Infof(
 		"Delete previous round flows and persist current round info. vdsID: %s, roundNum: %d -> %d, datapathVersion: %s -> %s",

--- a/pkg/agent/datapath/startup_flow_sync.go
+++ b/pkg/agent/datapath/startup_flow_sync.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datapath
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+type StartupFlowSync struct {
+	lock sync.Mutex
+	done chan struct{}
+
+	normalPolicyDone    bool
+	globalPolicyDone    bool
+	trafficRedirectDone bool
+}
+
+func NewStartupFlowSync() *StartupFlowSync {
+	return &StartupFlowSync{
+		done: make(chan struct{}),
+	}
+}
+
+func (s *StartupFlowSync) MarkNormalPolicyDone() {
+	if s == nil {
+		return
+	}
+	s.markDone(&s.normalPolicyDone, "normal policy")
+}
+
+func (s *StartupFlowSync) MarkGlobalPolicyDone() {
+	if s == nil {
+		return
+	}
+	s.markDone(&s.globalPolicyDone, "global policy")
+}
+
+func (s *StartupFlowSync) MarkTrafficRedirectDone() {
+	if s == nil {
+		return
+	}
+	s.markDone(&s.trafficRedirectDone, "trafficredirect")
+}
+
+func (s *StartupFlowSync) NormalPolicyDone() bool {
+	if s == nil {
+		return true
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.normalPolicyDone
+}
+
+func (s *StartupFlowSync) AllDone() bool {
+	if s == nil {
+		return true
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.normalPolicyDone && s.globalPolicyDone && s.trafficRedirectDone
+}
+
+func (s *StartupFlowSync) WaitWithMinDelay(ctx context.Context, vdsID string, minDelay, logInterval time.Duration) error {
+	if logInterval <= 0 {
+		logInterval = time.Minute
+	}
+
+	ticker := time.NewTicker(logInterval)
+	defer ticker.Stop()
+
+	minDelayDone := minDelay <= 0
+	var delayDoneCh <-chan time.Time
+	if !minDelayDone {
+		delayTimer := time.NewTimer(minDelay)
+		defer delayTimer.Stop()
+		delayDoneCh = delayTimer.C
+	}
+
+	startupFlowSyncDone := true
+	var startupFlowSyncDoneCh <-chan struct{}
+	if s != nil {
+		startupFlowSyncDone = s.AllDone()
+		if !startupFlowSyncDone {
+			startupFlowSyncDoneCh = s.done
+		}
+	}
+	if startupFlowSyncDone {
+		startupFlowSyncDoneCh = nil
+	}
+
+	for {
+		if minDelayDone && startupFlowSyncDone {
+			s.logReadyToDeletePreviousRoundFlows(vdsID, minDelayDone)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			klog.Infof("Stop waiting before deleting previous round flows because context is done, vdsID: %s, err: %v", vdsID, ctx.Err())
+			return ctx.Err()
+		case <-startupFlowSyncDoneCh:
+			startupFlowSyncDone = true
+			startupFlowSyncDoneCh = nil
+			if minDelayDone {
+				s.logReadyToDeletePreviousRoundFlows(vdsID, minDelayDone)
+				return nil
+			}
+		case <-delayDoneCh:
+			minDelayDone = true
+			delayDoneCh = nil
+			if startupFlowSyncDone {
+				s.logReadyToDeletePreviousRoundFlows(vdsID, minDelayDone)
+				return nil
+			}
+			normalPolicyDone, globalPolicyDone, trafficRedirectDone := s.doneStatus()
+			klog.Infof("Flow round clean delay elapsed, waiting startup flow sync before deleting previous round flows, "+
+				"vdsID: %s, normalPolicyDone: %t, globalPolicyDone: %t, trafficRedirectDone: %t",
+				vdsID, normalPolicyDone, globalPolicyDone, trafficRedirectDone)
+		case <-ticker.C:
+			normalPolicyDone, globalPolicyDone, trafficRedirectDone := s.doneStatus()
+			klog.Infof("Waiting before deleting previous round flows, vdsID: %s, flowRoundCleanDelayDone: %t, normalPolicyDone: %t, globalPolicyDone: %t, trafficRedirectDone: %t",
+				vdsID, minDelayDone, normalPolicyDone, globalPolicyDone, trafficRedirectDone)
+		}
+	}
+}
+
+func (s *StartupFlowSync) logReadyToDeletePreviousRoundFlows(vdsID string, minDelayDone bool) {
+	if s == nil {
+		klog.Infof("Flow round clean delay completed and startup flow sync disabled, ready to delete previous round flows, "+
+			"vdsID: %s, flowRoundCleanDelayDone: %t", vdsID, minDelayDone)
+		return
+	}
+	normalPolicyDone, globalPolicyDone, trafficRedirectDone := s.doneStatus()
+	klog.Infof("Startup flow sync and flow round clean delay completed, ready to delete previous round flows, "+
+		"vdsID: %s, flowRoundCleanDelayDone: %t, normalPolicyDone: %t, globalPolicyDone: %t, trafficRedirectDone: %t",
+		vdsID, minDelayDone, normalPolicyDone, globalPolicyDone, trafficRedirectDone)
+}
+
+func (s *StartupFlowSync) markDone(done *bool, name string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if *done {
+		return
+	}
+	*done = true
+	klog.Infof("Startup %s flow sync done", name)
+	if s.normalPolicyDone && s.globalPolicyDone && s.trafficRedirectDone {
+		close(s.done)
+	}
+}
+
+func (s *StartupFlowSync) doneStatus() (normalPolicyDone, globalPolicyDone, trafficRedirectDone bool) {
+	if s == nil {
+		return true, true, true
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.normalPolicyDone, s.globalPolicyDone, s.trafficRedirectDone
+}

--- a/pkg/agent/datapath/startup_flow_sync_test.go
+++ b/pkg/agent/datapath/startup_flow_sync_test.go
@@ -1,0 +1,87 @@
+package datapath
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStartupFlowSyncWaitWithMinDelayWaitsForBothConditions(t *testing.T) {
+	sync := NewStartupFlowSync()
+
+	result := waitStartupFlowSync(t, sync, 20*time.Millisecond)
+
+	select {
+	case err := <-result:
+		t.Fatalf("wait returned before startup flow sync done: %v", err)
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	sync.MarkNormalPolicyDone()
+	sync.MarkGlobalPolicyDone()
+	sync.MarkTrafficRedirectDone()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("wait returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("wait should return after startup flow sync done and min delay elapsed")
+	}
+}
+
+func TestStartupFlowSyncWaitWithMinDelayWaitsForMinDelayWhenStartupAlreadyDone(t *testing.T) {
+	sync := NewStartupFlowSync()
+	sync.MarkNormalPolicyDone()
+	sync.MarkGlobalPolicyDone()
+	sync.MarkTrafficRedirectDone()
+
+	result := waitStartupFlowSync(t, sync, 80*time.Millisecond)
+
+	select {
+	case err := <-result:
+		t.Fatalf("wait returned before min delay elapsed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("wait returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("wait should return after min delay elapsed")
+	}
+}
+
+func TestStartupFlowSyncWaitWithMinDelayReturnsOnContextCancel(t *testing.T) {
+	sync := NewStartupFlowSync()
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+
+	go func() {
+		result <- sync.WaitWithMinDelay(ctx, "", time.Hour, time.Hour)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatalf("expected context cancellation error")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("wait should return after context cancellation")
+	}
+}
+
+func waitStartupFlowSync(t *testing.T, sync *StartupFlowSync, minDelay time.Duration) <-chan error {
+	t.Helper()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- sync.WaitWithMinDelay(context.Background(), "", minDelay, time.Hour)
+	}()
+	return result
+}

--- a/pkg/common/startupsync/reconciler.go
+++ b/pkg/common/startupsync/reconciler.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Everoute Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package startupsync
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/everoute/everoute/pkg/common/initsync"
+	"github.com/everoute/everoute/pkg/source"
+)
+
+type Reconciler struct {
+	Queue chan event.GenericEvent
+	// ListExpected should return resources that can enter reconcile. If a
+	// controller uses predicates to filter out part of the watched resources,
+	// this function must apply the same filter to avoid waiting for resources
+	// that will never be marked processed.
+	ListExpected func(context.Context) (sets.Set[string], error)
+	MarkDone     func()
+
+	tracker *initsync.Tracker
+}
+
+var request = types.NamespacedName{Name: "__everoute_startup_sync__"}
+
+func (r *Reconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request,
+	reconcile func(context.Context, ctrl.Request) (ctrl.Result, error),
+) (ctrl.Result, error) {
+	if r == nil {
+		// Startup sync is disabled for this controller.
+		return reconcile(ctx, req)
+	}
+	if r.IsDone() {
+		if req.NamespacedName == request {
+			return ctrl.Result{}, nil
+		}
+		return reconcile(ctx, req)
+	}
+
+	if req.NamespacedName == request {
+		ctrl.LoggerFrom(ctx).Info("Received startup sync request, checking startup completion")
+		r.checkDone(ctx)
+		return ctrl.Result{}, nil
+	}
+
+	res, err := reconcile(ctx, req)
+	if err == nil && !res.Requeue && res.RequeueAfter == 0 {
+		r.markProcessed(ctx, req.NamespacedName)
+	}
+	return res, err
+}
+
+func (r *Reconciler) Enqueue(ctx context.Context) {
+	if r == nil || r.Queue == nil {
+		return
+	}
+
+	select {
+	case r.Queue <- source.NewResourceEvent(request.Name, request.Namespace):
+		ctrl.LoggerFrom(ctx).Info("Enqueued startup sync request")
+	case <-ctx.Done():
+	default:
+	}
+}
+
+func (r *Reconciler) checkDone(ctx context.Context) {
+	if r == nil || r.ListExpected == nil {
+		return
+	}
+	expected, err := r.ListExpected(ctx)
+	if err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "Failed to list startup resources")
+		r.Enqueue(contextWithLogger(context.Background(), ctx))
+		return
+	}
+
+	_, justDone, processed := r.initTracker().CheckDone(expected)
+	if justDone {
+		ctrl.LoggerFrom(ctx).Info("Startup flow sync completed", "processedCount", len(processed))
+		if r.MarkDone != nil {
+			r.MarkDone()
+		}
+	}
+}
+
+func (r *Reconciler) markProcessed(ctx context.Context, key types.NamespacedName) {
+	if r == nil || r.IsDone() {
+		return
+	}
+
+	isNew, processed, recorded := r.initTracker().MarkProcessed(key.String())
+	if !recorded {
+		return
+	}
+	ctrl.LoggerFrom(ctx).Info("Startup resource processed", "key", key, "isNew", isNew, "processedCount", len(processed))
+	r.checkDone(ctx)
+}
+
+func (r *Reconciler) IsDone() bool {
+	return r != nil && r.initTracker().IsDone()
+}
+
+func contextWithLogger(ctx, from context.Context) context.Context {
+	return ctrl.LoggerInto(ctx, ctrl.LoggerFrom(from))
+}
+
+func (r *Reconciler) initTracker() *initsync.Tracker {
+	if r.tracker == nil {
+		r.tracker = initsync.NewTracker()
+	}
+	return r.tracker
+}

--- a/pkg/common/startupsync/reconciler_test.go
+++ b/pkg/common/startupsync/reconciler_test.go
@@ -1,0 +1,113 @@
+package startupsync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestReconcileStartupRequestChecksDone(t *testing.T) {
+	markDoneCount := 0
+	reconciler := &Reconciler{
+		ListExpected: func(context.Context) (sets.Set[string], error) {
+			return sets.New[string](), nil
+		},
+		MarkDone: func() {
+			markDoneCount++
+		},
+	}
+
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: request}, func(context.Context, ctrl.Request) (ctrl.Result, error) {
+		t.Fatalf("business reconcile should not be called for startup request")
+		return ctrl.Result{}, nil
+	})
+	if err != nil || res != (ctrl.Result{}) {
+		t.Fatalf("unexpected reconcile result, res=%+v err=%v", res, err)
+	}
+	if markDoneCount != 1 {
+		t.Fatalf("expected MarkDone called once, got %d", markDoneCount)
+	}
+	if !reconciler.IsDone() {
+		t.Fatalf("reconciler should be done after empty expected startup check")
+	}
+}
+
+func TestReconcileMarksProcessedAfterSuccessfulBusinessReconcile(t *testing.T) {
+	key := types.NamespacedName{Namespace: "ns", Name: "rule-a"}
+	markDoneCount := 0
+	reconciler := &Reconciler{
+		ListExpected: func(context.Context) (sets.Set[string], error) {
+			return sets.New[string](key.String()), nil
+		},
+		MarkDone: func() {
+			markDoneCount++
+		},
+	}
+
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}, func(context.Context, ctrl.Request) (ctrl.Result, error) {
+		return ctrl.Result{}, nil
+	})
+	if err != nil || res != (ctrl.Result{}) {
+		t.Fatalf("unexpected reconcile result, res=%+v err=%v", res, err)
+	}
+	if markDoneCount != 1 {
+		t.Fatalf("expected MarkDone called once, got %d", markDoneCount)
+	}
+	if !reconciler.IsDone() {
+		t.Fatalf("reconciler should be done after expected key processed")
+	}
+}
+
+func TestReconcileDoesNotMarkProcessedWhenBusinessReconcileRequeues(t *testing.T) {
+	key := types.NamespacedName{Namespace: "ns", Name: "rule-a"}
+	reconciler := &Reconciler{
+		ListExpected: func(context.Context) (sets.Set[string], error) {
+			return sets.New[string](key.String()), nil
+		},
+		MarkDone: func() {
+			t.Fatalf("MarkDone should not be called when business reconcile requeues")
+		},
+	}
+
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}, func(context.Context, ctrl.Request) (ctrl.Result, error) {
+		return ctrl.Result{Requeue: true}, nil
+	})
+	if err != nil || !res.Requeue {
+		t.Fatalf("unexpected reconcile result, res=%+v err=%v", res, err)
+	}
+	if reconciler.IsDone() {
+		t.Fatalf("reconciler should not be done after requeued business reconcile")
+	}
+}
+
+func TestCheckDoneListErrorRequeuesStartupRequest(t *testing.T) {
+	queue := make(chan event.GenericEvent, 1)
+	reconciler := &Reconciler{
+		Queue: queue,
+		ListExpected: func(context.Context) (sets.Set[string], error) {
+			return nil, errors.New("list failed")
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: request}, func(context.Context, ctrl.Request) (ctrl.Result, error) {
+		t.Fatalf("business reconcile should not be called for startup request")
+		return ctrl.Result{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	select {
+	case event := <-queue:
+		if event.Object.GetName() != request.Name || event.Object.GetNamespace() != request.Namespace {
+			t.Fatalf("unexpected startup event object %s/%s", event.Object.GetNamespace(), event.Object.GetName())
+		}
+	default:
+		t.Fatalf("expected startup request requeued after list error")
+	}
+}


### PR DESCRIPTION
## 目标

agent 重启后，删除上一轮 flow 前需要确保新一轮关键流表已经完成初始化，避免旧 flow 过早删除导致转发或本机流量受影响。

需要等待的初始化内容包括：

- normal policy flow
  - SecurityPolicy
  - GroupMembers
- global policy flow
- trafficredirect flow

同时，删除旧 flow 的时间仍然不能早于原来的 `flow-round-clean-delay`，默认 90s。原因是旧 flow 清理不仅会清理 policy bridge，也会清理 non-policy bridge 上的旧 flow；另外 internal IP 放通 flow 可能仍在初始化，如果此时 global deny 已经下发，过早删除旧的 internal IP 放通 flow 可能影响本机流量。

## 方案

新增 startup flow sync 机制，在 agent 启动时为相关 controller 主动触发一次 startup reconcile：

- policy controller 启动后 enqueue startup sync event
- groupMembers controller 启动后 enqueue startup sync event
- global policy controller 启动后 enqueue 一个特殊的 startup event
- trafficredirect controller 启动后 enqueue startup sync event

主动 enqueue 的原因是：启动完成后不一定会立刻有资源增删改事件。如果当前集群里对应资源为空，或者资源已经存在但没有新的 watch event，controller 可能不会再次进入 reconcile，也就无法判断 startup sync 是否完成。因此启动时需要通过 synthetic startup event 至少触发一次 reconcile，让 controller 基于当前 cache 状态完成 startup done 判断。

资源是否处理完成的判断方式：

- startup sync event 触发后，controller 从本地 cache list 当前已有资源，得到 expected key 集合。
- 普通资源 reconcile 成功且没有 requeue 时，将该资源的 `namespace/name` 记录为 processed。
- 每次记录 processed 后，重新 list expected 并判断 processed 是否已经覆盖 expected。
- 如果 expected 为空，startup sync event 会直接完成，覆盖空集合场景。
- 如果 list expected 失败，会重新 enqueue startup sync event，后续再检查。

这个判断方式要求 expected 里的资源都能正常进入 reconcile。如果某个 controller 通过 predicate 过滤掉部分资源，使这些资源虽然能被 list 到但不会触发 reconcile，则这些资源不会被记录为 processed，startup sync 也不会完成。因此这个方案不适用于这类 predicate 过滤部分资源的场景；如果后续要适配这类场景，需要在 `ListExpected` 函数中应用相同过滤逻辑，只返回会进入 reconcile 的资源。本次涉及的 policy/groupMembers watch 只在 update 事件中过滤无关字段变化，trafficredirect watch 没有 predicate，startup sync channel watch 也没有 predicate。

normal policy flow 的完成条件是：

```text
SecurityPolicy startup sync done
&& GroupMembers startup sync done
```

global policy flow 会在 normal policy flow done 后再处理。

删除旧 flow 前需要同时满足：

```text
flow-round-clean-delay elapsed
&& normal policy flow done
&& global policy flow done
&& trafficredirect flow done
```

如果 agent 未启用 policy controller 或 trafficredirect controller，则对应 startup done 会在启动阶段直接标记完成，避免等待未启动的 controller。

## 测试

本地编译/检查：

```bash
go test ./pkg/common/startupsync ./pkg/agent/datapath
go test ./pkg/common/startupsync ./pkg/common/initsync ./pkg/agent/controller/policy ./pkg/agent/controller/trafficredirect ./cmd/everoute-agent -run TestNonExistent -count=0
make agent
```

部署验证：

在 `172.21.152.103` 上替换 `everoute-agent` 二进制并重启 agent。

验证日志显示：

- startup sync event 已触发：
  - securityPolicy
  - groupMembers
  - globalPolicy
  - trafficRedirect
- trafficredirect 先完成
- 90s 到期后，因为 normal/global 未完成，没有删除旧 flow
- memory/rule guard 恢复后，normal/global policy sync done
- 所有条件满足后才删除旧 flow

关键日志：

```text
Startup trafficredirect flow sync done
Flow round clean delay elapsed, waiting startup flow sync before deleting previous round flows, normalPolicyDone: false, globalPolicyDone: false, trafficRedirectDone: true
Startup normal policy flow sync done
Startup global policy flow sync done
Startup flow sync and flow round clean delay completed, ready to delete previous round flows, flowRoundCleanDelayDone: true, normalPolicyDone: true, globalPolicyDone: true, trafficRedirectDone: true
Delete previous round flows and persist current round info. vdsID: ..., roundNum: 5 -> 6
Delete previous round flows and persist current round info. vdsID: ..., roundNum: 9 -> 10
```
