### PR TITLE
ci: avoid named protocol dump flaky in datapath ut

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -558,7 +558,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -604,10 +604,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
-			if ruleV6.IPProtocol == 58 {
-				// ipv6 with proto number 58 is icmp6, the proto in flow would be icmp6 and can't match ipv6 with nw_proto=58
-				ruleV6.IPProtocol = 59
-			}
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -677,7 +674,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -694,10 +691,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
-			if ruleV6.IPProtocol == 58 {
-				// ipv6 with proto number 58 is icmp6, the proto in flow would be icmp6 and can't match ipv6 with nw_proto=58
-				ruleV6.IPProtocol = 59
-			}
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -721,7 +715,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -738,10 +732,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
-			if ruleV6.IPProtocol == 58 {
-				// ipv6 with proto number 58 is icmp6, the proto in flow would be icmp6 and can't match ipv6 with nw_proto=58
-				ruleV6.IPProtocol = 59
-			}
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -765,7 +756,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -782,10 +773,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
-			if ruleV6.IPProtocol == 58 {
-				// ipv6 with proto number 58 is icmp6, the proto in flow would be icmp6 and can't match ipv6 with nw_proto=58
-				ruleV6.IPProtocol = 59
-			}
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -1428,6 +1416,18 @@ func randomIP() string {
 
 func randomIPv6() string {
 	return fmt.Sprintf("2401::%d:%d:%d:%d", rand.IntnRange(1, 255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
+}
+
+func avoidNamedProtocolInFlowDump(ipFamily int, proto uint8) uint8 {
+	if proto == 132 {
+		// ovs-ofctl dumps protocol 132 as sctp/sctp6 instead of nw_proto=132.
+		return 133
+	}
+	if ipFamily == unix.AF_INET6 && proto == 58 {
+		// ovs-ofctl dumps ipv6 protocol 58 as icmp6 instead of nw_proto=58.
+		return 59
+	}
+	return proto
 }
 
 func TestReleaseRuleSeqID(t *testing.T) {


### PR DESCRIPTION
## Purpose
修复 datapath monitor policy rule 单测中的随机协议号 flaky 问题，避免 OVS flow dump 使用协议名输出时导致断言失败。

## Changes
- 为 monitor policy rule 相关随机协议测试增加协议号规避逻辑
- 继续保留已有的 IPv6 `58 -> 59` 处理
- 新增绕开 `132`，避免 OVS 将其输出为 `sctp`/`sctp6` 导致 `nw_proto` 断言失败

## Tests
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/agent/datapath -run 'TestEverouteDp/check_policy_rule_monitor_mode' -count=1`
