### PR TITLE
ci: avoid named protocol dump flaky in datapath ut

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath_test.go
+++ b/pkg/agent/datapath/multiBridgeDatapath_test.go
@@ -477,7 +477,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -506,7 +506,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -523,6 +523,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -592,7 +593,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -609,6 +610,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -632,7 +634,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -649,6 +651,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -672,7 +675,7 @@ func testERPolicyRule(t *testing.T) {
 				Priority:   rand.IntnRange(DEFAULT_FLOW_MISS_PRIORITY, HIGH_MATCH_FLOW_PRIORITY),
 				SrcIPAddr:  randomIP(),
 				DstIPAddr:  randomIP(),
-				IPProtocol: uint8(rand.IntnRange(20, 254)),
+				IPProtocol: avoidNamedProtocolInFlowDump(unix.AF_INET, uint8(rand.IntnRange(20, 254))),
 				IPFamily:   unix.AF_INET,
 				SrcPort:    uint16(rand.IntnRange(1, 65534)),
 				DstPort:    uint16(rand.IntnRange(1, 65534)),
@@ -689,6 +692,7 @@ func testERPolicyRule(t *testing.T) {
 
 			ruleV6 := rule.DeepCopy()
 			ruleV6.IPFamily = unix.AF_INET6
+			ruleV6.IPProtocol = avoidNamedProtocolInFlowDump(unix.AF_INET6, ruleV6.IPProtocol)
 			ruleV6.SrcIPAddr = randomIPv6()
 			ruleV6.DstIPAddr = randomIPv6()
 			err = datapathManager.AddEveroutePolicyRule(ctx, ruleV6, baseInfo)
@@ -1153,6 +1157,18 @@ func randomIP() string {
 
 func randomIPv6() string {
 	return fmt.Sprintf("2401::%d:%d:%d:%d", rand.IntnRange(1, 255), rand.Intn(255), rand.Intn(255), rand.Intn(255))
+}
+
+func avoidNamedProtocolInFlowDump(ipFamily int, proto uint8) uint8 {
+	if proto == 132 {
+		// ovs-ofctl dumps protocol 132 as sctp/sctp6 instead of nw_proto=132.
+		return 133
+	}
+	if ipFamily == unix.AF_INET6 && proto == 58 {
+		// ovs-ofctl dumps ipv6 protocol 58 as icmp6 instead of nw_proto=58.
+		return 59
+	}
+	return proto
 }
 
 func TestReleaseRuleSeqID(t *testing.T) {


### PR DESCRIPTION
## Purpose
修复 datapath monitor policy rule 单测中的随机协议号 flaky 问题，避免 OVS flow dump 使用协议名输出时导致断言失败。

## Changes
- 为 monitor policy rule 相关随机协议测试增加协议号规避逻辑
- 保留已有的 IPv6 `58 -> 59` 处理
- 新增绕开 `132`，避免 OVS 将其输出为 `sctp`/`sctp6` 导致 `nw_proto` 断言失败
