### PR TITLE
ci: align release ut runners with main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,14 @@ jobs:
 
   pr-check:
     needs: [build-unit-test-image, static-check, generate-check]
-    runs-on: [self-hosted, pod]
+    runs-on: ubuntu-24.04
+    env:
+      DOCKER_BUILD_OPTS: >-
+        --build-context registry.smtx.io/sdn-base/golang:1.20=docker-image://golang:1.20
+        --build-context registry.smtx.io/sdn-base/ubuntu:22.04=docker-image://ubuntu:22.04
     strategy:
       matrix:
-        act: [docker-race-test-ci, docker-cover-test-ci]
+        act: [docker-race-test, docker-cover-test]
     steps:
       - uses: actions/checkout@v2
 
@@ -48,7 +52,7 @@ jobs:
         with:
           timeout_minutes: 40
           max_attempts: 2
-          command: make ${{ matrix.act }}
+          command: sudo make ${{ matrix.act }} DOCKER_BUILD_OPTS="$DOCKER_BUILD_OPTS"
 
       - uses: codecov/codecov-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ image-generate:
 	docker buildx build -f build/images/generate/Dockerfile -t everoute/generate ./build/images/generate/ --load
 
 image-test:
-	docker buildx build -f build/images/unit-test/Dockerfile -t everoute/unit-test ./build/images/unit-test/ --load
+	docker buildx build -f build/images/unit-test/Dockerfile -t everoute/unit-test ./build/images/unit-test/ --load $(DOCKER_BUILD_OPTS)
 
 image-test-pull:
 	docker pull registry.smtx.io/everoute/unit-test:latest


### PR DESCRIPTION
## Purpose
减少 release-cni-1.2.x 分支在 unit test / generate check 上因 self-hosted runner 环境差异导致的 CI 波动，尤其是 `/lib/modules` 与 `modprobe openvswitch` 相关问题。

## Changes
- 将 `static-check`、`generate-check`、`pr-check` 的 runner 对齐到 `main` 分支使用的 `ubuntu-24.04`
- 将 `pr-check` 调整为与 `main` 一致的 `docker-race-test` / `docker-cover-test` 调用方式
- 为 `generate-check` 与 `pr-check` 增加与 `main` 一致的 `DOCKER_BUILD_OPTS`
- 删除仅服务于旧 self-hosted UT/生成流程的 `build-unit-test-image` 依赖链
