### PR TITLE
chore: remove unused datapath policy rule limit

### DIFF
--- a/pkg/agent/controller/policy/policy_controller.go
+++ b/pkg/agent/controller/policy/policy_controller.go
@@ -26,7 +26,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -868,11 +867,6 @@ func (r *Reconciler) compareAndApplyPolicyRulesChanges(ctx context.Context, poli
 		}
 	}
 
-	if r.DatapathManager.PolicyRuleLimit(policyName, addRuleList, delRuleList) {
-		r.DatapathManager.PolicyRuleMetricsUpdate(policyName, true)
-		return apierrors.NewForbidden(schema.GroupResource{}, "", nil)
-	}
-
 	if len(addRuleList) == 0 && len(delRuleList) == 0 {
 		return nil
 	}
@@ -890,7 +884,7 @@ func (r *Reconciler) compareAndApplyPolicyRulesChanges(ctx context.Context, poli
 		)
 	}
 
-	r.DatapathManager.PolicyRuleMetricsUpdate(policyName, false)
+	r.DatapathManager.PolicyRuleMetricsUpdate(policyName)
 
 	return errors.NewAggregate(errList)
 }
@@ -926,17 +920,6 @@ func (r *Reconciler) addPolicyRuleToDatapath(ctx context.Context, ruleID string,
 
 	return r.DatapathManager.AddEveroutePolicyRule(ctx, everoutePolicyRule, ruleBase)
 }
-
-// func (r *Reconciler) getSecurityPolicyByCompleteRule(ruleID string) *securityv1alpha1.SecurityPolicy {
-// 	sp := securityv1alpha1.SecurityPolicy{}
-// 	if err := r.Get(context.Background(), k8stypes.NamespacedName{
-// 		Namespace: strings.Split(ruleID, "/")[0],
-// 		Name:      strings.Split(ruleID, "/")[1],
-// 	}, &sp); err != nil {
-// 		return nil
-// 	}
-// 	return &sp
-// }
 
 func (r *Reconciler) isReadyToProcessGlobalRule(ctx context.Context) bool {
 	log := ctrl.LoggerFrom(ctx)

--- a/pkg/agent/datapath/utils.go
+++ b/pkg/agent/datapath/utils.go
@@ -32,7 +32,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
-	policycache "github.com/everoute/everoute/pkg/agent/controller/policy/cache"
 	"github.com/everoute/everoute/pkg/apis/rpc/v1alpha1"
 	cniconst "github.com/everoute/everoute/pkg/constants/cni"
 	"github.com/everoute/everoute/pkg/metrics"
@@ -504,40 +503,9 @@ func FlowKeyFromRuleName(ruleName string) string {
 	return keys[len(keys)-1]
 }
 
-// func (dm *DpManager) PolicyRuleLimit(policyIDs []string, addList, deleteList []*policycache.PolicyRule) bool {
-func (dm *DpManager) PolicyRuleLimit(_ []string, _, _ []*policycache.PolicyRule) bool {
-	return false
-	/*
-		dm.lockflowReplayWithTimeout()
-		defer dm.flowReplayMutex.Unlock()
-
-		if !dm.AgentMetric.ShouldLimit(policyIDs) {
-			return false
-		}
-
-		// count real rule num after changes
-		addCnt := 0
-		delCnt := 0
-		for _, item := range addList {
-			if dm.GetRuleEntryByRuleID(FlowKeyFromRuleName(item.Name)) == nil {
-				addCnt++
-			}
-		}
-		for _, item := range deleteList {
-			entry := dm.GetRuleEntryByRuleID(FlowKeyFromRuleName(item.Name))
-			if entry != nil && len(entry.PolicyRuleReference.List()) <= 1 {
-				delCnt++
-			}
-		}
-
-		diffSize := addCnt - delCnt
-		return len(dm.ListRuleEntry())*len(dm.BridgeChainMap)+diffSize > RuleEntryCap
-	*/
-}
-
-func (dm *DpManager) PolicyRuleMetricsUpdate(policyIDs []string, limited bool) {
+func (dm *DpManager) PolicyRuleMetricsUpdate(policyIDs []string) {
 	for _, k := range policyIDs {
-		dm.AgentMetric.SetRuleEntryNum(k, dm.policyRuleNums[k], limited)
+		dm.AgentMetric.SetRuleEntryNum(k, dm.policyRuleNums[k])
 	}
 
 	dm.AgentMetric.SetRuleEntryTotalNum(len(dm.Rules))

--- a/pkg/constants/ms/constants.go
+++ b/pkg/constants/ms/constants.go
@@ -20,7 +20,6 @@ const (
 
 	MetricRuleEntryNumTotal        = "rule_entry_num_total"
 	MetricRuleEntryNum             = "rule_entry_num"
-	MetricRuleEntryNumLimit        = "rule_entry_num_limit"
 	MetricRuleEntryPolicyNameLabel = "name"
 
 	// globalRule

--- a/pkg/metrics/agent_metrics.go
+++ b/pkg/metrics/agent_metrics.go
@@ -39,7 +39,6 @@ type AgentMetric struct {
 
 	ruleEntryTotalNum prometheus.Gauge
 	ruleEntryNum      prometheus.GaugeVec
-	ruleEntryLimitNum prometheus.GaugeVec
 
 	policyNameMap map[string]string
 
@@ -96,10 +95,6 @@ func NewAgentMetric() *AgentMetric {
 		ruleEntryNum: *prometheus.NewGaugeVec(newAgentGaugeOpt(
 			constants.MetricRuleEntryNum,
 			"The count of datapath policy rule for each policy",
-		), []string{constants.MetricRuleEntryPolicyNameLabel}),
-		ruleEntryLimitNum: *prometheus.NewGaugeVec(newAgentGaugeOpt(
-			constants.MetricRuleEntryNumLimit,
-			"The count of datapath policy rule for each policy currently limited",
 		), []string{constants.MetricRuleEntryPolicyNameLabel}),
 		policyNameMap: map[string]string{},
 		flowIDUsedCount: *prometheus.NewGaugeVec(newAgentGaugeOpt(
@@ -203,16 +198,6 @@ func (m *AgentMetric) UpdatePolicyName(policyID string, policy *securityv1alpha1
 	}
 }
 
-func (m *AgentMetric) ShouldLimit(policyID []string) bool {
-	for _, item := range policyID {
-		_, ok := m.policyNameMap[item]
-		if ok {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *AgentMetric) ArpInc() {
 	m.arpCount.Inc()
 }
@@ -221,17 +206,12 @@ func (m *AgentMetric) ArpRejectInc() {
 	m.arpRejectCount.Inc()
 }
 
-func (m *AgentMetric) SetRuleEntryNum(policyID string, num int, limited bool) {
+func (m *AgentMetric) SetRuleEntryNum(policyID string, num int) {
 	name, ok := m.policyNameMap[policyID]
 	if !ok {
 		return
 	}
-	if limited {
-		m.ruleEntryLimitNum.WithLabelValues(name).Set(float64(num))
-	} else {
-		m.ruleEntryNum.WithLabelValues(name).Set(float64(num))
-		m.ruleEntryLimitNum.DeleteLabelValues(name)
-	}
+	m.ruleEntryNum.WithLabelValues(name).Set(float64(num))
 }
 
 func (m *AgentMetric) SetRuleEntryTotalNum(num int) {
@@ -242,7 +222,7 @@ func (m *AgentMetric) GetCollectors() []prometheus.Collector {
 	res := []prometheus.Collector{m.flowIDUsedCount, m.flowIDExhaust}
 	if config.EnableMs {
 		klog.Infof("Register ms metrics for enabled ms")
-		res = append(res, m.arpCount, m.arpRejectCount, m.ruleEntryTotalNum, m.ruleEntryNum, m.ruleEntryLimitNum,
+		res = append(res, m.arpCount, m.arpRejectCount, m.ruleEntryTotalNum, m.ruleEntryNum,
 			m.policyGuardEnabled,
 			m.policyMemoryBreakerOpen,
 			m.policyMemoryBreakerOpenTotal,


### PR DESCRIPTION
## Purpose
移除 `r.DatapathManager.PolicyRuleLimit` 相关的无效代码路径。这个 datapath rule limit 实际没有实现，当前逻辑恒为 `false`，继续保留会误导后续维护和运行时观测。

## Changes
- 删除 policy controller 中基于 `PolicyRuleLimit` 的拒绝分支。
- 删除 datapath 中未实现且恒为 `false` 的 `PolicyRuleLimit` 方法。
- 简化 rule entry metrics 更新路径，移除仅服务于该废弃逻辑的 `rule_entry_num_limit` 指标和相关辅助方法。

## Tests
- `make docker-generate`
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute-remove-policy-rule-limit:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/agent/controller/policy ./pkg/agent/datapath ./pkg/metrics ./pkg/constants/ms -run TestDoesNotExist -count=1`
