### PR TITLE
feat(er-1780): add metric for previous round flow cleanup

### DIFF
--- a/pkg/agent/datapath/multiBridgeDatapath.go
+++ b/pkg/agent/datapath/multiBridgeDatapath.go
@@ -1395,6 +1395,7 @@ func DeletePreviousRoundFlow(ctx context.Context, datapathManager *DpManager, vd
 			b.PostDeletePreviousRoundFlow(roundInfo)
 		}
 	}
+	datapathManager.AgentMetric.SetStartupPreviousRoundFlowDeleted(true)
 
 	err := persistentRoundInfo(*roundInfo, datapathManager.OvsdbDriverMap[vdsID][LOCAL_BRIDGE_KEYWORD])
 	if err != nil {

--- a/pkg/metrics/agent_metrics.go
+++ b/pkg/metrics/agent_metrics.go
@@ -42,8 +42,9 @@ type AgentMetric struct {
 
 	policyNameMap map[string]string
 
-	flowIDUsedCount prometheus.GaugeVec
-	flowIDExhaust   prometheus.GaugeVec
+	flowIDUsedCount                 prometheus.GaugeVec
+	flowIDExhaust                   prometheus.GaugeVec
+	startupPreviousRoundFlowDeleted prometheus.Gauge
 
 	trNicMount  prometheus.GaugeVec
 	trNicStatus prometheus.GaugeVec
@@ -105,6 +106,10 @@ func NewAgentMetric() *AgentMetric {
 			agentconst.MetricFlowIDExhaust,
 			"flow seq ids has exhaust or not",
 		), []string{agentconst.MetricFlowIDLabel}),
+		startupPreviousRoundFlowDeleted: prometheus.NewGauge(newAgentGaugeOpt(
+			"startup_previous_round_flow_deleted",
+			"Whether previous round flows have been deleted during startup cleanup",
+		)),
 		trNicMount: *prometheus.NewGaugeVec(newAgentGaugeOpt(
 			MetricTRNicMount,
 			"trafficredirect nic mount status",
@@ -118,6 +123,7 @@ func NewAgentMetric() *AgentMetric {
 			"trafficredirect nic link status",
 		), []string{BridgeLabel, TypeLabel}),
 	}
+	m.startupPreviousRoundFlowDeleted.Set(0)
 	m.initPolicyGuardMetrics()
 
 	return m
@@ -219,7 +225,7 @@ func (m *AgentMetric) SetRuleEntryTotalNum(num int) {
 }
 
 func (m *AgentMetric) GetCollectors() []prometheus.Collector {
-	res := []prometheus.Collector{m.flowIDUsedCount, m.flowIDExhaust}
+	res := []prometheus.Collector{m.flowIDUsedCount, m.flowIDExhaust, m.startupPreviousRoundFlowDeleted}
 	if config.EnableMs {
 		klog.Infof("Register ms metrics for enabled ms")
 		res = append(res, m.arpCount, m.arpRejectCount, m.ruleEntryTotalNum, m.ruleEntryNum,
@@ -242,6 +248,10 @@ func (m *AgentMetric) GetCollectors() []prometheus.Collector {
 
 func (m *AgentMetric) SetPolicyMemoryBreakerOpen(open bool) {
 	m.policyMemoryBreakerOpen.WithLabelValues().Set(boolToFloat64(open))
+}
+
+func (m *AgentMetric) SetStartupPreviousRoundFlowDeleted(deleted bool) {
+	m.startupPreviousRoundFlowDeleted.Set(boolToFloat64(deleted))
 }
 
 func (m *AgentMetric) IncPolicyMemoryBreakerOpen(reason string) {

--- a/pkg/metrics/agent_metrics_test.go
+++ b/pkg/metrics/agent_metrics_test.go
@@ -29,3 +29,27 @@ everoute_ms_policy_rule_estimate_rejected_value{name="policy-a",namespace="tower
 		t.Fatalf("expected rejected value metric to be deleted, got %d metrics", count)
 	}
 }
+
+func TestStartupPreviousRoundFlowDeletedMetric(t *testing.T) {
+	metric := NewAgentMetric()
+
+	expectedUndeleted := `
+# HELP everoute_ms_startup_previous_round_flow_deleted Whether previous round flows have been deleted during startup cleanup
+# TYPE everoute_ms_startup_previous_round_flow_deleted gauge
+everoute_ms_startup_previous_round_flow_deleted 0
+`
+	if err := testutil.CollectAndCompare(metric.startupPreviousRoundFlowDeleted, strings.NewReader(expectedUndeleted)); err != nil {
+		t.Fatalf("unexpected undeleted startup flow metric: %s", err)
+	}
+
+	metric.SetStartupPreviousRoundFlowDeleted(true)
+
+	expectedDeleted := `
+# HELP everoute_ms_startup_previous_round_flow_deleted Whether previous round flows have been deleted during startup cleanup
+# TYPE everoute_ms_startup_previous_round_flow_deleted gauge
+everoute_ms_startup_previous_round_flow_deleted 1
+`
+	if err := testutil.CollectAndCompare(metric.startupPreviousRoundFlowDeleted, strings.NewReader(expectedDeleted)); err != nil {
+		t.Fatalf("unexpected deleted startup flow metric: %s", err)
+	}
+}


### PR DESCRIPTION
## Purpose
为 agent 启动阶段的旧轮次流表清理增加可观测 metric，便于确认 cleanup 是否已经执行完成。

## Changes
- 新增 `everoute_ms_startup_previous_round_flow_deleted` gauge metric。
- metric 初始化时置为 `0`。
- 在 `DeletePreviousRoundFlow` 完成后将 metric 置为 `1`。
- 补充对应单测，覆盖初始值和置位行为。

## Tests
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/metrics -count=1`
- `docker run --rm -iu 0:0 -w /go/src/github.com/everoute/everoute -v /root/workspace/everoute:/go/src/github.com/everoute/everoute -v /lib/modules:/lib/modules --privileged everoute/unit-test go test ./pkg/agent/datapath -run TestStartupFlowSync -count=1`
- 在 `172.21.152.102` 部署 `registry.smtx.io/everoute/debug:6b73a38`，验证 agent metrics 中 `everoute_ms_startup_previous_round_flow_deleted 1`，并确认日志出现 previous round flow cleanup 完成记录。
