### PR TITLE
ci: bump kubesmartcluster template to v1.27.16

### DIFF
--- a/hack/kubesmartcluster.yaml.tmpl
+++ b/hack/kubesmartcluster.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
           server: ""
           username: ""
       elfCluster: ef8a4866-4764-4cc5-a213-699e7aecad10
-      vmTemplate: sks-managed-rocky-8.10-amd64-k8s-v1.26.15-v6
+      vmTemplate: sks-managed-rocky-8.10-amd64-k8s-v1.27.16-v6
       zbsVip: ""
     name: cloudtower
   clusterConfiguration:
@@ -198,4 +198,4 @@ spec:
             vlan: clg9ooxpx00wn0958aq97kssi
       nodeDrainTimeout: 5m0s
       replicas: 5
-  version: v1.26.15
+  version: v1.27.16


### PR DESCRIPTION
## Purpose
将 main 上的 `ci: bump kubesmartcluster template to v1.27.16` 回移到 `release-cni-1.2.x`，同步 kubesmartcluster 模板版本。

## Changes
- cherry-pick `f358c07ea2517de1629e8b963397312129730728` 到 `release-cni-1.2.x` 新分支。
- 更新 `hack/kubesmartcluster.yaml.tmpl` 中的模板版本到 v1.27.16。

## Tests
- 未运行测试；本 PR 仅包含模板版本调整。
