### PR TITLE
fix(er-1732): recover overlay gw endpoint on node recreate

### DIFF
--- a/pkg/agent/controller/overlay/controller.go
+++ b/pkg/agent/controller/overlay/controller.go
@@ -199,7 +199,7 @@ func (r *Reconciler) deleteEndpoint(key types.NamespacedName) error {
 			}
 		}
 		delete(nodeIPs.PodIPs, epIndex)
-		_ = r.nodeIPsCache.Update(nodeIPs)
+		r.updateOrDeleteNodeIPs(nodeIPs)
 	}
 
 	return nil
@@ -243,7 +243,7 @@ func (r *Reconciler) updateEndpoint(ep v1alpha1.Endpoint) error {
 					}
 				}
 				nodeIPs.PodIPs[epIndex] = newIPs
-				_ = r.nodeIPsCache.Update(nodeIPs)
+				r.updateOrDeleteNodeIPs(nodeIPs)
 			}
 		}
 	}
@@ -277,7 +277,7 @@ func (r *Reconciler) updateEndpoint(ep v1alpha1.Endpoint) error {
 				}
 			}
 			nodeIPs.PodIPs[epIndex] = newIPs
-			_ = r.nodeIPsCache.Update(nodeIPs)
+			r.updateOrDeleteNodeIPs(nodeIPs)
 		} else {
 			// delete endpoint in this node
 			if nodeIPs.IP != "" {
@@ -295,7 +295,7 @@ func (r *Reconciler) updateEndpoint(ep v1alpha1.Endpoint) error {
 				}
 			}
 			delete(nodeIPs.PodIPs, epIndex)
-			_ = r.nodeIPsCache.Update(nodeIPs)
+			r.updateOrDeleteNodeIPs(nodeIPs)
 		}
 	}
 
@@ -316,12 +316,12 @@ func (r *Reconciler) deleteNode(key types.NamespacedName) error {
 
 	nodeIPs := obj.(*ercache.NodeIPs).DeepCopy()
 	if nodeIPs.IP == "" {
-		_ = r.nodeIPsCache.Delete(nodeIPs)
+		r.updateOrDeleteNodeIPs(nodeIPs)
 		return nil
 	}
 
 	ips := nodeIPs.ListPodIPs()
-	klog.Infof("Delete all remote ips %v of node %s with node ip %s", ips, nodeIPs.Name, nodeIPs.IP)
+	klog.Infof("Delete remote flows for ips %v of node %s with node ip %s, then clear node ip and keep pod ips cache", ips, nodeIPs.Name, nodeIPs.IP)
 	var errs []error
 	for _, ip := range ips {
 		if err := r.UplinkBr.RemoveRemoteEndpoint(ip); err != nil {
@@ -332,7 +332,8 @@ func (r *Reconciler) deleteNode(key types.NamespacedName) error {
 	if errors.Join(errs...) != nil {
 		return fmt.Errorf("failed to remove remote ips in dp")
 	}
-	_ = r.nodeIPsCache.Delete(nodeIPs)
+	nodeIPs.IP = ""
+	r.updateOrDeleteNodeIPs(nodeIPs)
 	return nil
 }
 
@@ -362,12 +363,12 @@ func (r *Reconciler) updateNode(node corev1.Node) error {
 	allPodIPs := nodeIPs.ListPodIPs()
 	if len(allPodIPs) == 0 {
 		nodeIPs.IP = newNodeIP
-		_ = r.nodeIPsCache.Update(nodeIPs)
+		r.updateOrDeleteNodeIPs(nodeIPs)
 		return nil
 	}
 
 	if nodeIPs.IP != "" {
-		klog.Infof("Delete all remote ips %v with node ip %s in node %s for update node ip from %s to %s", allPodIPs, nodeIPs.IP, nodeName, nodeIPs.IP, newNodeIP)
+		klog.Infof("Delete remote flows for ips %v in node %s for node ip update from %s to %s", allPodIPs, nodeName, nodeIPs.IP, newNodeIP)
 		var errs []error
 		for _, ip := range allPodIPs {
 			if err := r.UplinkBr.RemoveRemoteEndpoint(ip); err != nil {
@@ -381,7 +382,7 @@ func (r *Reconciler) updateNode(node corev1.Node) error {
 	}
 
 	if newNodeIP != "" {
-		klog.Infof("Add all remote ips %v with node ip %s in node %s for update node ip from %s to %s", allPodIPs, newNodeIP, nodeName, nodeIPs.IP, newNodeIP)
+		klog.Infof("Restore remote flows for ips %v in node %s after node ip update from %s to %s", allPodIPs, nodeName, nodeIPs.IP, newNodeIP)
 		var errs []error
 		for _, ip := range allPodIPs {
 			if err := r.UplinkBr.AddRemoteEndpoint(net.ParseIP(ip), net.ParseIP(newNodeIP)); err != nil {
@@ -394,7 +395,7 @@ func (r *Reconciler) updateNode(node corev1.Node) error {
 		}
 	}
 	nodeIPs.IP = newNodeIP
-	_ = r.nodeIPsCache.Update(nodeIPs)
+	r.updateOrDeleteNodeIPs(nodeIPs)
 	return nil
 }
 
@@ -440,4 +441,16 @@ func ipAddressesToStringSet(ips []ertypes.IPAddress) sets.Set[string] {
 	}
 
 	return res
+}
+
+func (r *Reconciler) updateOrDeleteNodeIPs(nodeIPs *ercache.NodeIPs) {
+	if nodeIPs == nil {
+		return
+	}
+	if nodeIPs.IP == "" && len(nodeIPs.PodIPs) == 0 {
+		klog.Infof("Delete node %s pod ips cache entry after node ip is cleared and no endpoint ips remain", nodeIPs.Name)
+		_ = r.nodeIPsCache.Delete(nodeIPs)
+		return
+	}
+	_ = r.nodeIPsCache.Update(nodeIPs)
 }

--- a/pkg/agent/controller/overlay/controller_test.go
+++ b/pkg/agent/controller/overlay/controller_test.go
@@ -263,7 +263,11 @@ var _ = Describe("overlay controller", func() {
 					}
 					Expect(k8sClient.Status().Update(ctx, &node)).Should(Succeed())
 					Eventually(func() bool {
-						return checkNodeIPsInCache(nodeName, "")
+						_, exists, err := overlayReconciler.nodeIPsCache.GetByKey(nodeName)
+						if err != nil {
+							return false
+						}
+						return !exists
 					}, Timeout, Interval).Should(BeTrue())
 				})
 
@@ -347,13 +351,85 @@ var _ = Describe("overlay controller", func() {
 				It("delete node", func() {
 					Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
 					Eventually(func(g Gomega) {
-						_, exists, err := overlayReconciler.nodeIPsCache.GetByKey(nodeName)
-						g.Expect(err).Should(BeNil())
-						g.Expect(exists).Should(BeFalse())
+						g.Expect(checkNodeIPsInCache(nodeName, "")).Should(BeTrue())
+						g.Expect(checkEndpointInCache(epIndex, nodeName, []string{epIP})).Should(BeTrue())
 						g.Expect(checkRemoteFlow(epIP)).Should(BeFalse())
 					}, Timeout, Interval).Should(Succeed())
 				})
 			})
+		})
+	})
+
+	Context("test node recreate", func() {
+		It("should recover remote flow after node recreate without gw endpoint recreate", func() {
+			gwEpName := "gw-ep-" + nodeName
+			gwEpIP := "123.1.1.254"
+			gwEpIndex := ercache.GenEpRefIndex(nsName, gwEpName)
+
+			gwEp := v1alpha1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwEpName,
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.EndpointSpec{
+					Type: v1alpha1.EndpointStatic,
+					Reference: v1alpha1.EndpointReference{
+						ExternalIDName:  "gw-ep",
+						ExternalIDValue: nodeName,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &gwEp)).Should(Succeed())
+			gwEp.Status.Agents = []string{nodeName}
+			gwEp.Status.IPs = []ertypes.IPAddress{ertypes.IPAddress(gwEpIP)}
+			Expect(k8sClient.Status().Update(ctx, &gwEp)).Should(Succeed())
+			Eventually(func() bool {
+				return checkEndpointInCache(gwEpIndex, nodeName, []string{gwEpIP})
+			}, Timeout, Interval).Should(BeTrue())
+
+			node = corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &node)).Should(Succeed())
+			node.Status.Addresses = []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: internalIP,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, &node)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(checkNodeIPsInCache(nodeName, internalIP)).Should(BeTrue())
+				g.Expect(checkRemoteFlow(gwEpIP, internalIP)).Should(BeTrue())
+			}, Timeout, Interval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(checkNodeIPsInCache(nodeName, "")).Should(BeTrue())
+				g.Expect(checkEndpointInCache(gwEpIndex, nodeName, []string{gwEpIP})).Should(BeTrue())
+				g.Expect(checkRemoteFlow(gwEpIP)).Should(BeFalse())
+			}, Timeout, Interval).Should(Succeed())
+
+			node = corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, &node)).Should(Succeed())
+			node.Status.Addresses = []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: internalIP,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, &node)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(checkNodeIPsInCache(nodeName, internalIP)).Should(BeTrue())
+				g.Expect(checkEndpointInCache(gwEpIndex, nodeName, []string{gwEpIP})).Should(BeTrue())
+				g.Expect(checkRemoteFlow(gwEpIP, internalIP)).Should(BeTrue())
+			}, Timeout, Interval).Should(Succeed())
 		})
 	})
 

--- a/pkg/controller/k8s/node_controller.go
+++ b/pkg/controller/k8s/node_controller.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/everoute/everoute/pkg/apis/security/v1alpha1"
+	cniconst "github.com/everoute/everoute/pkg/constants/cni"
 	"github.com/everoute/everoute/pkg/source"
 	"github.com/everoute/everoute/pkg/utils"
 )
@@ -59,6 +61,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		klog.Errorf("Failed to delete gw-ep endpoint for node %s", req.Name)
 		return ctrl.Result{}, err
 	}
+	klog.Infof("Deleted gw-ep endpoint %s/%s for node %s", ep.GetNamespace(), ep.GetName(), req.Name)
 
 	return ctrl.Result{}, nil
 }
@@ -73,7 +76,14 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return c.Watch(source.Kind(mgr.GetCache(), &corev1.Node{}), &handler.EnqueueRequestForObject{}, nodePredicate())
+	if err := c.Watch(source.Kind(mgr.GetCache(), &corev1.Node{}), &handler.EnqueueRequestForObject{}, nodePredicate()); err != nil {
+		return err
+	}
+	return c.Watch(
+		source.Kind(mgr.GetCache(), &v1alpha1.Endpoint{}),
+		handler.EnqueueRequestsFromMapFunc(r.enqueueNodeByGwEndpoint),
+		gwEndpointPredicate(r.GwEpNamespace),
+	)
 }
 
 func nodePredicate() predicate.Predicate {
@@ -91,4 +101,55 @@ func nodePredicate() predicate.Predicate {
 			return false
 		},
 	}
+}
+
+func (r *NodeReconciler) enqueueNodeByGwEndpoint(_ context.Context, obj client.Object) []ctrl.Request {
+	if obj == nil {
+		return nil
+	}
+	nodeName, isGwEp := getGwEndpointNodeName(obj.GetName())
+	if !isGwEp {
+		return nil
+	}
+	return []ctrl.Request{{NamespacedName: k8stypes.NamespacedName{Name: nodeName}}}
+}
+
+func gwEndpointPredicate(namespace string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isGwEndpointObject(e.Object, namespace)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isGwEndpointObject(e.ObjectNew, namespace)
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func isGwEndpointObject(obj client.Object, namespace string) bool {
+	if obj == nil {
+		return false
+	}
+	if obj.GetNamespace() != namespace {
+		return false
+	}
+	_, isGwEp := getGwEndpointNodeName(obj.GetName())
+	return isGwEp
+}
+
+func getGwEndpointNodeName(epName string) (string, bool) {
+	prefix := cniconst.GwEpNamePrefix + "-"
+	if !strings.HasPrefix(epName, prefix) {
+		return "", false
+	}
+	nodeName := strings.TrimPrefix(epName, prefix)
+	if nodeName == "" {
+		return "", false
+	}
+	return nodeName, true
 }

--- a/pkg/controller/k8s/node_controller_test.go
+++ b/pkg/controller/k8s/node_controller_test.go
@@ -29,7 +29,8 @@ var _ = Describe("node controller test", func() {
 				Name: GwEpNs,
 			},
 		}
-		Expect(k8sClient.Create(ctx, &ns)).Should(Succeed())
+		err := k8sClient.Create(ctx, &ns)
+		Expect(err == nil || errors.IsAlreadyExists(err)).Should(BeTrue())
 	})
 
 	Context("delete node", func() {
@@ -61,6 +62,62 @@ var _ = Describe("node controller test", func() {
 					g.Expect(err2).ShouldNot(BeNil())
 					g.Expect(errors.IsNotFound(err2)).Should(BeTrue())
 				}, timeout, interval).Should(Succeed())
+			})
+		})
+	})
+
+	Context("cleanup stale gw endpoint by endpoint watch", func() {
+		When("node doesn't exist", func() {
+			BeforeEach(func() {
+				ep := v1alpha1.Endpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      utils.GetGwEndpointName(nodeName),
+						Namespace: GwEpNs,
+					},
+				}
+				Expect(k8sClient.Create(ctx, &ep)).Should(Succeed())
+			})
+
+			It("should delete stale gw-ep endpoint", func() {
+				epKey := k8stypes.NamespacedName{
+					Namespace: GwEpNs,
+					Name:      utils.GetGwEndpointName(nodeName),
+				}
+				Eventually(func(g Gomega) {
+					ep := v1alpha1.Endpoint{}
+					err := k8sClient.Get(ctx, epKey, &ep)
+					g.Expect(err).ShouldNot(BeNil())
+					g.Expect(errors.IsNotFound(err)).Should(BeTrue())
+				}, timeout, interval).Should(Succeed())
+			})
+		})
+
+		When("node exists", func() {
+			BeforeEach(func() {
+				node = corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+				}
+				Expect(k8sClient.Create(ctx, &node)).Should(Succeed())
+				ep := v1alpha1.Endpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      utils.GetGwEndpointName(nodeName),
+						Namespace: GwEpNs,
+					},
+				}
+				Expect(k8sClient.Create(ctx, &ep)).Should(Succeed())
+			})
+
+			It("should keep gw-ep endpoint", func() {
+				epKey := k8stypes.NamespacedName{
+					Namespace: GwEpNs,
+					Name:      utils.GetGwEndpointName(nodeName),
+				}
+				Consistently(func() error {
+					ep := v1alpha1.Endpoint{}
+					return k8sClient.Get(ctx, epKey, &ep)
+				}, interval*3, interval).Should(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
## Purpose
修复 overlay 模式下 controller 重启错过 Node 删除事件后，残留 gw-ep 且其他 agent 在 node delete 时清掉远端流表，导致同名 node 重建后远端流表无法自动恢复的问题。

## Changes
- 调整 overlay controller 的 node 缓存处理逻辑：node 删除时仅清空 node IP 并删除现有 remote flow，保留 endpoint 关联；同名 node 重建并重新获得 node IP 后，自动恢复对应 remote flow；pod ip cache 删除由 endpoint delete 事件触发
- 调整 k8s node controller：除 Node delete 外，额外 watch `gw-ep` endpoint，在 controller 重启后通过现存 `gw-ep` 事件清理缺失 node 对应的 stale gw-ep
- 补充 overlay node recreate 与 stale gw-ep 清理的单测
