### PR TITLE
ci: bump kubesmartcluster template to v1.27.16

### DIFF
--- a/hack/kubesmartcluster.yaml.tmpl
+++ b/hack/kubesmartcluster.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
           server: ""
           username: ""
       elfCluster: ef8a4866-4764-4cc5-a213-699e7aecad10
-      vmTemplate: sks-managed-rocky-8.10-amd64-k8s-v1.26.15-v6
+      vmTemplate: sks-managed-rocky-8.10-amd64-k8s-v1.27.16-v6
       zbsVip: ""
     name: cloudtower
   clusterConfiguration:
@@ -198,4 +198,4 @@ spec:
             vlan: clg9ooxpx00wn0958aq97kssi
       nodeDrainTimeout: 5m0s
       replicas: 5
-  version: v1.26.15
+  version: v1.27.16


### PR DESCRIPTION
## Purpose
- 更新 `hack/kubesmartcluster.yaml.tmpl` 中的默认 Kubernetes 版本与对应 VM 模板，供 CI/bjoffice 场景使用。

## Changes
- 将 `vmTemplate` 从 `sks-managed-rocky-8.10-amd64-k8s-v1.26.15-v6` 更新为 `sks-managed-rocky-8.10-amd64-k8s-v1.27.16-v6`
- 将 `version` 从 `v1.26.15` 更新为 `v1.27.16`

## Testing
- 执行 `make docker-generate`
