### PR TITLE
ci: remove run-e2e from release-cni-1.2.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,15 +80,6 @@ jobs:
           GOGC: 1
           GOPROXY: https://goproxy.cn|https://proxy.golang.org|direct
 
-  run-e2e:
-    runs-on: [self-hosted, pod]
-    needs: [static-check, generate-check, pr-check]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: run everoute e2e test
-        run: sudo make docker-e2e-test-ci
-
   build-k8s-e2e-image:
     runs-on: [self-hosted, build]
     steps:
@@ -275,13 +266,12 @@ jobs:
 
   slack-notification:
     if: ${{ always() }}
-    needs: [ pr-check,static-check,run-e2e,run-k8s-e2e,generate-check ]
+    needs: [ pr-check,static-check,run-k8s-e2e,generate-check ]
     runs-on: [self-hosted, pod]
     env:
       SLACK_COLOR: 2EA44F
       RESULT_PR_CHECK: ":white_check_mark:"
       RESULT_STATIC_CHECK: ":white_check_mark:"
-      RESULT_RUN_E2E: ":white_check_mark:"
       RESULT_RUN_K8S_E2E: ":white_check_mark:"
       RESULT_RUN_TOWER_E2E: ":white_check_mark:"
       RESULT_GENERATE_CHECK: ":white_check_mark:"
@@ -290,8 +280,6 @@ jobs:
         run: echo "SLACK_COLOR=DF0000" >> $GITHUB_ENV && echo "RESULT_PR_CHECK=:x:" >> $GITHUB_ENV
       - if: ${{ needs.static-check.result == 'failure'}}
         run: echo "SLACK_COLOR=DF0000" >> $GITHUB_ENV && echo "RESULT_STATIC_CHECK=:x:" >> $GITHUB_ENV
-      - if: ${{ needs.run-e2e.result == 'failure'}}
-        run: echo "SLACK_COLOR=DF0000" >> $GITHUB_ENV && echo "RESULT_RUN_E2E=:x:" >> $GITHUB_ENV
       - if: ${{ needs.run-k8s-e2e.result == 'failure'}}
         run: echo "SLACK_COLOR=DF0000" >> $GITHUB_ENV && echo "RESULT_RUN_K8S_E2E=:x:" >> $GITHUB_ENV
       - if: ${{ needs.run-tower-e2e.result == 'failure'}}
@@ -303,8 +291,6 @@ jobs:
         run: echo "RESULT_PR_CHECK=:ballot_box_with_check:" >> $GITHUB_ENV
       - if: ${{ needs.static-check.result == 'cancelled'}}
         run: echo "RESULT_STATIC_CHECK=:ballot_box_with_check:" >> $GITHUB_ENV
-      - if: ${{ needs.run-e2e.result == 'cancelled'}}
-        run: echo "RESULT_RUN_E2E=:ballot_box_with_check:" >> $GITHUB_ENV
       - if: ${{ needs.run-k8s-e2e.result == 'cancelled'}}
         run: echo "RESULT_RUN_K8S_E2E=:ballot_box_with_check:" >> $GITHUB_ENV
       - if: ${{ needs.run-tower-e2e.result == 'cancelled'}}
@@ -359,10 +345,6 @@ jobs:
                       {
                         "type": "mrkdwn",
                         "text": "${{ env.RESULT_STATIC_CHECK }} => *static-check*"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "${{ env.RESULT_RUN_E2E }} => *run-e2e*"
                       },
                       {
                         "type": "mrkdwn",


### PR DESCRIPTION
## Purpose
在 `release-cni-1.2.x` 分支移除 `run-e2e` job，减少重复的 e2e 开销。当前 CNI 相关验证主要依赖 `run-k8s-e2e`。

## Changes
- 删除 CI workflow 中独立的 `run-e2e` job。
- 同步清理 `slack-notification` 中对 `run-e2e` 的 `needs`、状态变量和消息展示。

## Why
- `run-k8s-e2e` 中的 `run securitypolicy cases` 直接执行 `go test ./tests/e2e/...`，与 `run-e2e` 复用了同一套 e2e 测试入口。
- 对于 CNI 分支更关注的场景，大部分有效 case 已经在 `run-k8s-e2e` 创建的真实 k8s 集群环境中覆盖。
- `run-e2e` 中未被 `Provider=pod` 覆盖的额外 case，主要是非 CNI 场景或当前 CNI 不支持的能力，继续保留收益有限。

## Tests
- `make docker-generate`
