### PR TITLE
fix(er-1797): read agentname from env only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,13 +72,11 @@ e2e-tools:
 		-X github.com/everoute/everoute/pkg/version.releaseCommit=$(GIT_COMMIT)" \
 	tests/e2e/tools/net-utils/*.go
 
-agent-uuid:
-	mkdir -p /var/lib/everoute/agent
-	cat /proc/sys/kernel/random/uuid > /var/lib/everoute/agent/name
+TEST_AGENT_NAME ?= unit-test-agent
 
-test: agent-uuid
+test:
 	mkdir -p ut_tmp; curl https://raw.githubusercontent.com/everoute/trafficredirect/7078b1baad07d7e07c073274b6de123073272fe7/deploy/chart/templates/crds/tr.everoute.io_rules.yaml -o ut_tmp/tr_crd.yaml
-	go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/...
+	NODE_NAME=$(TEST_AGENT_NAME) go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/...
 	rm -rf ut_tmp
 
 debug-test: image-test
@@ -93,9 +91,9 @@ docker-test-ci:
 	$(eval WORKDIR := /go/src/github.com/everoute/everoute)
 	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) -v /lib/modules:/lib/modules --privileged registry.smtx.io/everoute/unit-test make test
 
-cover-test: agent-uuid
+cover-test:
 	mkdir -p ut_tmp; curl https://raw.githubusercontent.com/everoute/trafficredirect/7078b1baad07d7e07c073274b6de123073272fe7/deploy/chart/templates/crds/tr.everoute.io_rules.yaml -o ut_tmp/tr_crd.yaml
-	go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/... -coverprofile=coverage.out \
+	NODE_NAME=$(TEST_AGENT_NAME) go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/... -coverprofile=coverage.out \
 		-coverpkg=./pkg/...,./plugin/tower/pkg/controller/...
 	rm -rf ut_tmp
 
@@ -107,9 +105,9 @@ docker-cover-test-ci:
 	$(eval WORKDIR := /go/src/github.com/everoute/everoute)
 	docker run --rm -iu 0:0 -w $(WORKDIR) -v $(CURDIR):$(WORKDIR) -v /lib/modules:/lib/modules -e GOPROXY=http://goproxy.smartx.com,https://goproxy.cn,direct --privileged registry.smtx.io/everoute/unit-test:$(COMMIT_ID) make cover-test
 
-race-test: agent-uuid
+race-test:
 	mkdir -p ut_tmp; curl https://raw.githubusercontent.com/everoute/trafficredirect/7078b1baad07d7e07c073274b6de123073272fe7/deploy/chart/templates/crds/tr.everoute.io_rules.yaml -o ut_tmp/tr_crd.yaml
-	go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/... -race
+	NODE_NAME=$(TEST_AGENT_NAME) go test --gcflags=all=-l -p 1 ./plugin/... ./pkg/... -race
 	rm -rf ut_tmp
 
 docker-race-test: image-test

--- a/cmd/everoute-agent/main.go
+++ b/cmd/everoute-agent/main.go
@@ -103,6 +103,7 @@ func main() {
 	defer klog.Flush()
 
 	ctrl.SetLogger(klog.Background())
+	utils.InitCurrentAgentName()
 	// complete options
 	err := opts.complete()
 	if err != nil {

--- a/pkg/agent/controller/policy/cache/rule_test.go
+++ b/pkg/agent/controller/policy/cache/rule_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -147,6 +148,11 @@ func TestResolveDstPort(t *testing.T) {
 }
 
 func TestCompleteRuleHasLocalRule(t *testing.T) {
+	if err := os.Setenv(constants.AgentNodeNameENV, "rule-cache-ut"); err != nil {
+		t.Fatalf("Setenv() error = %v", err)
+	}
+	utils.InitCurrentAgentName()
+
 	rule := &CompleteRule{}
 	currentAgent := utils.CurrentAgentName()
 	otherAgent := currentAgent + "-other"

--- a/pkg/agent/controller/policy/suite_test.go
+++ b/pkg/agent/controller/policy/suite_test.go
@@ -42,6 +42,7 @@ import (
 	msconst "github.com/everoute/everoute/pkg/constants/ms"
 	"github.com/everoute/everoute/pkg/metrics"
 	"github.com/everoute/everoute/pkg/types"
+	"github.com/everoute/everoute/pkg/utils"
 	"github.com/everoute/everoute/plugin/tower/pkg/informer"
 )
 
@@ -74,6 +75,8 @@ var _ = BeforeSuite(func() {
 	//l.Set("4")
 
 	ctrl.SetLogger(klog.Background())
+	Expect(os.Setenv("NODE_NAME", "policy-controller-ut")).To(Succeed())
+	utils.InitCurrentAgentName()
 	if os.Getenv(RunTestWithExistingCluster) == "true" {
 		By("testing with existing cluster")
 		useExistingCluster = true

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -59,8 +59,7 @@ const (
 	ControllerRuntimeQPS   = 1000.0
 	ControllerRuntimeBurst = 2000
 
-	AgentNodeNameENV    = "NODE_NAME"
-	AgentNameConfigPath = "/var/lib/everoute/agent/name"
+	AgentNodeNameENV = "NODE_NAME"
 
 	NamespaceNameENV = "NAMESPACE"
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -66,15 +66,15 @@ func EqualStringSlice(list1, list2 []string) bool {
 
 var currentAgentName string
 
-func CurrentAgentName() string {
-	if currentAgentName != "" {
-		return currentAgentName
-	}
-
-	// use node name for agent name in kubernetes
+func InitCurrentAgentName() {
 	currentAgentName = os.Getenv(constants.AgentNodeNameENV)
-
+	if currentAgentName == "" {
+		klog.Fatalf("%s is empty", constants.AgentNodeNameENV)
+	}
 	klog.Infof("Current AgentName: %s", currentAgentName)
+}
+
+func CurrentAgentName() string {
 	return currentAgentName
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"sync"
 
 	coretypes "k8s.io/apimachinery/pkg/types"
@@ -72,13 +71,8 @@ func CurrentAgentName() string {
 		return currentAgentName
 	}
 
-	content, err := os.ReadFile(constants.AgentNameConfigPath)
-	if err == nil {
-		currentAgentName = strings.TrimSpace(string(content))
-	} else {
-		// use node name for agent name in kubernetes
-		currentAgentName = os.Getenv(constants.AgentNodeNameENV)
-	}
+	// use node name for agent name in kubernetes
+	currentAgentName = os.Getenv(constants.AgentNodeNameENV)
 
 	klog.Infof("Current AgentName: %s", currentAgentName)
 	return currentAgentName

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"os"
 	"testing"
+
+	"github.com/everoute/everoute/pkg/constants"
 )
 
 func makeMap(kvs ...string) map[string]string {
@@ -77,5 +80,37 @@ func TestIsK8sLabelDiff(t *testing.T) {
 		if res != tests[i].exp {
 			t.Errorf("test %s failed, real is %v, expect is %v", tests[i].name, res, tests[i].exp)
 		}
+	}
+}
+
+func TestCurrentAgentNameFromEnv(t *testing.T) {
+	t.Setenv(constants.AgentNodeNameENV, "node-from-env")
+	currentAgentName = ""
+	t.Cleanup(func() {
+		currentAgentName = ""
+	})
+
+	if got := CurrentAgentName(); got != "node-from-env" {
+		t.Fatalf("CurrentAgentName() = %q, want %q", got, "node-from-env")
+	}
+}
+
+func TestCurrentAgentNameCache(t *testing.T) {
+	t.Setenv(constants.AgentNodeNameENV, "node-first")
+	currentAgentName = ""
+	t.Cleanup(func() {
+		currentAgentName = ""
+	})
+
+	if got := CurrentAgentName(); got != "node-first" {
+		t.Fatalf("CurrentAgentName() first = %q, want %q", got, "node-first")
+	}
+
+	if err := os.Setenv(constants.AgentNodeNameENV, "node-second"); err != nil {
+		t.Fatalf("Setenv() error = %v", err)
+	}
+
+	if got := CurrentAgentName(); got != "node-first" {
+		t.Fatalf("CurrentAgentName() cached = %q, want %q", got, "node-first")
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/everoute/everoute/pkg/constants"
@@ -90,27 +91,66 @@ func TestCurrentAgentNameFromEnv(t *testing.T) {
 		currentAgentName = ""
 	})
 
+	InitCurrentAgentName()
 	if got := CurrentAgentName(); got != "node-from-env" {
 		t.Fatalf("CurrentAgentName() = %q, want %q", got, "node-from-env")
 	}
 }
 
-func TestCurrentAgentNameCache(t *testing.T) {
-	t.Setenv(constants.AgentNodeNameENV, "node-first")
+func TestCurrentAgentNameInitOnce(t *testing.T) {
+	t.Setenv(constants.AgentNodeNameENV, "node-init")
 	currentAgentName = ""
 	t.Cleanup(func() {
 		currentAgentName = ""
 	})
 
-	if got := CurrentAgentName(); got != "node-first" {
-		t.Fatalf("CurrentAgentName() first = %q, want %q", got, "node-first")
+	InitCurrentAgentName()
+	if got := CurrentAgentName(); got != "node-init" {
+		t.Fatalf("CurrentAgentName() = %q, want %q", got, "node-init")
+	}
+}
+
+func TestInitCurrentAgentNameFatalOnEmpty(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestInitCurrentAgentNameFatalOnEmptyHelper")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		constants.AgentNodeNameENV+"=",
+	)
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("InitCurrentAgentName() should exit when NODE_NAME is empty")
+	}
+}
+
+func TestInitCurrentAgentNameFatalOnEmptyHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
 	}
 
-	if err := os.Setenv(constants.AgentNodeNameENV, "node-second"); err != nil {
-		t.Fatalf("Setenv() error = %v", err)
-	}
+	currentAgentName = ""
+	InitCurrentAgentName()
+}
 
-	if got := CurrentAgentName(); got != "node-first" {
-		t.Fatalf("CurrentAgentName() cached = %q, want %q", got, "node-first")
+func TestCurrentAgentNameConcurrentRead(t *testing.T) {
+	t.Setenv(constants.AgentNodeNameENV, "node-concurrent")
+	currentAgentName = ""
+	t.Cleanup(func() {
+		currentAgentName = ""
+	})
+
+	InitCurrentAgentName()
+
+	done := make(chan struct{}, 8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			if got := CurrentAgentName(); got != "node-concurrent" {
+				t.Errorf("CurrentAgentName() = %q, want %q", got, "node-concurrent")
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-done
 	}
 }

--- a/tests/e2e/framework/node/agent.go
+++ b/tests/e2e/framework/node/agent.go
@@ -32,8 +32,9 @@ type Agent struct {
 }
 
 const (
-	agentBinaryName = "everoute-agent"
-	ovsRestart      = "systemctl restart openvswitch"
+	agentBinaryName  = "everoute-agent"
+	agentNodeNameEnv = "NODE_NAME"
+	ovsRestart       = "systemctl restart openvswitch"
 )
 
 func (n *Agent) Restart() error {
@@ -41,7 +42,7 @@ func (n *Agent) Restart() error {
 		return nil
 	}
 	if rand.Intn(2) == 0 {
-		return n.reRunProcess(agentBinaryName)
+		return n.reRunProcessWithEnv(agentBinaryName, map[string]string{agentNodeNameEnv: n.Name})
 	}
 	_, _, err := n.runCommand(ovsRestart)
 	return err

--- a/tests/e2e/framework/node/node.go
+++ b/tests/e2e/framework/node/node.go
@@ -118,6 +118,10 @@ func (n *Node) fetchFile(name string) ([]byte, error) {
 }
 
 func (n *Node) reRunProcess(name string) error {
+	return n.reRunProcessWithEnv(name, nil)
+}
+
+func (n *Node) reRunProcessWithEnv(name string, envs map[string]string) error {
 	rc, out, err := n.runCommand(fmt.Sprintf("ps -o cmd= -p $(pidof %s)", name))
 	if err != nil || rc != 0 {
 		return fmt.Errorf("can't found process %s", name)
@@ -144,12 +148,24 @@ func (n *Node) reRunProcess(name string) error {
 	defer session.Close()
 
 	// start as daemon, and redirect output to log file
-	return session.Start(fmt.Sprintf("%s >> /var/log/%s.log 2>&1", processCommand, name))
+	return session.Start(fmt.Sprintf("%s %s >> /var/log/%s.log 2>&1", renderShellEnv(envs), processCommand, name))
 }
 
 func (n *Node) checkProcess(name string) (bool, error) {
 	rc, out, err := n.runCommand(fmt.Sprintf("pidof %s", name))
 	return rc == 0 && len(out) != 0, err
+}
+
+func renderShellEnv(envs map[string]string) string {
+	if len(envs) == 0 {
+		return ""
+	}
+
+	var result string
+	for key, value := range envs {
+		result += fmt.Sprintf("%s=%q ", key, value)
+	}
+	return result
 }
 
 func (n *Node) runCommand(cmd string) (int, []byte, error) {

--- a/tests/e2e/scripts/agent-setup.sh
+++ b/tests/e2e/scripts/agent-setup.sh
@@ -20,9 +20,9 @@ set -o nounset
 
 UPLINK_IFACE=${1:-ens11}
 KUBECONFIG_PATH=${2:-/var/lib/everoute/agent-kubeconfig.yaml}
+AGENT_NODE_NAME=${3:-$(hostname)}
 OFPORT_NUM=10
 AGENT_CONFIG_PATH=/var/lib/everoute/agentconfig.yaml
-AGENT_NAME_PATH=/var/lib/everoute/agent/name
 
 DEFAULT_BRIDGE="ovsbr1"
 POLICY_BRIDGE="${DEFAULT_BRIDGE}-policy"
@@ -74,8 +74,7 @@ vdsConfigs:
         bridgeName: ${DEFAULT_BRIDGE}
         enableMS: true
 EOF
-mkdir -p "$(dirname ${AGENT_NAME_PATH})"
-cat /proc/sys/kernel/random/uuid > ${AGENT_NAME_PATH}
+echo "generate everoute-agent node name: ${AGENT_NODE_NAME}"
 
 echo "start everoute-agent"
-nohup /usr/local/bin/everoute-agent --kubeconfig "${KUBECONFIG_PATH}" --ready-to-process-global-rule true > /var/log/everoute-agent.log 2>&1 &
+NODE_NAME="${AGENT_NODE_NAME}" nohup /usr/local/bin/everoute-agent --kubeconfig "${KUBECONFIG_PATH}" --ready-to-process-global-rule true > /var/log/everoute-agent.log 2>&1 &

--- a/tests/e2e/scripts/e2e-setup.sh
+++ b/tests/e2e/scripts/e2e-setup.sh
@@ -48,7 +48,7 @@ for agent in $(IFS=','; echo ${EVEROUTE_AGENT_HOSTLIST}); do
   scp ${ssh_args} bin/net-utils ${agent}:/usr/local/bin/net-utils
   scp ${ssh_args} /etc/everoute/kubeconfig/everoute-agent.yaml ${agent}:${agent_kubeconfig}
 
-  ssh ${ssh_args} ${agent} 'bash -s' < ${LOCAL_PATH}/agent-setup.sh ${UPLINK_IFACE} ${agent_kubeconfig}
+  ssh ${ssh_args} ${agent} 'bash -s' < ${LOCAL_PATH}/agent-setup.sh ${UPLINK_IFACE} ${agent_kubeconfig} ${agent}
 done
 
 echo "generate everoute e2e environment config"


### PR DESCRIPTION
## Summary
- fix(er-1797): read agentname from env only
- ci: reduce k8s e2e matrix on main
- chore: remove unused datapath policy rule limit

## Testing
- make docker-generate
- docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/utils -count=1

## Risks
- Low: only changes agent name source from file fallback to NODE_NAME env.

## Changed Files
- .github/workflows/ci.yaml
- pkg/agent/controller/policy/policy_controller.go
- pkg/agent/datapath/utils.go
- pkg/constants/constants.go
- pkg/constants/ms/constants.go
- pkg/metrics/agent_metrics.go
- pkg/utils/utils.go
- pkg/utils/utils_test.go

## Related
- ER-1797

---
Head: `fix-agentname-env-only-20260715`
Base: `main`
Title: `fix(er-1797): read agentname from env only`
