### PR TITLE
ci: reduce k8s e2e matrix on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,8 +110,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        enable-proxy: [true, false]
-        encap-mode: ["", geneve]
+        enable-proxy: [true]
+        encap-mode: [geneve]
         include:
           - ipam: "everoute"
             enable-proxy: true


### PR DESCRIPTION
## Purpose
k8s e2e 主要承担 CNI 相关 CI，但 CNI 不在 `main` 分支持续迭代，而是基于 `release-cni-1.2.x` 分支演进。为降低 `main` 分支 CI 成本，仅保留一组能够覆盖全部 CNI 功能的模式。

## Changes
- 收缩 `run-k8s-e2e` 的 matrix，仅保留 `enable-proxy=true` 和 `encap-mode=geneve`。
- 移除 `enable-proxy=false` 和非 `geneve` 组合在 `main` 分支上的重复 CNI e2e 覆盖。

## Tests
- 未额外运行测试。
- 提交前执行了 `make docker-generate`，未产生额外文件变更。
